### PR TITLE
Resolve cross-module type constructors as pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `graded infer` now resolves cross-module type constructors as pure, matching the existing handling for unqualified constructors. Previously, calls like `types.NotFound(id)` from a sibling project module were marked `[Unknown]` because constructors aren't tracked in the knowledge base and the defining project module isn't in `pure_modules`. Constructors are pure by Gleam's syntactic rules — an uppercase-initial label after a `.` is always a type variant — so the qualified call, qualified pipe target, and qualified value-position branches in the extractor now short-circuit the same way the unqualified path does. Side-effecting expressions inside a constructor's argument list (e.g. `NotFound(io.println(x))`) still propagate.
+
 ## [0.4.1] - 2026-04-11
 
 ### Fixed

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -172,7 +172,7 @@ fn extract_from_expression(
   context: ImportContext,
 ) -> ExtractResult {
   case expression {
-    // Qualified call: io.println(x)
+    // Qualified call: io.println(x), or qualified type constructor: types.NotFound(id)
     glance.Call(
       location: span,
       function: glance.FieldAccess(
@@ -182,27 +182,35 @@ fn extract_from_expression(
       ),
       arguments:,
     ) -> {
-      let call_result = case dict.get(context.aliases, alias) {
-        Ok(module_path) ->
-          ExtractResult(
-            resolved: [
-              ResolvedCall(QualifiedName(module_path, function_name), span),
-            ],
-            local: [],
-            field: [],
-            references: [],
-          )
-        Error(Nil) ->
-          ExtractResult(
-            resolved: [],
-            local: [],
-            field: [
-              FieldCall(alias, function_name, span),
-            ],
-            references: [],
-          )
+      case is_constructor_name(function_name) {
+        // Type constructor — pure value creation. Skip the lookup but
+        // still walk the arguments so any side-effecting sub-expressions
+        // (e.g. NotFound(io.println(x))) are still counted.
+        True -> extract_from_arguments(arguments, context)
+        False -> {
+          let call_result = case dict.get(context.aliases, alias) {
+            Ok(module_path) ->
+              ExtractResult(
+                resolved: [
+                  ResolvedCall(QualifiedName(module_path, function_name), span),
+                ],
+                local: [],
+                field: [],
+                references: [],
+              )
+            Error(Nil) ->
+              ExtractResult(
+                resolved: [],
+                local: [],
+                field: [
+                  FieldCall(alias, function_name, span),
+                ],
+                references: [],
+              )
+          }
+          merge(call_result, extract_from_arguments(arguments, context))
+        }
       }
-      merge(call_result, extract_from_arguments(arguments, context))
     }
 
     // Unqualified or local call: println(x) or helper(x)
@@ -262,18 +270,23 @@ fn extract_from_expression(
     // Record update
     glance.RecordUpdate(record:, ..) -> extract_from_expression(record, context)
 
-    // Function reference: qualified name used as a value (not called)
+    // Function reference: qualified name used as a value (not called).
+    // Qualified type constructors used as values are pure and not tracked.
     glance.FieldAccess(
       location: span,
       container: glance.Variable(_, alias),
       label: function_name,
     ) ->
-      case dict.get(context.aliases, alias) {
-        Ok(module_path) ->
-          ExtractResult(resolved: [], local: [], field: [], references: [
-            ResolvedCall(QualifiedName(module_path, function_name), span),
-          ])
-        Error(Nil) -> empty()
+      case is_constructor_name(function_name) {
+        True -> empty()
+        False ->
+          case dict.get(context.aliases, alias) {
+            Ok(module_path) ->
+              ExtractResult(resolved: [], local: [], field: [], references: [
+                ResolvedCall(QualifiedName(module_path, function_name), span),
+              ])
+            Error(Nil) -> empty()
+          }
       }
 
     // Other field access (not a call — just traversing)
@@ -333,25 +346,29 @@ fn extract_pipe_target(
       container: glance.Variable(_, alias),
       label: function_name,
     ) ->
-      case dict.get(context.aliases, alias) {
-        Ok(module_path) ->
-          ExtractResult(
-            resolved: [
-              ResolvedCall(QualifiedName(module_path, function_name), span),
-            ],
-            local: [],
-            field: [],
-            references: [],
-          )
-        Error(Nil) ->
-          ExtractResult(
-            resolved: [],
-            local: [],
-            field: [
-              FieldCall(alias, function_name, span),
-            ],
-            references: [],
-          )
+      case is_constructor_name(function_name) {
+        True -> empty()
+        False ->
+          case dict.get(context.aliases, alias) {
+            Ok(module_path) ->
+              ExtractResult(
+                resolved: [
+                  ResolvedCall(QualifiedName(module_path, function_name), span),
+                ],
+                local: [],
+                field: [],
+                references: [],
+              )
+            Error(Nil) ->
+              ExtractResult(
+                resolved: [],
+                local: [],
+                field: [
+                  FieldCall(alias, function_name, span),
+                ],
+                references: [],
+              )
+          }
       }
 
     glance.Variable(location: span, name:) ->

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -135,6 +135,77 @@ fn resolve_unqualified_call(
   }
 }
 
+/// Resolve a qualified `alias.label` call or pipe target. Constructor
+/// labels short-circuit to empty (pure value creation). Known aliases
+/// produce a cross-module ResolvedCall; unknown aliases fall back to a
+/// FieldCall on a local variable.
+fn resolve_qualified_call(
+  alias: String,
+  function_name: String,
+  span: glance.Span,
+  context: ImportContext,
+) -> ExtractResult {
+  case is_constructor_name(function_name) {
+    True -> empty()
+    False -> qualified_call_lookup(alias, function_name, span, context)
+  }
+}
+
+fn qualified_call_lookup(
+  alias: String,
+  function_name: String,
+  span: glance.Span,
+  context: ImportContext,
+) -> ExtractResult {
+  case dict.get(context.aliases, alias) {
+    Ok(module_path) ->
+      ExtractResult(
+        resolved: [
+          ResolvedCall(QualifiedName(module_path, function_name), span),
+        ],
+        local: [],
+        field: [],
+        references: [],
+      )
+    Error(Nil) ->
+      ExtractResult(
+        resolved: [],
+        local: [],
+        field: [FieldCall(alias, function_name, span)],
+        references: [],
+      )
+  }
+}
+
+/// Resolve a qualified `alias.label` used as a value (not called).
+/// Constructors short-circuit to empty; unknown aliases are dropped.
+fn resolve_qualified_reference(
+  alias: String,
+  function_name: String,
+  span: glance.Span,
+  context: ImportContext,
+) -> ExtractResult {
+  case is_constructor_name(function_name) {
+    True -> empty()
+    False -> qualified_reference_lookup(alias, function_name, span, context)
+  }
+}
+
+fn qualified_reference_lookup(
+  alias: String,
+  function_name: String,
+  span: glance.Span,
+  context: ImportContext,
+) -> ExtractResult {
+  case dict.get(context.aliases, alias) {
+    Ok(module_path) ->
+      ExtractResult(resolved: [], local: [], field: [], references: [
+        ResolvedCall(QualifiedName(module_path, function_name), span),
+      ])
+    Error(Nil) -> empty()
+  }
+}
+
 fn last_segment(module_path: String) -> String {
   module_path
   |> string.split("/")
@@ -172,7 +243,9 @@ fn extract_from_expression(
   context: ImportContext,
 ) -> ExtractResult {
   case expression {
-    // Qualified call: io.println(x), or qualified type constructor: types.NotFound(id)
+    // Qualified call: io.println(x), or qualified type constructor: types.NotFound(id).
+    // The argument walk is unconditional so side-effecting sub-expressions
+    // inside a constructor's args (e.g. NotFound(io.println(x))) still propagate.
     glance.Call(
       location: span,
       function: glance.FieldAccess(
@@ -181,37 +254,11 @@ fn extract_from_expression(
         ..,
       ),
       arguments:,
-    ) -> {
-      case is_constructor_name(function_name) {
-        // Type constructor — pure value creation. Skip the lookup but
-        // still walk the arguments so any side-effecting sub-expressions
-        // (e.g. NotFound(io.println(x))) are still counted.
-        True -> extract_from_arguments(arguments, context)
-        False -> {
-          let call_result = case dict.get(context.aliases, alias) {
-            Ok(module_path) ->
-              ExtractResult(
-                resolved: [
-                  ResolvedCall(QualifiedName(module_path, function_name), span),
-                ],
-                local: [],
-                field: [],
-                references: [],
-              )
-            Error(Nil) ->
-              ExtractResult(
-                resolved: [],
-                local: [],
-                field: [
-                  FieldCall(alias, function_name, span),
-                ],
-                references: [],
-              )
-          }
-          merge(call_result, extract_from_arguments(arguments, context))
-        }
-      }
-    }
+    ) ->
+      merge(
+        resolve_qualified_call(alias, function_name, span, context),
+        extract_from_arguments(arguments, context),
+      )
 
     // Unqualified or local call: println(x) or helper(x)
     glance.Call(location: span, function: glance.Variable(_, name), arguments:) ->
@@ -271,23 +318,11 @@ fn extract_from_expression(
     glance.RecordUpdate(record:, ..) -> extract_from_expression(record, context)
 
     // Function reference: qualified name used as a value (not called).
-    // Qualified type constructors used as values are pure and not tracked.
     glance.FieldAccess(
       location: span,
       container: glance.Variable(_, alias),
       label: function_name,
-    ) ->
-      case is_constructor_name(function_name) {
-        True -> empty()
-        False ->
-          case dict.get(context.aliases, alias) {
-            Ok(module_path) ->
-              ExtractResult(resolved: [], local: [], field: [], references: [
-                ResolvedCall(QualifiedName(module_path, function_name), span),
-              ])
-            Error(Nil) -> empty()
-          }
-      }
+    ) -> resolve_qualified_reference(alias, function_name, span, context)
 
     // Other field access (not a call — just traversing)
     glance.FieldAccess(container:, ..) ->
@@ -345,31 +380,7 @@ fn extract_pipe_target(
       location: span,
       container: glance.Variable(_, alias),
       label: function_name,
-    ) ->
-      case is_constructor_name(function_name) {
-        True -> empty()
-        False ->
-          case dict.get(context.aliases, alias) {
-            Ok(module_path) ->
-              ExtractResult(
-                resolved: [
-                  ResolvedCall(QualifiedName(module_path, function_name), span),
-                ],
-                local: [],
-                field: [],
-                references: [],
-              )
-            Error(Nil) ->
-              ExtractResult(
-                resolved: [],
-                local: [],
-                field: [
-                  FieldCall(alias, function_name, span),
-                ],
-                references: [],
-              )
-          }
-      }
+    ) -> resolve_qualified_call(alias, function_name, span, context)
 
     glance.Variable(location: span, name:) ->
       resolve_unqualified_call(name, span, context)

--- a/test/topo_test.gleam
+++ b/test/topo_test.gleam
@@ -446,6 +446,76 @@ pub fn total(a: String, b: String) -> String {
   cleanup(directory)
 }
 
+// ----- cross-module type constructors are pure -----
+
+/// Calls to a custom type constructor defined in a sibling project
+/// module should be inferred as pure, regardless of position: as a
+/// direct call, at a pipe target, or as a value reference. Side
+/// effects inside a constructor's argument list must still propagate.
+/// All four positions are exercised against one fixture and one
+/// `run_infer` invocation; each function name isolates the case.
+pub fn cross_module_type_constructors_resolve_pure_test() {
+  let directory =
+    make_fixture("cross_module_constructors", [
+      #(
+        "myapp/types.gleam",
+        "pub type MyError {
+  NotFound(id: String)
+}
+
+pub type Logged {
+  Logged(message: String)
+}
+",
+      ),
+      #(
+        "myapp/service.gleam",
+        "import gleam/io
+import myapp/types
+
+pub fn lookup(id: String) -> Result(Nil, types.MyError) {
+  Error(types.NotFound(id))
+}
+
+pub fn pipe_lookup(id: String) -> types.MyError {
+  id |> types.NotFound
+}
+
+pub fn make(message: String) -> types.Logged {
+  io.println(message)
+  types.Logged(message)
+}
+
+pub fn maker() -> fn(String) -> types.MyError {
+  types.NotFound
+}
+",
+      ),
+    ])
+
+  let assert Ok(Nil) = graded.run_infer(directory)
+
+  let inferred =
+    read_inferred(directory <> "/build/.graded/myapp/service.graded")
+
+  // Direct call: types.NotFound(id) — pure.
+  effects_of(inferred, "lookup") |> should.equal(pure())
+
+  // Pipe target: id |> types.NotFound — pure.
+  effects_of(inferred, "pipe_lookup") |> should.equal(pure())
+
+  // Argument-list effects propagate even though the wrapping
+  // constructor itself is pure.
+  effects_of(inferred, "make") |> should.equal(with_labels(["Stdout"]))
+
+  // Value position: types.NotFound used as a function reference.
+  // Currently `references` aren't fed into inference, so this passes
+  // pre-fix as well — kept to pin the contract if that ever changes.
+  effects_of(inferred, "maker") |> should.equal(pure())
+
+  cleanup(directory)
+}
+
 // ----- path-dep smoke test -----
 
 /// Same regression class as the project chain test (deep transitive


### PR DESCRIPTION
A function that constructs a custom type defined in another project module was inferred as `[Unknown]`. The qualified-call branch in the extractor produced a `ResolvedCall(types.NotFound)` which fell through both `all_effects` (constructors aren't tracked) and `pure_modules` (project modules aren't external), so the lookup returned Unknown. Same gap at the pipe target and value-reference sites.