### PR TITLE
Dedup shared helpers and read dependency specs once

### DIFF
--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -160,7 +160,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
   let results =
     list.map(parsed, fn(entry) {
       let #(gleam_path, module) = entry
-      let module_path = extract.module_path_for_source(gleam_path, directory)
+      let module_path = config.module_path_for_source(gleam_path, directory)
       let module_checks = case dict.get(checks_by_module, module_path) {
         Ok(list) -> list
         Error(_) -> []
@@ -632,7 +632,7 @@ fn build_module_index(
 ) -> Dict(String, #(String, glance.Module)) {
   list.fold(parsed, dict.new(), fn(acc, entry) {
     let #(gleam_path, module) = entry
-    let module_path = extract.module_path_for_source(gleam_path, directory)
+    let module_path = config.module_path_for_source(gleam_path, directory)
     dict.insert(acc, module_path, #(gleam_path, module))
   })
 }
@@ -977,11 +977,7 @@ fn enrich_with_path_deps(knowledge_base: KnowledgeBase) -> KnowledgeBase {
   let path_deps = effects.parse_path_dependencies("gleam.toml")
   list.fold(path_deps, knowledge_base, fn(kb, dep) {
     let #(name, dep_path) = dep
-    let spec_file = case config.read(filepath.join(dep_path, "gleam.toml")) {
-      Ok(cfg) -> cfg.spec_file
-      Error(_) -> config.default_spec_file(name)
-    }
-    let spec_path = filepath.join(dep_path, spec_file)
+    let spec_path = config.spec_file_for(dep_path, name)
     case simplifile.is_file(spec_path) {
       Ok(True) ->
         effects.with_inferred(kb, effects.load_spec_effects(spec_path))
@@ -1021,7 +1017,7 @@ pub fn infer_path_dep(
       use module <- result.try(
         read_and_parse_gleam(gleam_path) |> result.map_error(fn(_) { Nil }),
       )
-      let module_path = extract.module_path_for_source(gleam_path, source_dir)
+      let module_path = config.module_path_for_source(gleam_path, source_dir)
       // Path-dep checks come from the dep's spec file (loaded by
       // enrich_with_path_deps), not from per-module files. Inference here
       // only needs the parsed module.

--- a/src/graded/internal/annotation.gleam
+++ b/src/graded/internal/annotation.gleam
@@ -151,7 +151,9 @@ pub fn extract_type_fields(file: GradedFile) -> List(TypeFieldAnnotation) {
   })
 }
 
-/// Render an ExternalAnnotation back to its .graded line format.
+/// The qualified name (`module` or `module.function`) an external annotation
+/// targets. Used both as a sort key and as the rendered name in
+/// `format_external`.
 fn external_sort_key(external_annotation: ExternalAnnotation) -> String {
   case external_annotation.target {
     ModuleExternal -> external_annotation.module
@@ -159,13 +161,10 @@ fn external_sort_key(external_annotation: ExternalAnnotation) -> String {
   }
 }
 
+/// Render an ExternalAnnotation back to its `.graded` line format.
 pub fn format_external(external_annotation: ExternalAnnotation) -> String {
-  let name = case external_annotation.target {
-    ModuleExternal -> external_annotation.module
-    FunctionExternal(function) -> external_annotation.module <> "." <> function
-  }
   "external effects "
-  <> name
+  <> external_sort_key(external_annotation)
   <> " : "
   <> format_effect_set(external_annotation.effects)
 }
@@ -584,11 +583,7 @@ fn parse_name_colon_effects(input: String) -> Result(#(String, EffectTerm), Nil)
 /// A token is an effect label if its first character is uppercase.
 /// Lowercase first character => effect variable.
 fn is_label_token(token: String) -> Bool {
-  case string.first(token) {
-    Ok(first) ->
-      first == string.uppercase(first) && first != string.lowercase(first)
-    Error(Nil) -> False
-  }
+  types.is_upper_initial(token)
 }
 
 /// Parse an effect term `[...]`. Beyond labels and variables, supports
@@ -793,7 +788,11 @@ fn abstraction_spine(term: EffectTerm) -> #(List(String), EffectTerm) {
   }
 }
 
-fn format_effect_set(effect_set: EffectSet) -> String {
+/// Render an effect set to its `[A, B]` surface syntax: `[]` for empty, `[_]`
+/// for wildcard, labels then variables each sorted. The single source of truth
+/// for the on-disk effect-set format (`effects.format_effect_set` delegates
+/// here for diagnostics).
+pub fn format_effect_set(effect_set: EffectSet) -> String {
   case effect_set {
     Wildcard -> "[_]"
     Specific(labels) ->

--- a/src/graded/internal/config.gleam
+++ b/src/graded/internal/config.gleam
@@ -11,7 +11,9 @@
 //// defaults apply. The `name` field at the top of `gleam.toml` provides the
 //// package name used to derive the default `spec_file`.
 
+import filepath
 import gleam/result
+import gleam/string
 import simplifile
 import tom
 
@@ -84,4 +86,33 @@ pub fn default_spec_file(package_name: String) -> String {
 
 pub fn default_cache_dir() -> String {
   "build/.graded"
+}
+
+/// Resolve the full path to a package's spec file given its root directory and
+/// package name. Reads the package's own `[tools.graded].spec_file`, falling
+/// back to `<package_name>.graded` when the config is missing or unreadable.
+/// Single source of truth for "where does package X keep its spec file".
+pub fn spec_file_for(package_root: String, package_name: String) -> String {
+  let spec_file = case read(filepath.join(package_root, "gleam.toml")) {
+    Ok(cfg) -> cfg.spec_file
+    Error(_) -> default_spec_file(package_name)
+  }
+  filepath.join(package_root, spec_file)
+}
+
+/// Compute the dotted module name (as it appears in `import` statements) for a
+/// `.gleam` file under a given source directory. For example,
+/// `module_path_for_source("src/app/router.gleam", "src")` returns
+/// `"app/router"` — the same string `import` statements use, so the project's
+/// dependency graph can be built by intersecting the two.
+pub fn module_path_for_source(
+  gleam_path: String,
+  source_directory: String,
+) -> String {
+  let prefix = source_directory <> "/"
+  let relative = case string.starts_with(gleam_path, prefix) {
+    True -> string.drop_start(gleam_path, string.length(prefix))
+    False -> gleam_path
+  }
+  filepath.strip_extension(relative)
 }

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -13,8 +13,7 @@ import graded/internal/types.{
   type ArgumentValue, type EffectAnnotation, type EffectSet, type EffectTerm,
   type ExternalAnnotation, type ParamBound, type QualifiedName,
   type TypeFieldAnnotation, type TypeFieldEffect, Check, ConstructorRef, Effects,
-  FunctionExternal, FunctionRef, ModuleExternal, Polymorphic, QualifiedName,
-  Specific, TypeFieldEffect, Wildcard,
+  FunctionExternal, FunctionRef, ModuleExternal, QualifiedName, TypeFieldEffect,
 }
 import simplifile
 import tom
@@ -53,7 +52,8 @@ pub type KnowledgeBase {
 /// Build a knowledge base by scanning dependency .graded files
 /// and loading versioned catalog files from priv/catalog/.
 pub fn load_knowledge_base(packages_directory: String) -> KnowledgeBase {
-  let #(dep_effects, dep_params) = load_dependency_effects(packages_directory)
+  let #(dep_effects, dep_params, dep_returns) =
+    load_dependencies(packages_directory)
   let catalog_dir = find_catalog_directory()
   let #(cat_effects, cat_pure, cat_params) =
     load_catalog(catalog_dir, "manifest.toml")
@@ -63,7 +63,7 @@ pub fn load_knowledge_base(packages_directory: String) -> KnowledgeBase {
     // ordering in CLAUDE.md — dict.merge lets the second arg win.
     param_bounds: dict.merge(cat_params, dep_params),
     type_fields: dict.new(),
-    returned_operators: load_dependency_returns(packages_directory),
+    returned_operators: dep_returns,
     factories: dict.new(),
     pure_modules: cat_pure,
   )
@@ -237,23 +237,11 @@ pub fn lookup_param_bounds(
   }
 }
 
-/// Format an effect set for display: [] for empty, [_] for wildcard, [A, B] sorted.
+/// Format an effect set for display: [] for empty, [_] for wildcard, [A, B]
+/// sorted. Delegates to `annotation.format_effect_set` so diagnostics and the
+/// on-disk spec format share one renderer.
 pub fn format_effect_set(effect_set: EffectSet) -> String {
-  case effect_set {
-    Wildcard -> "[_]"
-    Specific(labels) ->
-      case set.to_list(labels) |> list.sort(string.compare) {
-        [] -> "[]"
-        sorted -> "[" <> string.join(sorted, ", ") <> "]"
-      }
-    Polymorphic(labels, variables) -> {
-      let sorted_labels = set.to_list(labels) |> list.sort(string.compare)
-      let sorted_variables = set.to_list(variables) |> list.sort(string.compare)
-      "["
-      <> string.join(list.append(sorted_labels, sorted_variables), ", ")
-      <> "]"
-    }
-  }
+  annotation.format_effect_set(effect_set)
 }
 
 /// Parse gleam.toml to find path dependencies.
@@ -358,28 +346,6 @@ fn fold_spec_returns(
   })
 }
 
-/// Scan dependency `.graded` specs for `returns` lines so a returned operator a
-/// dependency declares crosses the package boundary.
-fn load_dependency_returns(
-  packages_directory: String,
-) -> Dict(QualifiedName, EffectTerm) {
-  let entries = case simplifile.read_directory(packages_directory) {
-    Ok(found) -> found
-    Error(_) -> []
-  }
-  list.fold(entries, dict.new(), fn(acc, package_name) {
-    let dep_root = packages_directory <> "/" <> package_name
-    let spec_file = case config.read(dep_root <> "/gleam.toml") {
-      Ok(cfg) -> cfg.spec_file
-      Error(_) -> config.default_spec_file(package_name)
-    }
-    case read_spec_file(dep_root <> "/" <> spec_file) {
-      Ok(file) -> dict.merge(acc, load_spec_returns_from_file(file))
-      Error(_) -> acc
-    }
-  })
-}
-
 /// Merge inferred effects into a knowledge base.
 /// Existing entries in the knowledge base take priority.
 pub fn with_inferred(
@@ -443,39 +409,44 @@ pub fn lookup_returned_operator(
 // PRIVATE
 
 /// For each installed package, locate its spec file via the package's own
-/// `[tools.graded]` config (defaulting to `<package_name>.graded`), parse
-/// its qualified `effects` and `check` annotations, and fold them into the
-/// global effect / param maps. Packages with no spec file are silently
-/// skipped — same fail-soft semantics as the catalog and the old
-/// per-module reader.
-fn load_dependency_effects(
+/// `[tools.graded]` config (defaulting to `<package_name>.graded`), then read
+/// and parse it *once*, folding its qualified `effects`/`check` annotations
+/// into the global effect/param maps and its `returns` lines into the
+/// returned-operator map. Packages with no spec file are silently skipped —
+/// same fail-soft semantics as the catalog and the old per-module reader.
+fn load_dependencies(
   packages_directory: String,
-) -> #(Dict(QualifiedName, EffectTerm), Dict(QualifiedName, List(ParamBound))) {
+) -> #(
+  Dict(QualifiedName, EffectTerm),
+  Dict(QualifiedName, List(ParamBound)),
+  Dict(QualifiedName, EffectTerm),
+) {
   let entries = case simplifile.read_directory(packages_directory) {
     Ok(found) -> found
     Error(_) -> []
   }
-  list.fold(entries, #(dict.new(), dict.new()), fn(maps, package_name) {
-    let dep_root = packages_directory <> "/" <> package_name
-    let spec_file = case config.read(dep_root <> "/gleam.toml") {
-      Ok(cfg) -> cfg.spec_file
-      Error(_) -> config.default_spec_file(package_name)
-    }
-    load_spec_into_maps(maps, dep_root <> "/" <> spec_file)
-  })
-}
-
-fn load_spec_into_maps(
-  maps: #(
-    Dict(QualifiedName, EffectTerm),
-    Dict(QualifiedName, List(ParamBound)),
-  ),
-  spec_path: String,
-) -> #(Dict(QualifiedName, EffectTerm), Dict(QualifiedName, List(ParamBound))) {
-  case read_spec_annotations(spec_path) {
-    Error(_) -> maps
-    Ok(annotations) -> list.fold(annotations, maps, fold_qualified_annotation)
-  }
+  list.fold(
+    entries,
+    #(dict.new(), dict.new(), dict.new()),
+    fn(acc, package_name) {
+      let #(effect_map, param_map, returns_map) = acc
+      let dep_root = packages_directory <> "/" <> package_name
+      case read_spec_file(config.spec_file_for(dep_root, package_name)) {
+        Error(_) -> acc
+        Ok(file) -> {
+          let #(new_effects, new_params) =
+            list.fold(
+              annotation.extract_annotations(file),
+              #(effect_map, param_map),
+              fold_qualified_annotation,
+            )
+          let new_returns =
+            dict.merge(returns_map, load_spec_returns_from_file(file))
+          #(new_effects, new_params, new_returns)
+        }
+      }
+    },
+  )
 }
 
 fn fold_qualified_annotation(

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -1,4 +1,3 @@
-import filepath
 import glance.{
   type Clause, type Expression, type Field, type Module, type Statement,
 }
@@ -44,24 +43,6 @@ type LocalBinding {
 
 type Env =
   Dict(String, LocalBinding)
-
-/// Compute the dotted module name (as it appears in `import` statements) for
-/// a `.gleam` file under a given source directory. For example,
-/// `module_path_for_source("src/app/router.gleam", "src")` returns
-/// `"app/router"`. The returned string is what `build_import_context` will
-/// produce for any module that imports this file — the project's dependency
-/// graph is built by intersecting the two.
-pub fn module_path_for_source(
-  gleam_path: String,
-  source_directory: String,
-) -> String {
-  let prefix = source_directory <> "/"
-  let relative = case string.starts_with(gleam_path, prefix) {
-    True -> string.drop_start(gleam_path, string.length(prefix))
-    False -> gleam_path
-  }
-  filepath.strip_extension(relative)
-}
 
 /// Import context built from a module's import list.
 ///
@@ -600,10 +581,7 @@ fn use_pattern_to_fn_param(pattern: glance.UsePattern) -> glance.FnParameter {
 // PRIVATE
 
 fn is_constructor_name(name: String) -> Bool {
-  case string.first(name) {
-    Ok(char) -> char == string.uppercase(char) && char != string.lowercase(char)
-    Error(Nil) -> False
-  }
+  types.is_upper_initial(name)
 }
 
 /// Env-captured function refs beat import-based resolution.

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -19,6 +19,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/set.{type Set}
 import gleam/string
+import graded/internal/config
 import graded/internal/types.{type QualifiedName, QualifiedName}
 import simplifile
 
@@ -342,7 +343,10 @@ fn registry_from_gleam_file(
 ) -> SignatureRegistry {
   use source <- bool_or_default(simplifile.read(gleam_path), empty())
   use module <- bool_or_default(glance.module(source), empty())
-  from_glance_module(module_path_for(gleam_path, source_dir), module)
+  from_glance_module(
+    config.module_path_for_source(gleam_path, source_dir),
+    module,
+  )
 }
 
 /// Continuation-style result-or-default: runs `next` with the Ok value,
@@ -353,16 +357,4 @@ fn bool_or_default(result: Result(a, b), default: c, next: fn(a) -> c) -> c {
     Ok(v) -> next(v)
     Error(_) -> default
   }
-}
-
-/// Compute the dotted module name for a gleam file under a dep's
-/// `src/` directory. Mirrors `extract.module_path_for_source` but
-/// kept inline to avoid a circular dep between modules.
-fn module_path_for(gleam_path: String, source_dir: String) -> String {
-  let prefix = source_dir <> "/"
-  let relative = case string.starts_with(gleam_path, prefix) {
-    True -> string.drop_start(gleam_path, string.length(prefix))
-    False -> gleam_path
-  }
-  filepath.strip_extension(relative)
 }

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -1,6 +1,20 @@
 import glance.{type Span, type Statement}
 import gleam/option.{type Option}
 import gleam/set.{type Set}
+import gleam/string
+
+/// Whether a name's first character is an uppercase letter. This single
+/// lexical rule distinguishes effect labels from effect variables and record
+/// constructors from ordinary functions — the comparison against both cases
+/// excludes non-cased graphemes (digits, symbols) that compare equal to
+/// themselves under both `uppercase` and `lowercase`.
+pub fn is_upper_initial(name: String) -> Bool {
+  case string.first(name) {
+    Ok(first) ->
+      first == string.uppercase(first) && first != string.lowercase(first)
+    Error(Nil) -> False
+  }
+}
 
 /// A fully qualified function name: module path + function name.
 pub type QualifiedName {

--- a/test/path_test.gleam
+++ b/test/path_test.gleam
@@ -2,25 +2,26 @@ import glance
 import gleam/dict
 import gleam/list
 import gleeunit/should
+import graded/internal/config
 import graded/internal/extract
 
 pub fn module_path_simple_test() {
-  extract.module_path_for_source("src/app.gleam", "src")
+  config.module_path_for_source("src/app.gleam", "src")
   |> should.equal("app")
 }
 
 pub fn module_path_nested_test() {
-  extract.module_path_for_source("src/app/router.gleam", "src")
+  config.module_path_for_source("src/app/router.gleam", "src")
   |> should.equal("app/router")
 }
 
 pub fn module_path_custom_directory_test() {
-  extract.module_path_for_source("test/fixtures/view.gleam", "test/fixtures")
+  config.module_path_for_source("test/fixtures/view.gleam", "test/fixtures")
   |> should.equal("view")
 }
 
 pub fn module_path_deeply_nested_test() {
-  extract.module_path_for_source("src/app/web/handlers/auth.gleam", "src")
+  config.module_path_for_source("src/app/web/handlers/auth.gleam", "src")
   |> should.equal("app/web/handlers/auth")
 }
 
@@ -31,7 +32,7 @@ pub fn module_path_deeply_nested_test() {
 /// disappear and inference degenerates back to the per-file behaviour.
 pub fn module_path_matches_import_context_test() {
   // Compute the module name for a fake "leaf" file as it would live on disk.
-  let leaf_module = extract.module_path_for_source("src/app/d.gleam", "src")
+  let leaf_module = config.module_path_for_source("src/app/d.gleam", "src")
 
   // Parse a sibling that imports it and read what extract sees.
   let src =
@@ -49,7 +50,7 @@ pub fn run() { d.format(\"hi\") }"
 
 pub fn module_path_matches_import_context_nested_test() {
   let leaf_module =
-    extract.module_path_for_source("src/app/web/handlers/auth.gleam", "src")
+    config.module_path_for_source("src/app/web/handlers/auth.gleam", "src")
 
   let src =
     "import app/web/handlers/auth


### PR DESCRIPTION
Quality-only cleanup (no behavior change): collapse several duplicated-concept implementations onto single sources of truth, and fold the two dependency-spec scans into one read+parse per dep.

## Changes

- **`module_path_for_source` deduped** — moved into `config` (which owns path conventions); dropped the byte-identical copies in `extract` and `signatures` (the latter's "avoid a circular dep" comment was stale).
- **One effect-set renderer** — `annotation.format_effect_set` is now the sole implementation; `effects.format_effect_set` delegates to it. Public API unchanged.
- **One uppercase-initial predicate** — extracted `types.is_upper_initial`; `annotation.is_label_token` and `extract.is_constructor_name` route through it (kept as readable domain aliases).
- **`format_external` reuses `external_sort_key`** for the name, removing a duplicated `case`.
- **Dependency specs read once** — `load_dependency_effects` + `load_dependency_returns` each scanned `build/packages`, re-read every `gleam.toml`, and re-parsed every spec file. Merged into a single `load_dependencies` pass; added `config.spec_file_for` to centralize spec-path resolution (also used by `enrich_with_path_deps`).

## Testing

- `gleam build` clean
- `gleam test` — 352 passed, no failures
- `gleam format` applied