### PR TITLE
Load spec externals into knowledge base during infer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `graded infer` now reads the spec file's `external effects` and `type` field declarations into the knowledge base before walking the import graph. Previously these were only consumed by `graded check`, so functions calling into a third-party module declared pure via `external effects` were still inferred as `[Unknown]`. The `check` pass passed but the inferred spec stayed noisy.
+
 ## [0.4.0] - 2026-04-10
 
 ### Added

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -161,9 +161,12 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
 /// resolves transitive chains of any depth.
 pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
   let cfg = read_config(directory)
+  let spec = read_spec(cfg.spec_file)
   let base_kb =
     effects.load_knowledge_base("build/packages")
     |> enrich_with_path_deps()
+    |> effects.with_externals(annotation.extract_externals(spec))
+    |> effects.with_type_fields(annotation.extract_type_fields(spec))
 
   use gleam_files <- result.try(find_gleam_files(directory))
   use parsed <- result.try(parse_all_files(gleam_files))
@@ -198,7 +201,7 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
     }),
   )
 
-  write_spec_file(cfg.spec_file, public_annotations)
+  write_spec_file(cfg.spec_file, spec, public_annotations)
 }
 
 /// Format the project's spec file in place. The spec file is the single
@@ -354,9 +357,10 @@ fn public_function_names(module: glance.Module) -> set.Set(String) {
 /// public-function annotations, and writes the result back.
 fn write_spec_file(
   spec_path: String,
+  existing: GradedFile,
   inferred: List(EffectAnnotation),
 ) -> Result(Nil, GradedError) {
-  let merged = annotation.merge_inferred(read_spec(spec_path), inferred)
+  let merged = annotation.merge_inferred(existing, inferred)
 
   // create_directory_all is a no-op when the parent already exists, so it's
   // safe to call unconditionally — and necessary when the user has

--- a/test/topo_test.gleam
+++ b/test/topo_test.gleam
@@ -407,6 +407,45 @@ fn read_all_graded(directory: String) -> List(#(String, String)) {
   }
 }
 
+// ----- spec-file externals are honoured during inference -----
+
+/// Regression: a project module that calls into a third-party package not
+/// in the catalog should pick up the spec file's `external effects` line
+/// during `run_infer`, not fall back to `[Unknown]`. Pre-fix, externals
+/// were only consumed by `run` (check), so `infer` produced a noisy spec
+/// even when the user had already declared the dependency pure.
+pub fn run_infer_honours_spec_file_externals_test() {
+  let directory =
+    make_fixture("externals_in_infer", [
+      #(
+        "app/main.gleam",
+        "import dee/decimal
+
+pub fn total(a: String, b: String) -> String {
+  decimal.add(a, b)
+}
+",
+      ),
+    ])
+
+  // Mirror the user's setup: spec file at <root>/<basename>.graded
+  // declares the third-party module as pure via `external effects`.
+  let spec_path = directory <> "/graded_topo_externals_in_infer.graded"
+  let assert Ok(Nil) =
+    simplifile.write(spec_path, "external effects dee/decimal : []\n")
+
+  let assert Ok(Nil) = graded.run_infer(directory)
+
+  // The crucial assertion: total is inferred as pure, not [Unknown].
+  effects_of(
+    read_inferred(directory <> "/build/.graded/app/main.graded"),
+    "total",
+  )
+  |> should.equal(pure())
+
+  cleanup(directory)
+}
+
 // ----- path-dep smoke test -----
 
 /// Same regression class as the project chain test (deep transitive


### PR DESCRIPTION
`graded infer` was building its base knowledge base from only the package catalog and path deps, so calls into a third-party module declared pure via `external effects` in the spec file were still inferred as `[Unknown]`. The `check` pass already loaded these — only `infer` was missing them, leaving the inferred spec noisy even after the user had correctly annotated the dependency.
