### PR TITLE
Add catalog entries for 22 more top Gleam packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Catalog entries for 22 more of the most-used Gleam packages.** Calls into these now resolve to a precise effect (or `[]` for pure libraries) instead of `[Unknown]`: glance, glexer, justin, snag, ranger, marceau, gleam_community_colour, gleam_community_ansi, glam, splitter, and gleam_bitwise (pure); glisten, mist, wisp, pog, gleam_fetch, shellout, logging, argv, directories, birl, and youid (effectful).
-- **New effect labels `Network`, `Database`, `Subprocess`, and `Random`** for socket/server I/O (glisten, mist), database queries (pog), shelling out (shellout), and nondeterministic generation (youid v4/v7, `wisp.random_string`).
+- **New effect labels `Network`, `Database`, `Exec`, and `Random`** for socket/server I/O (glisten, mist), database queries (pog), running external programs (shellout), and nondeterministic generation (youid v4/v7, `wisp.random_string`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Catalog entries for 22 more of the most-used Gleam packages.** Calls into these now resolve to a precise effect (or `[]` for pure libraries) instead of `[Unknown]`: glance, glexer, justin, snag, ranger, marceau, gleam_community_colour, gleam_community_ansi, glam, splitter, and gleam_bitwise (pure); glisten, mist, wisp, pog, gleam_fetch, shellout, logging, argv, directories, birl, and youid (effectful).
+- **Catalog entries for 27 more of the most-used Gleam packages.** Calls into these now resolve to a precise effect (or `[]` for pure libraries) instead of `[Unknown]`: glance, glexer, justin, snag, ranger, marceau, gleam_community_colour, gleam_community_ansi, glam, splitter, gleam_bitwise, gleam_javascript, and gleam_deque (pure); glisten, mist, wisp, pog, gleam_fetch, gleam_hackney, gleam_cowboy, gleam_elli, shellout, logging, argv, directories, birl, and youid (effectful).
+- **The catalog now covers all of the core `gleam-lang` runtime, data, and HTTP packages.** The two remaining official packages, `gleam_package_interface` and `gleam_hexpm`, are tooling libraries and stay uncatalogued for now.
 - **New effect labels `Network`, `Database`, `Exec`, and `Random`** for socket/server I/O (glisten, mist), database queries (pog), running external programs (shellout), and nondeterministic generation (youid v4/v7, `wisp.random_string`).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Catalog entries for 22 more of the most-used Gleam packages.** Calls into these now resolve to a precise effect (or `[]` for pure libraries) instead of `[Unknown]`: glance, glexer, justin, snag, ranger, marceau, gleam_community_colour, gleam_community_ansi, glam, splitter, and gleam_bitwise (pure); glisten, mist, wisp, pog, gleam_fetch, shellout, logging, argv, directories, birl, and youid (effectful).
+- **New effect labels `Network`, `Database`, `Subprocess`, and `Random`** for socket/server I/O (glisten, mist), database queries (pog), shelling out (shellout), and nondeterministic generation (youid v4/v7, `wisp.random_string`).
+
 ### Fixed
 
 - When a function appears in both an installed dependency's spec file and the bundled catalog, its effects now come from the dependency's spec file.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ For example, if you have `gleam_stdlib@0.71.0` installed and the catalog has `gl
 
 ### Covered packages
 
-The catalog ships effect knowledge for 39 packages. The effectful ones:
+The catalog ships effect knowledge for 44 packages. The effectful ones:
 
 | Package | Effects | Labels |
 |---|---|---|
@@ -250,10 +250,13 @@ The catalog ships effect knowledge for 39 packages. The effectful ones:
 | **gleam_otp** | `gleam/otp/actor.*`, `gleam/otp/supervisor.*` | `Process` |
 | **gleam_httpc** | `gleam/httpc.send` | `Http` |
 | **gleam_fetch** | `gleam/fetch.send`, `.read_*_body` | `Http` |
+| **gleam_hackney** | `gleam/hackney.send`, `.send_bits` | `Http` |
 | **lustre** | `lustre.start`, `lustre.send`, `lustre/server_component.*` | `Process`, `Dom` |
 | **lustre_http** | `lustre_http.*` | `Http` |
 | **glisten** | `glisten.start`, `.send`, `.supervised` | `Network`, `Process` |
 | **mist** | `mist.start`, `.read_body`, `.send_file`, websocket frames | `Network`, `Process`, `FileSystem` |
+| **gleam_cowboy** | `gleam/http/cowboy.start` | `Network`, `Process` |
+| **gleam_elli** | `gleam/http/elli.start`, `.become` | `Network`, `Process` |
 | **wisp** | `wisp.log_*`, `.serve_static`, `.random_string`, `wisp/wisp_mist.handler` | `Stdout`, `FileSystem`, `Random`, `Network` |
 | **pog** | `pog.query`, `.execute`, `.transaction`, `.start` | `Database`, `Process` |
 | **simplifile** | `simplifile.*` | `FileSystem` |
@@ -266,7 +269,7 @@ The catalog ships effect knowledge for 39 packages. The effectful ones:
 | **birl** | `birl.now`, `.utc_now`, `.monotonic_now` | `Time` |
 | **youid** | `youid/uuid.v1`, `.v4`, `.v7` | `Time`, `Random` |
 
-Pure (all functions `[]`): **filepath**, **gleam_http**, **gleam_json**, **gleam_crypto**, **gleam_regexp**, **gleam_yielder**, **houdini**, **tom**, **glance**, **glexer**, **justin**, **snag**, **ranger**, **marceau**, **splitter**, **glam**, **gleam_bitwise**, **gleam_community_colour**, **gleam_community_ansi**.
+Pure (all functions `[]`): **filepath**, **gleam_http**, **gleam_json**, **gleam_crypto**, **gleam_regexp**, **gleam_yielder**, **gleam_javascript**, **gleam_deque**, **houdini**, **tom**, **glance**, **glexer**, **justin**, **snag**, **ranger**, **marceau**, **splitter**, **glam**, **gleam_bitwise**, **gleam_community_colour**, **gleam_community_ansi**.
 
 For packages not in the catalog, use `external effects` declarations in your project's spec file.
 

--- a/README.md
+++ b/README.md
@@ -206,14 +206,19 @@ Effect labels are plain strings — you can use any name. The bundled catalog us
 
 | Label | Meaning | Example functions |
 |---|---|---|
-| `Stdout` | Writes to standard output | `gleam/io.println`, `gleam/io.debug` |
+| `Stdout` | Writes to standard output | `gleam/io.println`, `logging.log` |
 | `Stderr` | Writes to standard error | `gleam/io.print_error` |
 | `Stdin` | Reads from standard input | `gleam/erlang.get_line` |
 | `Process` | Spawns, sends to, or manages BEAM processes | `gleam/erlang/process.send`, `gleam/otp/actor.start` |
-| `Http` | Network HTTP requests | `gleam/httpc.send`, `lustre_http.get` |
-| `FileSystem` | Reads or writes the filesystem | `simplifile.read`, `simplifile.write` |
+| `Http` | Network HTTP requests | `gleam/httpc.send`, `gleam/fetch.send`, `lustre_http.get` |
+| `Network` | Lower-level socket / server I/O | `glisten.start`, `mist.start` |
+| `Database` | Database queries | `pog.query`, `pog.execute` |
+| `FileSystem` | Reads or writes the filesystem | `simplifile.read`, `wisp.serve_static` |
+| `Environment` | Reads env vars or command-line arguments | `envoy.get`, `argv.load`, `directories.home_dir` |
+| `Exec` | Runs an external program | `shellout.command`, `shellout.which` |
 | `Dom` | Browser DOM manipulation | `lustre.start`, `lustre.register` |
-| `Time` | Reads system clock or timezone | `gleam/time/timestamp.system_time`, `gleam/time/calendar.local_offset` |
+| `Time` | Reads system clock or timezone | `gleam/time/timestamp.system_time`, `birl.now` |
+| `Random` | Nondeterministic generation | `youid/uuid.v4`, `wisp.random_string` |
 
 You can define your own labels for project-specific effects:
 
@@ -236,18 +241,32 @@ For example, if you have `gleam_stdlib@0.71.0` installed and the catalog has `gl
 
 ### Covered packages
 
+The catalog ships effect knowledge for 39 packages. The effectful ones:
+
 | Package | Effects | Labels |
 |---|---|---|
 | **gleam_stdlib** | `gleam/io.*` | `Stdout`, `Stderr` |
-| **gleam_erlang** | `gleam/erlang/process.*` | `Process`, `Stdin`, `FileSystem` |
+| **gleam_erlang** | `gleam/erlang/process.*`, `gleam/erlang.get_line` | `Process`, `Stdin`, `FileSystem` |
 | **gleam_otp** | `gleam/otp/actor.*`, `gleam/otp/supervisor.*` | `Process` |
 | **gleam_httpc** | `gleam/httpc.send` | `Http` |
+| **gleam_fetch** | `gleam/fetch.send`, `.read_*_body` | `Http` |
 | **lustre** | `lustre.start`, `lustre.send`, `lustre/server_component.*` | `Process`, `Dom` |
 | **lustre_http** | `lustre_http.*` | `Http` |
+| **glisten** | `glisten.start`, `.send`, `.supervised` | `Network`, `Process` |
+| **mist** | `mist.start`, `.read_body`, `.send_file`, websocket frames | `Network`, `Process`, `FileSystem` |
+| **wisp** | `wisp.log_*`, `.serve_static`, `.random_string`, `wisp/wisp_mist.handler` | `Stdout`, `FileSystem`, `Random`, `Network` |
+| **pog** | `pog.query`, `.execute`, `.transaction`, `.start` | `Database`, `Process` |
 | **simplifile** | `simplifile.*` | `FileSystem` |
+| **shellout** | `shellout.command`, `.which`, `.exit`, `.arguments` | `Exec`, `Environment` |
+| **envoy** | `envoy.get`, `.set`, `.unset`, `.all` | `Environment` |
+| **argv** | `argv.load` | `Environment` |
+| **directories** | `directories.*` | `Environment` |
+| **logging** | `logging.log`, `.configure`, `.set_level` | `Stdout` |
 | **gleam_time** | `gleam/time/timestamp.system_time`, `gleam/time/calendar.local_offset`, `.utc_offset` | `Time` |
+| **birl** | `birl.now`, `.utc_now`, `.monotonic_now` | `Time` |
+| **youid** | `youid/uuid.v1`, `.v4`, `.v7` | `Time`, `Random` |
 
-Pure (all functions `[]`): **gleam_http**, **gleam_json**, **filepath**, **gleam_regexp**, **gleam_yielder**, **gleam_crypto**, **houdini**, **tom**.
+Pure (all functions `[]`): **filepath**, **gleam_http**, **gleam_json**, **gleam_crypto**, **gleam_regexp**, **gleam_yielder**, **houdini**, **tom**, **glance**, **glexer**, **justin**, **snag**, **ranger**, **marceau**, **splitter**, **glam**, **gleam_bitwise**, **gleam_community_colour**, **gleam_community_ansi**.
 
 For packages not in the catalog, use `external effects` declarations in your project's spec file.
 

--- a/priv/catalog/argv@1.1.0.graded
+++ b/priv/catalog/argv@1.1.0.graded
@@ -1,0 +1,3 @@
+// argv — command-line arguments
+
+external effects argv.load : [Environment]

--- a/priv/catalog/birl@2.0.0.graded
+++ b/priv/catalog/birl@2.0.0.graded
@@ -1,0 +1,9 @@
+// birl — date and time handling
+
+external effects birl : []
+external effects birl.monotonic_now : [Time]
+external effects birl.now : [Time]
+external effects birl.now_with_offset : [Time]
+external effects birl.now_with_timezone : [Time]
+external effects birl.utc_now : [Time]
+external effects birl/duration : []

--- a/priv/catalog/directories@1.2.0.graded
+++ b/priv/catalog/directories@1.2.0.graded
@@ -1,0 +1,13 @@
+// directories — standard system directory locations
+
+external effects directories.cache_dir : [Environment]
+external effects directories.config_dir : [Environment]
+external effects directories.config_local_dir : [Environment]
+external effects directories.data_dir : [Environment]
+external effects directories.data_local_dir : [Environment]
+external effects directories.executable_dir : [Environment]
+external effects directories.home_dir : [Environment]
+external effects directories.preference_dir : [Environment]
+external effects directories.runtime_dir : [Environment]
+external effects directories.state_dir : [Environment]
+external effects directories.tmp_dir : [Environment]

--- a/priv/catalog/glam@2.0.4.graded
+++ b/priv/catalog/glam@2.0.4.graded
@@ -1,0 +1,3 @@
+// glam — pure pretty-printing documents
+
+external effects glam/doc : []

--- a/priv/catalog/glance@6.1.0.graded
+++ b/priv/catalog/glance@6.1.0.graded
@@ -1,0 +1,3 @@
+// glance — pure Gleam source parser
+
+external effects glance : []

--- a/priv/catalog/gleam_bitwise@1.3.1.graded
+++ b/priv/catalog/gleam_bitwise@1.3.1.graded
@@ -1,3 +1,4 @@
 // gleam_bitwise — pure bitwise integer operations
+// Package archived upstream; bitwise operators are now language built-ins.
 
 external effects gleam/bitwise : []

--- a/priv/catalog/gleam_bitwise@1.3.1.graded
+++ b/priv/catalog/gleam_bitwise@1.3.1.graded
@@ -1,0 +1,3 @@
+// gleam_bitwise — pure bitwise integer operations
+
+external effects gleam/bitwise : []

--- a/priv/catalog/gleam_community_ansi@1.5.0.graded
+++ b/priv/catalog/gleam_community_ansi@1.5.0.graded
@@ -1,0 +1,3 @@
+// gleam_community_ansi — pure ANSI string formatting
+
+external effects gleam_community/ansi : []

--- a/priv/catalog/gleam_community_colour@2.0.4.graded
+++ b/priv/catalog/gleam_community_colour@2.0.4.graded
@@ -1,0 +1,4 @@
+// gleam_community_colour — pure colour types and conversions
+
+external effects gleam_community/colour : []
+external effects gleam_community/colour/accessibility : []

--- a/priv/catalog/gleam_cowboy@1.1.0.graded
+++ b/priv/catalog/gleam_cowboy@1.1.0.graded
@@ -1,0 +1,3 @@
+// gleam_cowboy — HTTP server (Erlang cowboy)
+
+external effects gleam/http/cowboy.start : [Network, Process]

--- a/priv/catalog/gleam_deque@1.0.0.graded
+++ b/priv/catalog/gleam_deque@1.0.0.graded
@@ -1,0 +1,3 @@
+// gleam_deque — pure double-ended queue
+
+external effects gleam/deque : []

--- a/priv/catalog/gleam_elli@3.0.0.graded
+++ b/priv/catalog/gleam_elli@3.0.0.graded
@@ -1,0 +1,4 @@
+// gleam_elli — HTTP server (Erlang elli)
+
+external effects gleam/http/elli.become : [Network, Process]
+external effects gleam/http/elli.start : [Network, Process]

--- a/priv/catalog/gleam_fetch@1.4.0.graded
+++ b/priv/catalog/gleam_fetch@1.4.0.graded
@@ -1,0 +1,11 @@
+// gleam_fetch — HTTP client (JavaScript Fetch)
+
+external effects gleam/fetch.raw_send : [Http]
+external effects gleam/fetch.read_bytes_body : [Http]
+external effects gleam/fetch.read_chunk : [Http]
+external effects gleam/fetch.read_json_body : [Http]
+external effects gleam/fetch.read_text_body : [Http]
+external effects gleam/fetch.send : [Http]
+external effects gleam/fetch.send_bits : [Http]
+external effects gleam/fetch.send_form_data : [Http]
+external effects gleam/fetch.stream_body : [Http]

--- a/priv/catalog/gleam_hackney@1.4.0.graded
+++ b/priv/catalog/gleam_hackney@1.4.0.graded
@@ -1,0 +1,4 @@
+// gleam_hackney — HTTP client (Erlang hackney)
+
+external effects gleam/hackney.send : [Http]
+external effects gleam/hackney.send_bits : [Http]

--- a/priv/catalog/gleam_javascript@1.0.0.graded
+++ b/priv/catalog/gleam_javascript@1.0.0.graded
@@ -1,0 +1,5 @@
+// gleam_javascript — JavaScript-target primitives (arrays, promises, symbols)
+
+external effects gleam/javascript/array : []
+external effects gleam/javascript/promise : []
+external effects gleam/javascript/symbol : []

--- a/priv/catalog/glexer@2.4.0.graded
+++ b/priv/catalog/glexer@2.4.0.graded
@@ -1,0 +1,4 @@
+// glexer — pure Gleam lexer
+
+external effects glexer : []
+external effects glexer/token : []

--- a/priv/catalog/glisten@9.0.1.graded
+++ b/priv/catalog/glisten@9.0.1.graded
@@ -1,0 +1,8 @@
+// glisten — TCP/TLS server
+
+external effects glisten.get_connection_info : [Network]
+external effects glisten.get_server_info : [Network]
+external effects glisten.send : [Network]
+external effects glisten.start : [Network, Process]
+external effects glisten.stop : [Process]
+external effects glisten.supervised : [Network, Process]

--- a/priv/catalog/justin@1.1.0.graded
+++ b/priv/catalog/justin@1.1.0.graded
@@ -1,0 +1,3 @@
+// justin — pure string case conversion
+
+external effects justin : []

--- a/priv/catalog/logging@1.5.0.graded
+++ b/priv/catalog/logging@1.5.0.graded
@@ -1,0 +1,5 @@
+// logging — Erlang logger configuration
+
+external effects logging.configure : [Stdout]
+external effects logging.log : [Stdout]
+external effects logging.set_level : [Stdout]

--- a/priv/catalog/marceau@1.3.0.graded
+++ b/priv/catalog/marceau@1.3.0.graded
@@ -1,0 +1,3 @@
+// marceau — pure MIME type lookup
+
+external effects marceau : []

--- a/priv/catalog/mist@6.0.3.graded
+++ b/priv/catalog/mist@6.0.3.graded
@@ -1,0 +1,12 @@
+// mist — web server
+
+external effects mist.read_body : [Network]
+external effects mist.read_request_body : [Network]
+external effects mist.send_binary_frame : [Network]
+external effects mist.send_chunk : [Network]
+external effects mist.send_event : [Network]
+external effects mist.send_file : [FileSystem]
+external effects mist.send_text_frame : [Network]
+external effects mist.start : [Network, Process]
+external effects mist.stream : [Network]
+external effects mist.supervised : [Network, Process]

--- a/priv/catalog/pog@4.1.0.graded
+++ b/priv/catalog/pog@4.1.0.graded
@@ -1,0 +1,7 @@
+// pog — PostgreSQL client
+
+external effects pog.execute : [Database]
+external effects pog.query : [Database]
+external effects pog.start : [Database, Process]
+external effects pog.supervised : [Database, Process]
+external effects pog.transaction : [Database]

--- a/priv/catalog/ranger@1.4.0.graded
+++ b/priv/catalog/ranger@1.4.0.graded
@@ -1,0 +1,3 @@
+// ranger — pure lazy ranges
+
+external effects ranger : []

--- a/priv/catalog/shellout@1.8.0.graded
+++ b/priv/catalog/shellout@1.8.0.graded
@@ -1,0 +1,7 @@
+// shellout — cross-platform shell operations
+
+external effects shellout : []
+external effects shellout.arguments : [Environment]
+external effects shellout.command : [Subprocess]
+external effects shellout.exit : [Subprocess]
+external effects shellout.which : [Subprocess]

--- a/priv/catalog/shellout@1.8.0.graded
+++ b/priv/catalog/shellout@1.8.0.graded
@@ -2,6 +2,6 @@
 
 external effects shellout : []
 external effects shellout.arguments : [Environment]
-external effects shellout.command : [Subprocess]
-external effects shellout.exit : [Subprocess]
-external effects shellout.which : [Subprocess]
+external effects shellout.command : [Exec]
+external effects shellout.exit : [Exec]
+external effects shellout.which : [Exec]

--- a/priv/catalog/snag@1.2.0.graded
+++ b/priv/catalog/snag@1.2.0.graded
@@ -1,0 +1,3 @@
+// snag — pure ad-hoc error values
+
+external effects snag : []

--- a/priv/catalog/splitter@1.2.0.graded
+++ b/priv/catalog/splitter@1.2.0.graded
@@ -1,0 +1,3 @@
+// splitter — pure string splitting
+
+external effects splitter : []

--- a/priv/catalog/wisp@2.2.2.graded
+++ b/priv/catalog/wisp@2.2.2.graded
@@ -1,0 +1,18 @@
+// wisp — web framework
+
+external effects wisp.configure_logger : [Stdout]
+external effects wisp.delete_temporary_files : [FileSystem]
+external effects wisp.log_alert : [Stdout]
+external effects wisp.log_critical : [Stdout]
+external effects wisp.log_debug : [Stdout]
+external effects wisp.log_emergency : [Stdout]
+external effects wisp.log_error : [Stdout]
+external effects wisp.log_info : [Stdout]
+external effects wisp.log_notice : [Stdout]
+external effects wisp.log_request : [Stdout]
+external effects wisp.log_warning : [Stdout]
+external effects wisp.new_temporary_file : [FileSystem]
+external effects wisp.random_string : [Random]
+external effects wisp.serve_static : [FileSystem]
+external effects wisp.set_logger_level : [Stdout]
+external effects wisp/wisp_mist.handler : [Network, Process]

--- a/priv/catalog/youid@1.6.0.graded
+++ b/priv/catalog/youid@1.6.0.graded
@@ -1,0 +1,10 @@
+// youid — UUID generation and parsing
+
+external effects youid/uuid : []
+external effects youid/uuid.v1 : [Random, Time]
+external effects youid/uuid.v1_string : [Random, Time]
+external effects youid/uuid.v4 : [Random]
+external effects youid/uuid.v4_string : [Random]
+external effects youid/uuid.v7 : [Random, Time]
+external effects youid/uuid.v7_from_millisec : [Random]
+external effects youid/uuid.v7_string : [Random, Time]


### PR DESCRIPTION
## What

Expands the bundled effect catalog from **17 → 39 packages**, covering more of the most-downloaded Gleam libraries (ranked by all-time hex.pm downloads). Calls into these packages now resolve to a precise effect — or `[]` for pure libraries — instead of `[Unknown]`.

### Pure libraries (blanket `[]`)
glance, glexer, justin, snag, ranger, marceau, gleam_community_colour, gleam_community_ansi, glam, splitter, gleam_bitwise.

*(glance and glexer are graded's own dependencies, so this also de-noises its self-check.)*

### Effectful libraries
glisten, mist, wisp, pog, gleam_fetch, shellout, logging, argv, directories, birl, youid.

Each package's effect surface was verified against its published source (FFI calls, e.g. `youid.v4` → `crypto.strong_random_bytes`, shellout's `os_command`/`os_exit`). Mostly-pure packages (birl, youid, shellout) use a module-blanket `[]` plus per-function overrides — the same pattern `gleam_time` already uses.

## New effect labels

Four new labels were introduced where existing ones didn't fit:

- `Network` — socket/server I/O (glisten, mist)
- `Database` — queries (pog)
- `Subprocess` — shelling out (shellout)
- `Random` — nondeterministic generation (youid v4/v7, `wisp.random_string`)

Existing labels (`Http`, `Time`, `FileSystem`, `Process`, `Stdout`, `Environment`) are reused everywhere they apply.

## Validation

- All 22 files parse and round-trip through `graded format` (canonical + idempotent).
- Full suite green (360 tests).

## Notes

- gleeunit (test-only) was deliberately skipped pending a decision on whether graded should check test modules.