### PR TITLE
Hand-written field bounds + dead-bound warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Field bounds.** A `check` line can bound a function-typed field reached through a parameter, using a `param.field` path: `check myapp.view(handler.on_click: [Dom]) : [Dom]`. The field call resolves to the declared effect, taking priority over receiver-type resolution — the boundary-scoped counterpart to a `type` line, for a receiver graded can't trace to a construction site.
+
 ## [0.8.1] - 2026-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Field bounds.** A `check` line can bound a function-typed field reached through a parameter, using a `param.field` path: `check myapp.view(handler.on_click: [Dom]) : [Dom]`. The field call resolves to the declared effect, taking priority over receiver-type resolution — the boundary-scoped counterpart to a `type` line, for a receiver graded can't trace to a construction site.
+- A field bound whose `param.field` path matches no field call in the checked function's body now emits a warning, catching typos in the path that would otherwise resolve nothing silently.
 
 ## [0.8.1] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Field bounds.** A `check` line can bound a function-typed field reached through a parameter, using a `param.field` path: `check myapp.view(handler.on_click: [Dom]) : [Dom]`. The field call resolves to the declared effect, taking priority over receiver-type resolution — the boundary-scoped counterpart to a `type` line, for a receiver graded can't trace to a construction site.
 - A field bound whose `param.field` path matches no field call in the checked function's body now emits a warning, catching typos in the path that would otherwise resolve nothing silently.
+- A plain parameter bound whose name matches no declared parameter now emits a warning. It is matched on parameter existence, not call presence, so a callback that's forwarded but never called directly is not flagged.
 
 ## [0.8.1] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Field bounds.** A `check` line can bound a function-typed field reached through a parameter, using a `param.field` path: `check myapp.view(handler.on_click: [Dom]) : [Dom]`. The field call resolves to the declared effect, taking priority over receiver-type resolution — the boundary-scoped counterpart to a `type` line, for a receiver graded can't trace to a construction site.
-- A field bound whose `param.field` path matches no field call in the checked function's body now emits a warning, catching typos in the path that would otherwise resolve nothing silently.
+- A field bound whose `param.field` path matches no field call in the checked function's body now emits a warning, catching typos in the path that would otherwise resolve nothing silently. When the receiver is not a parameter, the warning also notes the call may have resolved through value provenance, which shadows the bound, rather than blaming the path.
 - A plain parameter bound whose name matches no declared parameter now emits a warning. It is matched on parameter existence, not call presence, so a callback that's forwarded but never called directly is not flagged.
 
 ## [0.8.1] - 2026-06-22

--- a/docs/FUTURE_WORK.md
+++ b/docs/FUTURE_WORK.md
@@ -1,26 +1,10 @@
 # Future work
 
 graded's effect analysis is mature: first- and second-order effect polymorphism,
-girard-backed field resolution, and cross-module / cross-package inference all
-ship today. What remains is a short list of refinements and one new direction,
-ordered by incrementality — earlier items are smaller, later items push into
-different territory.
-
-## Hand-written field bounds
-
-Extend parameter bounds to accept a *path* expression, so a user can declare a
-record field's effects at the function boundary when graded can't trace the value
-on its own (the field-call case in [LIMITATIONS.md](./LIMITATIONS.md#1-a-record-field-reached-through-an-untraceable-receiver)):
-
-```
-check myapp.view(handler.on_click: [Dom]) : [Dom]
-```
-
-This is a syntax extension to `ParamBound` (a path instead of a bare identifier),
-no analysis required — the user states what a field's effects are, and
-substitution works exactly like first-order parameter bounds. It gives the
-field-call limitation a boundary-level escape hatch, complementing the existing
-`type` line.
+girard-backed field resolution, hand-written field bounds, and cross-module /
+cross-package inference all ship today. What remains is a short list of refinements
+and one new direction, ordered by incrementality — earlier items are smaller, later
+items push into different territory.
 
 ## Retiring the positional/label heuristics
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -45,6 +45,16 @@ type app.Validator.to_error : [Stdout]
 
 Field calls then resolve on *any* receiver of that type, however it was obtained.
 
+Or, when the assertion belongs at a single function boundary, declare it as a **field
+bound** on that function's `check` line:
+
+```
+check app.caller(v.to_error: [Stdout]) : [Stdout]
+```
+
+The `param.field` bound resolves the call inside `caller` only, leaving the type
+untouched elsewhere.
+
 > Note: when a record *is* built by a factory function (`let v = make(io.println)`),
 > graded resolves the field through the factory — but only for **positional**
 > wiring (`make(io.println)`). A factory that wires the field with a *labeled*

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -170,7 +170,10 @@ effect depends on its own arguments — use a [`type` line](#type-field-effects)
 instead, which substitutes the field call's arguments into the declared variables.
 
 If a field bound's `param.field` path matches no field call in the checked function's
-body, graded emits a warning — the bound is dead, usually a typo in the path.
+body, graded emits a warning — the bound is dead. When the receiver is a parameter the
+cause is a typo in the path; when it isn't, the warning also notes the field call may
+have resolved through value provenance (a receiver traced to a construction site),
+which shadows the bound.
 
 **Precedence.** A field bound only competes with receiver-type (`type`-line)
 resolution, and wins it. It does *not* override value provenance: when the receiver

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -172,6 +172,14 @@ instead, which substitutes the field call's arguments into the declared variable
 If a field bound's `param.field` path matches no field call in the checked function's
 body, graded emits a warning — the bound is dead, usually a typo in the path.
 
+**Precedence.** A field bound only competes with receiver-type (`type`-line)
+resolution, and wins it. It does *not* override value provenance: when the receiver
+is traced to a construction site — a direct constructor or a factory — and the field
+resolves through that value, the call is resolved before it is ever treated as a
+field call, so the bound doesn't apply. This isn't a conflict in practice: field
+bounds exist for receivers graded can't trace (a parameter, a value threaded through
+data), which is exactly the case where there's no provenance to compete with.
+
 ### Effect polymorphism
 
 When a function's effects *depend on* its callback, use lowercase effect variables:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -148,6 +148,22 @@ effects myapp.apply(f: [Stdout]) : [Stdout]
 A call to a bounded parameter (`f(x)` inside `apply`) uses the declared bound
 instead of `[Unknown]`.
 
+### Field bounds
+
+A bound's name can be a `param.field` path, declaring the effect of a function-typed
+field reached through a parameter:
+
+```
+// handler.on_click carries [Dom] inside view
+check myapp.view(handler.on_click: [Dom]) : [Dom]
+```
+
+A field call `handler.on_click(event)` then resolves to `[Dom]` directly, taking
+priority over receiver-type resolution. This is the boundary-scoped counterpart to a
+[`type` line](#type-field-effects): the `type` line declares a field's effect for
+every receiver of that type package-wide, the field bound for one `check`'d function.
+A field bound and an ordinary parameter bound can share one `check` line.
+
 ### Effect polymorphism
 
 When a function's effects *depend on* its callback, use lowercase effect variables:
@@ -222,8 +238,9 @@ The field's effect comes from one of:
 Field effects are keyed by the type's **defining module** (from girard's inferred
 type), so two different types both named `Validator` never conflate. When a field
 is wired to a value graded can't trace — a constructor parameter, or a local that
-isn't a traceable function — it falls back to `[Unknown]`, and the `type` line is
-the escape hatch; see [LIMITATIONS.md](./LIMITATIONS.md).
+isn't a traceable function — it falls back to `[Unknown]`. The escape hatch is a
+`type` line, or a [field bound](#field-bounds) when the assertion belongs at a single
+function boundary; see [LIMITATIONS.md](./LIMITATIONS.md).
 
 ## External declarations and FFI
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -164,6 +164,11 @@ priority over receiver-type resolution. This is the boundary-scoped counterpart 
 every receiver of that type package-wide, the field bound for one `check`'d function.
 A field bound and an ordinary parameter bound can share one `check` line.
 
+A field bound declares a *concrete* effect set: it resolves to exactly the effects
+written, with no call-site substitution. For an effect-polymorphic field — one whose
+effect depends on its own arguments — use a [`type` line](#type-field-effects)
+instead, which substitutes the field call's arguments into the declared variables.
+
 ### Effect polymorphism
 
 When a function's effects *depend on* its callback, use lowercase effect variables:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -169,6 +169,9 @@ written, with no call-site substitution. For an effect-polymorphic field — one
 effect depends on its own arguments — use a [`type` line](#type-field-effects)
 instead, which substitutes the field call's arguments into the declared variables.
 
+If a field bound's `param.field` path matches no field call in the checked function's
+body, graded emits a warning — the bound is dead, usually a typo in the path.
+
 ### Effect polymorphism
 
 When a function's effects *depend on* its callback, use lowercase effect variables:

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -1227,15 +1227,26 @@ fn print_warning(file: String, warning: Warning) -> Nil {
         <> effects.format_effect_set(effs)
         <> " won't be tracked",
       )
-    UnmatchedFieldBoundWarning(function:, field_path:) ->
+    UnmatchedFieldBoundWarning(function:, field_path:, receiver_is_param:) -> {
+      let cause = case receiver_is_param {
+        True -> " matches no field call in its body — check the path"
+        // A non-parameter receiver can be traced to a construction site, so the
+        // call may exist but resolve through value provenance, shadowing the bound.
+        False ->
+          " matches no field call in its body — check the path,"
+          <> " or the receiver is traced to a construction site and resolved"
+          <> " through value provenance (field bounds apply only to untraceable"
+          <> " receivers)"
+      }
       io.println(
         file
         <> ": warning: field bound "
         <> field_path
         <> " on "
         <> function
-        <> " matches no field call in its body — check the path",
+        <> cause,
       )
+    }
     UnmatchedParamBoundWarning(function:, param:) ->
       io.println(
         file

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -45,7 +45,7 @@ import graded/internal/typeinfo
 import graded/internal/types.{
   type CheckResult, type EffectAnnotation, type GradedFile, type QualifiedName,
   type Violation, type Warning, AnnotationLine, CheckResult, EffectAnnotation,
-  GradedFile, QualifiedName,
+  GradedFile, QualifiedName, UnmatchedFieldBoundWarning, UntrackedEffectWarning,
 }
 import simplifile
 
@@ -1212,18 +1212,30 @@ fn print_warnings(check_result: CheckResult) -> Nil {
 }
 
 fn print_warning(file: String, warning: Warning) -> Nil {
-  io.println(
-    file
-    <> ": warning: "
-    <> warning.function
-    <> " passes "
-    <> warning.reference.module
-    <> "."
-    <> warning.reference.function
-    <> " as a value — its effects "
-    <> effects.format_effect_set(warning.effects)
-    <> " won't be tracked",
-  )
+  case warning {
+    UntrackedEffectWarning(function:, reference:, effects: effs, ..) ->
+      io.println(
+        file
+        <> ": warning: "
+        <> function
+        <> " passes "
+        <> reference.module
+        <> "."
+        <> reference.function
+        <> " as a value — its effects "
+        <> effects.format_effect_set(effs)
+        <> " won't be tracked",
+      )
+    UnmatchedFieldBoundWarning(function:, field_path:) ->
+      io.println(
+        file
+        <> ": warning: field bound "
+        <> field_path
+        <> " on "
+        <> function
+        <> " matches no field call in its body — check the path",
+      )
+  }
 }
 
 @external(erlang, "erlang", "halt")

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -45,7 +45,8 @@ import graded/internal/typeinfo
 import graded/internal/types.{
   type CheckResult, type EffectAnnotation, type GradedFile, type QualifiedName,
   type Violation, type Warning, AnnotationLine, CheckResult, EffectAnnotation,
-  GradedFile, QualifiedName, UnmatchedFieldBoundWarning, UntrackedEffectWarning,
+  GradedFile, QualifiedName, UnmatchedFieldBoundWarning,
+  UnmatchedParamBoundWarning, UntrackedEffectWarning,
 }
 import simplifile
 
@@ -1234,6 +1235,15 @@ fn print_warning(file: String, warning: Warning) -> Nil {
         <> " on "
         <> function
         <> " matches no field call in its body — check the path",
+      )
+    UnmatchedParamBoundWarning(function:, param:) ->
+      io.println(
+        file
+        <> ": warning: parameter bound "
+        <> param
+        <> " on "
+        <> function
+        <> " names no parameter of the function — check the name",
       )
   }
 }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2366,72 +2366,49 @@ fn resolve_field_call(
   // construction site. User-declared, so it wins over inferred field effects.
   let field_target = field_call.object <> "." <> field_call.label
   case list.find(caller_param_bounds, fn(b) { b.name == field_target }) {
-    Ok(bound) -> #(effect_term.normalize(bound.effects), memo)
-    Error(Nil) ->
-      resolve_field_call_by_type(
-        field_call,
-        function,
-        knowledge_base,
-        module_types,
-        call_args,
-        caller_param_bounds,
-        registry,
-        lift_operator_arg,
-        memo,
-      )
-  }
-}
-
-fn resolve_field_call_by_type(
-  field_call: types.FieldCall,
-  function: Function,
-  knowledge_base: KnowledgeBase,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
-  call_args: dict.Dict(Int, List(types.CallArgument)),
-  caller_param_bounds: List(ParamBound),
-  registry: SignatureRegistry,
-  lift_operator_arg: fn(types.ArgumentValue, List(Int), Memo) ->
-    #(Result(EffectTerm, Nil), Memo),
-  memo: Memo,
-) -> #(EffectTerm, Memo) {
-  // Resolve the receiver's nominal type, qualified by its defining module:
-  // girard's inferred type for the receiver expression first (any receiver, and
-  // girard reports the defining module), then the receiver's syntactic parameter
-  // annotation (no module available, so keyed unqualified as "").
-  let receiver_type =
-    typeinfo.receiver_type(
-      module_types,
-      field_call.receiver_span.start,
-      field_call.receiver_span.end,
-    )
-    |> option.lazy_or(fn() {
-      syntactic_param_type(function, field_call.object)
-      |> option.map(fn(type_name) { #("", type_name) })
-    })
-  case receiver_type {
-    None -> #(effect_term.unknown(), memo)
-    Some(#(module, type_name)) ->
-      case
-        effects.lookup_type_field(
-          knowledge_base,
-          module,
-          type_name,
-          field_call.label,
+    Ok(bound) -> #(bound.effects, memo)
+    Error(Nil) -> {
+      // No field bound: resolve the receiver's nominal type, qualified by its
+      // defining module — girard's inferred type for the receiver expression
+      // first (any receiver, and girard reports the defining module), then the
+      // receiver's syntactic parameter annotation (no module available, so keyed
+      // unqualified as "").
+      let receiver_type =
+        typeinfo.receiver_type(
+          module_types,
+          field_call.receiver_span.start,
+          field_call.receiver_span.end,
         )
-      {
-        Error(Nil) -> #(effect_term.unknown(), memo)
-        Ok(field_effect) ->
-          resolve_field_effect(
-            field_effect,
-            field_call,
-            call_args,
-            knowledge_base,
-            caller_param_bounds,
-            registry,
-            lift_operator_arg,
-            memo,
-          )
+        |> option.lazy_or(fn() {
+          syntactic_param_type(function, field_call.object)
+          |> option.map(fn(type_name) { #("", type_name) })
+        })
+      case receiver_type {
+        None -> #(effect_term.unknown(), memo)
+        Some(#(module, type_name)) ->
+          case
+            effects.lookup_type_field(
+              knowledge_base,
+              module,
+              type_name,
+              field_call.label,
+            )
+          {
+            Error(Nil) -> #(effect_term.unknown(), memo)
+            Ok(field_effect) ->
+              resolve_field_effect(
+                field_effect,
+                field_call,
+                call_args,
+                knowledge_base,
+                caller_param_bounds,
+                registry,
+                lift_operator_arg,
+                memo,
+              )
+          }
       }
+    }
   }
 }
 

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2359,6 +2359,41 @@ fn resolve_field_call(
     #(Result(EffectTerm, Nil), Memo),
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
+  // A hand-written field bound on the enclosing `check` line
+  // (`check f(recv.field: [..])`) resolves the call directly, ahead of
+  // girard/type-registry resolution. It's the boundary-scoped counterpart to a
+  // `type` line — an escape hatch for a receiver graded can't trace to a
+  // construction site. User-declared, so it wins over inferred field effects.
+  let field_target = field_call.object <> "." <> field_call.label
+  case list.find(caller_param_bounds, fn(b) { b.name == field_target }) {
+    Ok(bound) -> #(effect_term.normalize(bound.effects), memo)
+    Error(Nil) ->
+      resolve_field_call_by_type(
+        field_call,
+        function,
+        knowledge_base,
+        module_types,
+        call_args,
+        caller_param_bounds,
+        registry,
+        lift_operator_arg,
+        memo,
+      )
+  }
+}
+
+fn resolve_field_call_by_type(
+  field_call: types.FieldCall,
+  function: Function,
+  knowledge_base: KnowledgeBase,
+  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  call_args: dict.Dict(Int, List(types.CallArgument)),
+  caller_param_bounds: List(ParamBound),
+  registry: SignatureRegistry,
+  lift_operator_arg: fn(types.ArgumentValue, List(Int), Memo) ->
+    #(Result(EffectTerm, Nil), Memo),
+  memo: Memo,
+) -> #(EffectTerm, Memo) {
   // Resolve the receiver's nominal type, qualified by its defining module:
   // girard's inferred type for the receiver expression first (any receiver, and
   // girard reports the defining module), then the receiver's syntactic parameter

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -742,8 +742,23 @@ fn check_annotation(
           knowledge_base,
         )
 
+      let param_names =
+        function_definition.definition.parameters
+        |> list.filter_map(fn(param) {
+          case param.name {
+            glance.Named(name) -> Ok(name)
+            glance.Discarded(_) -> Error(Nil)
+          }
+        })
+        |> set.from_list()
+
       // Warn about field bounds whose `recv.field` path matches no field call in
-      // the body — a dead bound, almost always a typo in the path.
+      // the body — a dead bound. When the receiver is a parameter it can't be
+      // traced to a construction site, so a missing field call is a genuine typo.
+      // When it isn't, the field call may exist but have resolved through value
+      // provenance, shadowing the bound; the warning says so rather than blaming
+      // the path. (Provenance only traces let-bound constructions, never a
+      // parameter, so the parameter case is never a false provenance report.)
       let field_call_targets =
         extract_result.field
         |> list.map(fn(field_call) {
@@ -757,9 +772,14 @@ fn check_annotation(
           !set.contains(field_call_targets, bound.name)
         })
         |> list.map(fn(bound) {
+          let receiver = case string.split_once(bound.name, ".") {
+            Ok(#(receiver, _)) -> receiver
+            Error(Nil) -> bound.name
+          }
           UnmatchedFieldBoundWarning(
             function: annotation.function,
             field_path: bound.name,
+            receiver_is_param: set.contains(param_names, receiver),
           )
         })
 
@@ -768,15 +788,6 @@ fn check_annotation(
       // a callback that's forwarded but never called directly is still a real
       // parameter, so its bound stays load-bearing during substitution and isn't
       // flagged. Only a name that is no parameter at all is dead.
-      let param_names =
-        function_definition.definition.parameters
-        |> list.filter_map(fn(param) {
-          case param.name {
-            glance.Named(name) -> Ok(name)
-            glance.Discarded(_) -> Error(Nil)
-          }
-        })
-        |> set.from_list()
       let unmatched_param_bound_warnings =
         annotation.params
         |> list.filter(fn(bound) { !string.contains(bound.name, ".") })

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -20,7 +20,8 @@ import graded/internal/typeinfo
 import graded/internal/types.{
   type EffectAnnotation, type EffectTerm, type LocalCall, type ParamBound,
   type ResolvedCall, type Violation, type Warning, EffectAnnotation, Effects,
-  ParamBound, QualifiedName, TUnion, TVar, UntrackedEffectWarning, Violation,
+  ParamBound, QualifiedName, TUnion, TVar, UnmatchedFieldBoundWarning,
+  UntrackedEffectWarning, Violation,
 }
 
 // Check a parsed module against its effect annotations.
@@ -734,12 +735,36 @@ fn check_annotation(
       // Warn about function references passed as values with known non-pure effects.
       let extract_result =
         extract.extract_calls(function_definition.definition.body, context)
-      let warnings =
+      let reference_warnings =
         collect_reference_warnings(
           annotation.function,
           extract_result.references,
           knowledge_base,
         )
+
+      // Warn about field bounds whose `recv.field` path matches no field call in
+      // the body — a dead bound, almost always a typo in the path.
+      let field_call_targets =
+        extract_result.field
+        |> list.map(fn(field_call) {
+          field_call.object <> "." <> field_call.label
+        })
+        |> set.from_list()
+      let unmatched_field_bound_warnings =
+        annotation.params
+        |> list.filter(fn(bound) { string.contains(bound.name, ".") })
+        |> list.filter(fn(bound) {
+          !set.contains(field_call_targets, bound.name)
+        })
+        |> list.map(fn(bound) {
+          UnmatchedFieldBoundWarning(
+            function: annotation.function,
+            field_path: bound.name,
+          )
+        })
+
+      let warnings =
+        list.append(reference_warnings, unmatched_field_bound_warnings)
 
       #(#(violations, warnings), memo)
     }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2367,48 +2367,73 @@ fn resolve_field_call(
   let field_target = field_call.object <> "." <> field_call.label
   case list.find(caller_param_bounds, fn(b) { b.name == field_target }) {
     Ok(bound) -> #(bound.effects, memo)
-    Error(Nil) -> {
-      // No field bound: resolve the receiver's nominal type, qualified by its
-      // defining module — girard's inferred type for the receiver expression
-      // first (any receiver, and girard reports the defining module), then the
-      // receiver's syntactic parameter annotation (no module available, so keyed
-      // unqualified as "").
-      let receiver_type =
-        typeinfo.receiver_type(
-          module_types,
-          field_call.receiver_span.start,
-          field_call.receiver_span.end,
+    Error(Nil) ->
+      resolve_field_call_by_type(
+        field_call,
+        function,
+        knowledge_base,
+        module_types,
+        call_args,
+        caller_param_bounds,
+        registry,
+        lift_operator_arg,
+        memo,
+      )
+  }
+}
+
+// Resolve a field call through the receiver's nominal type. The fallback when no
+// hand-written field bound applies: resolve the receiver's type qualified by its
+// defining module — girard's inferred type for the receiver expression first (any
+// receiver, and girard reports the defining module), then the receiver's syntactic
+// parameter annotation (no module available, so keyed unqualified as "") — then
+// look the field up in the type registry.
+fn resolve_field_call_by_type(
+  field_call: types.FieldCall,
+  function: Function,
+  knowledge_base: KnowledgeBase,
+  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  call_args: dict.Dict(Int, List(types.CallArgument)),
+  caller_param_bounds: List(ParamBound),
+  registry: SignatureRegistry,
+  lift_operator_arg: fn(types.ArgumentValue, List(Int), Memo) ->
+    #(Result(EffectTerm, Nil), Memo),
+  memo: Memo,
+) -> #(EffectTerm, Memo) {
+  let receiver_type =
+    typeinfo.receiver_type(
+      module_types,
+      field_call.receiver_span.start,
+      field_call.receiver_span.end,
+    )
+    |> option.lazy_or(fn() {
+      syntactic_param_type(function, field_call.object)
+      |> option.map(fn(type_name) { #("", type_name) })
+    })
+  case receiver_type {
+    None -> #(effect_term.unknown(), memo)
+    Some(#(module, type_name)) ->
+      case
+        effects.lookup_type_field(
+          knowledge_base,
+          module,
+          type_name,
+          field_call.label,
         )
-        |> option.lazy_or(fn() {
-          syntactic_param_type(function, field_call.object)
-          |> option.map(fn(type_name) { #("", type_name) })
-        })
-      case receiver_type {
-        None -> #(effect_term.unknown(), memo)
-        Some(#(module, type_name)) ->
-          case
-            effects.lookup_type_field(
-              knowledge_base,
-              module,
-              type_name,
-              field_call.label,
-            )
-          {
-            Error(Nil) -> #(effect_term.unknown(), memo)
-            Ok(field_effect) ->
-              resolve_field_effect(
-                field_effect,
-                field_call,
-                call_args,
-                knowledge_base,
-                caller_param_bounds,
-                registry,
-                lift_operator_arg,
-                memo,
-              )
-          }
+      {
+        Error(Nil) -> #(effect_term.unknown(), memo)
+        Ok(field_effect) ->
+          resolve_field_effect(
+            field_effect,
+            field_call,
+            call_args,
+            knowledge_base,
+            caller_param_bounds,
+            registry,
+            lift_operator_arg,
+            memo,
+          )
       }
-    }
   }
 }
 

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -134,7 +134,12 @@ pub fn infer_with_returns(
 
   // Seed param bounds from existing `check` annotations only — `effects`
   // annotations don't carry user-declared bounds, so they can't constrain
-  // higher-order parameters during inference.
+  // higher-order parameters during inference. Field bounds (dotted `param.field`
+  // names) ride this same path: they resolve field calls during the seeded
+  // inference exactly as plain bounds resolve parameter calls. Only callers that
+  // pass real checks here are affected — the `graded infer` cache pass passes
+  // `[]`, so a `check`-line bound never leaks into the written cache; path-dep
+  // inference passes its spec checks, so a dep's bounds do constrain it.
   let bounds_map =
     existing_checks
     |> list.filter(fn(annotation) { annotation.params != [] })

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2394,6 +2394,9 @@ fn resolve_field_call(
   // girard/type-registry resolution. It's the boundary-scoped counterpart to a
   // `type` line — an escape hatch for a receiver graded can't trace to a
   // construction site. User-declared, so it wins over inferred field effects.
+  // (Factory/constructor-traced receivers never reach here — extraction resolves
+  // them to a plain call through value provenance — so the bound only competes
+  // with, and beats, receiver-type resolution.)
   //
   // The bound's effects are returned verbatim — a concrete effect set, no
   // call-site substitution (unlike the `type`-line path below, which runs

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -21,7 +21,7 @@ import graded/internal/types.{
   type EffectAnnotation, type EffectTerm, type LocalCall, type ParamBound,
   type ResolvedCall, type Violation, type Warning, EffectAnnotation, Effects,
   ParamBound, QualifiedName, TUnion, TVar, UnmatchedFieldBoundWarning,
-  UntrackedEffectWarning, Violation,
+  UnmatchedParamBoundWarning, UntrackedEffectWarning, Violation,
 }
 
 // Check a parsed module against its effect annotations.
@@ -763,8 +763,35 @@ fn check_annotation(
           )
         })
 
+      // Warn about plain parameter bounds whose name matches no declared
+      // parameter — a typo. Checked on parameter *existence*, not call presence:
+      // a callback that's forwarded but never called directly is still a real
+      // parameter, so its bound stays load-bearing during substitution and isn't
+      // flagged. Only a name that is no parameter at all is dead.
+      let param_names =
+        function_definition.definition.parameters
+        |> list.filter_map(fn(param) {
+          case param.name {
+            glance.Named(name) -> Ok(name)
+            glance.Discarded(_) -> Error(Nil)
+          }
+        })
+        |> set.from_list()
+      let unmatched_param_bound_warnings =
+        annotation.params
+        |> list.filter(fn(bound) { !string.contains(bound.name, ".") })
+        |> list.filter(fn(bound) { !set.contains(param_names, bound.name) })
+        |> list.map(fn(bound) {
+          UnmatchedParamBoundWarning(
+            function: annotation.function,
+            param: bound.name,
+          )
+        })
+
       let warnings =
-        list.append(reference_warnings, unmatched_field_bound_warnings)
+        reference_warnings
+        |> list.append(unmatched_field_bound_warnings)
+        |> list.append(unmatched_param_bound_warnings)
 
       #(#(violations, warnings), memo)
     }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2364,6 +2364,11 @@ fn resolve_field_call(
   // girard/type-registry resolution. It's the boundary-scoped counterpart to a
   // `type` line — an escape hatch for a receiver graded can't trace to a
   // construction site. User-declared, so it wins over inferred field effects.
+  //
+  // The bound's effects are returned verbatim — a concrete effect set, no
+  // call-site substitution (unlike the `type`-line path below, which runs
+  // through `resolve_field_effect`). Effect-polymorphic fields belong on a
+  // `type` line.
   let field_target = field_call.object <> "." <> field_call.label
   case list.find(caller_param_bounds, fn(b) { b.name == field_target }) {
     Ok(bound) -> #(bound.effects, memo)

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -132,6 +132,12 @@ pub type EffectTerm {
 // An effect bound on a function-typed parameter. The `effects` is an
 // `EffectTerm`: a flat `Eff` term for a first-order callback (`f: [e]`), or
 // an operator `TAbs` for a higher-order one (`action: fn(cb) -> [cb]`).
+//
+// `name` is the bare parameter name (`f`) for a parameter bound, or a
+// `param.field` path (`handler.on_click`) for a *field bound* — a hand-written
+// declaration of a record field's effect at the function boundary, the
+// boundary-scoped counterpart to a `type` line. A field bound's path carries a
+// dot; a parameter name never can, so the two forms don't collide.
 pub type ParamBound {
   ParamBound(name: String, effects: EffectTerm)
 }

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -337,6 +337,12 @@ pub type Warning {
   // no field call in the function's body — usually a typo in the path. Such a
   // bound resolves nothing and is silently dead, so it's flagged.
   UnmatchedFieldBoundWarning(function: String, field_path: String)
+  // A plain parameter bound (`check f(g: [..])`) whose name matches no declared
+  // parameter of the function — a typo. Matched on parameter *existence*, not
+  // call presence: a callback forwarded but never called directly is still a
+  // real parameter and isn't flagged, since its bound stays load-bearing during
+  // substitution.
+  UnmatchedParamBoundWarning(function: String, param: String)
 }
 
 // Result of checking one file.

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -323,15 +323,20 @@ pub type Violation {
   )
 }
 
-// A warning about a function reference passed as a value whose effects
-// won't be tracked through the callee.
+// A warning surfaced during checking.
 pub type Warning {
+  // A function reference passed as a value whose effects won't be tracked
+  // through the callee.
   UntrackedEffectWarning(
     function: String,
     reference: QualifiedName,
     span: Span,
     effects: EffectSet,
   )
+  // A field bound (`check f(recv.field: [..])`) whose `recv.field` path matched
+  // no field call in the function's body — usually a typo in the path. Such a
+  // bound resolves nothing and is silently dead, so it's flagged.
+  UnmatchedFieldBoundWarning(function: String, field_path: String)
 }
 
 // Result of checking one file.

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -334,9 +334,16 @@ pub type Warning {
     effects: EffectSet,
   )
   // A field bound (`check f(recv.field: [..])`) whose `recv.field` path matched
-  // no field call in the function's body — usually a typo in the path. Such a
-  // bound resolves nothing and is silently dead, so it's flagged.
-  UnmatchedFieldBoundWarning(function: String, field_path: String)
+  // no field call in the function's body. Such a bound resolves nothing and is
+  // silently dead, so it's flagged. `receiver_is_param` distinguishes the cause:
+  // when the receiver is a parameter it can't be traced to a construction site,
+  // so a missing field call is a genuine typo; when it isn't, the field call may
+  // exist but have resolved through value provenance, shadowing the bound.
+  UnmatchedFieldBoundWarning(
+    function: String,
+    field_path: String,
+    receiver_is_param: Bool,
+  )
   // A plain parameter bound (`check f(g: [..])`) whose name matches no declared
   // parameter of the function — a typo. Matched on parameter *existence*, not
   // call presence: a callback forwarded but never called directly is still a

--- a/test/annotation_test.gleam
+++ b/test/annotation_test.gleam
@@ -642,6 +642,33 @@ pub fn roundtrip_multi_param_operator_bound_test() {
   annotation.format_annotation(ann) |> should.equal(line)
 }
 
+// ──── Field bounds (`param.field: [..]`) ────
+
+pub fn parse_field_bound_test() {
+  // A field bound's name is the `param.field` path; it parses like any other
+  // parameter bound, the dot carried verbatim in the name.
+  let assert Ok([ann]) =
+    annotation.parse("check view(handler.on_click: [Dom]) : [Dom]")
+  ann.params
+  |> should.equal([
+    ParamBound("handler.on_click", TLabels(set.from_list(["Dom"]))),
+  ])
+}
+
+pub fn roundtrip_field_bound_test() {
+  let line = "check view(handler.on_click: [Dom]) : [Dom]"
+  let assert Ok([ann]) = annotation.parse(line)
+  annotation.format_annotation(ann) |> should.equal(line)
+}
+
+pub fn roundtrip_mixed_param_and_field_bound_test() {
+  // A `check` line can mix an ordinary parameter bound with a field bound.
+  let line =
+    "check view(log: [Stdout], handler.on_click: [Dom]) : [Dom, Stdout]"
+  let assert Ok([ann]) = annotation.parse(line)
+  annotation.format_annotation(ann) |> should.equal(line)
+}
+
 fn union_vars(first: EffectTerm, second: String) -> EffectTerm {
   effect_term.normalize(TUnion([first, TVar(second)]))
 }

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -18,7 +18,7 @@ import graded/internal/signatures
 import graded/internal/types.{
   type EffectAnnotation, type EffectSet, Check, EffectAnnotation, Effects,
   ParamBound, Polymorphic, QualifiedName, Specific, TypeFieldEffect,
-  UntrackedEffectWarning, Wildcard,
+  UnmatchedFieldBoundWarning, UntrackedEffectWarning, Wildcard,
 }
 import qcheck
 
@@ -832,7 +832,8 @@ pub fn greet_all(names) { list.map(names, io.println) }"
     ])
   warnings |> list.length() |> should.equal(1)
   let assert [warning] = warnings
-  let UntrackedEffectWarning(function:, reference:, effects:, ..) = warning
+  let assert UntrackedEffectWarning(function:, reference:, effects:, ..) =
+    warning
   function |> should.equal("greet_all")
   reference |> should.equal(QualifiedName("gleam/io", "println"))
   effects |> should.equal(Specific(set.from_list(["Stdout"])))
@@ -855,8 +856,61 @@ pub fn greet_all(names) { list.map(names, println) }"
     ])
   warnings |> list.length() |> should.equal(1)
   let assert [warning] = warnings
-  let UntrackedEffectWarning(reference:, ..) = warning
+  let assert UntrackedEffectWarning(reference:, ..) = warning
   reference |> should.equal(QualifiedName("gleam/io", "println"))
+}
+
+// A field bound whose `param.field` path matches no field call in the body is
+// dead (typically a typo) and emits a warning naming the path and function.
+pub fn field_bound_unmatched_warns_test() {
+  let source =
+    "pub type Validator {
+  Validator(to_error: fn(String) -> Nil)
+}
+pub fn caller(v: Validator) -> Nil { v.to_error(\"bad\") }"
+  let warnings =
+    check_warnings(source, [
+      EffectAnnotation(
+        Check,
+        "caller",
+        // Typo: the body calls `v.to_error`, not `v.to_errorx`.
+        [
+          ParamBound(
+            "v.to_errorx",
+            effect_term.from_effect_set(Specific(set.new())),
+          ),
+        ],
+        effect_term.from_effect_set(Specific(set.new())),
+      ),
+    ])
+  warnings |> list.length() |> should.equal(1)
+  let assert [warning] = warnings
+  let assert UnmatchedFieldBoundWarning(function:, field_path:) = warning
+  function |> should.equal("caller")
+  field_path |> should.equal("v.to_errorx")
+}
+
+// A field bound whose path matches a real field call emits no warning.
+pub fn field_bound_matched_no_warning_test() {
+  let source =
+    "pub type Validator {
+  Validator(to_error: fn(String) -> Nil)
+}
+pub fn caller(v: Validator) -> Nil { v.to_error(\"bad\") }"
+  check_warnings(source, [
+    EffectAnnotation(
+      Check,
+      "caller",
+      [
+        ParamBound(
+          "v.to_error",
+          effect_term.from_effect_set(Specific(set.new())),
+        ),
+      ],
+      effect_term.from_effect_set(Specific(set.new())),
+    ),
+  ])
+  |> should.equal([])
 }
 
 // Pure function reference does not emit warning

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -18,7 +18,8 @@ import graded/internal/signatures
 import graded/internal/types.{
   type EffectAnnotation, type EffectSet, Check, EffectAnnotation, Effects,
   ParamBound, Polymorphic, QualifiedName, Specific, TypeFieldEffect,
-  UnmatchedFieldBoundWarning, UntrackedEffectWarning, Wildcard,
+  UnmatchedFieldBoundWarning, UnmatchedParamBoundWarning, UntrackedEffectWarning,
+  Wildcard,
 }
 import qcheck
 
@@ -907,6 +908,43 @@ pub fn caller(v: Validator) -> Nil { v.to_error(\"bad\") }"
           effect_term.from_effect_set(Specific(set.new())),
         ),
       ],
+      effect_term.from_effect_set(Specific(set.new())),
+    ),
+  ])
+  |> should.equal([])
+}
+
+// A plain parameter bound whose name matches no declared parameter is dead
+// (a typo) and emits a warning naming the parameter and function.
+pub fn param_bound_unmatched_warns_test() {
+  let source = "pub fn apply(f, x) { f(x) }"
+  let warnings =
+    check_warnings(source, [
+      EffectAnnotation(
+        Check,
+        "apply",
+        // Typo: the parameter is `f`, not `g`.
+        [ParamBound("g", effect_term.from_effect_set(Specific(set.new())))],
+        effect_term.from_effect_set(Specific(set.new())),
+      ),
+    ])
+  warnings |> list.length() |> should.equal(1)
+  let assert [warning] = warnings
+  let assert UnmatchedParamBoundWarning(function:, param:) = warning
+  function |> should.equal("apply")
+  param |> should.equal("g")
+}
+
+// A parameter bound on a callback that's forwarded but never called directly
+// still names a real parameter, so it stays load-bearing and emits no warning.
+pub fn param_bound_forwarded_no_warning_test() {
+  let source = "pub fn apply(f, x) { helper(f, x) }
+pub fn helper(g, y) { g(y) }"
+  check_warnings(source, [
+    EffectAnnotation(
+      Check,
+      "apply",
+      [ParamBound("f", effect_term.from_effect_set(Specific(set.new())))],
       effect_term.from_effect_set(Specific(set.new())),
     ),
   ])

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -886,9 +886,15 @@ pub fn caller(v: Validator) -> Nil { v.to_error(\"bad\") }"
     ])
   warnings |> list.length() |> should.equal(1)
   let assert [warning] = warnings
-  let assert UnmatchedFieldBoundWarning(function:, field_path:) = warning
+  let assert UnmatchedFieldBoundWarning(
+    function:,
+    field_path:,
+    receiver_is_param:,
+  ) = warning
   function |> should.equal("caller")
   field_path |> should.equal("v.to_errorx")
+  // `v` is a parameter, so the cause is a genuine typo, not provenance shadowing.
+  receiver_is_param |> should.be_true()
 }
 
 // A field bound whose path matches a real field call emits no warning.
@@ -938,7 +944,8 @@ pub fn param_bound_unmatched_warns_test() {
 // A parameter bound on a callback that's forwarded but never called directly
 // still names a real parameter, so it stays load-bearing and emits no warning.
 pub fn param_bound_forwarded_no_warning_test() {
-  let source = "pub fn apply(f, x) { helper(f, x) }
+  let source =
+    "pub fn apply(f, x) { helper(f, x) }
 pub fn helper(g, y) { g(y) }"
   check_warnings(source, [
     EffectAnnotation(
@@ -949,6 +956,48 @@ pub fn helper(g, y) { g(y) }"
     ),
   ])
   |> should.equal([])
+}
+
+// When the field bound's receiver is a local traced to a construction site, the
+// field call resolves through value provenance and never lands in the field
+// list, so the bound is unmatched — but the cause is provenance shadowing, not a
+// typo, and `receiver_is_param` is False to flag that.
+pub fn field_bound_unmatched_non_param_receiver_test() {
+  let source =
+    "import gleam/io
+pub type Validator {
+  Validator(to_error: fn(String) -> Nil)
+}
+pub fn caller() -> Nil {
+  let v = Validator(io.println)
+  v.to_error(\"bad\")
+}"
+  let warnings =
+    check_warnings(source, [
+      EffectAnnotation(
+        Check,
+        "caller",
+        [
+          ParamBound(
+            "v.to_error",
+            effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
+          ),
+        ],
+        effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
+      ),
+    ])
+  // Construction also wires io.println as a value, emitting an untracked-effect
+  // warning; pick out the field-bound one.
+  let assert Ok(warning) =
+    list.find(warnings, fn(w) {
+      case w {
+        UnmatchedFieldBoundWarning(..) -> True
+        _ -> False
+      }
+    })
+  let assert UnmatchedFieldBoundWarning(receiver_is_param:, ..) = warning
+  // `v` is a local, not a parameter, so provenance shadowing is the likely cause.
+  receiver_is_param |> should.be_false()
 }
 
 // Pure function reference does not emit warning

--- a/test/fixtures/field_bound.gleam
+++ b/test/fixtures/field_bound.gleam
@@ -1,0 +1,10 @@
+pub type Validator {
+  Validator(to_error: fn(String) -> Nil)
+}
+
+pub fn caller(v: Validator) -> Nil {
+  // `v` arrives as a parameter, so there's no construction site to trace and no
+  // `type` line for this module's Validator. The field call resolves only via
+  // the hand-written field bound on `caller`'s `check` line in fixtures.graded.
+  v.to_error("bad input")
+}

--- a/test/fixtures/fixtures.graded
+++ b/test/fixtures/fixtures.graded
@@ -11,6 +11,7 @@ check operator_field.run : []
 check factory_field.run : []
 check field_union.run : []
 check ffi_external.run : []
+check field_bound.caller(v.to_error: [Stdout]) : []
 
 // Type field annotations (the effect source for type-directed field calls).
 type opaque_receiver.Validator.to_error : [Stdout]

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -113,6 +113,22 @@ pub fn opaque_receiver_violation_detected_test() {
   v.actual |> should.equal(types.Specific(set.from_list(["Stdout"])))
 }
 
+pub fn field_bound_resolves_untraceable_receiver_test() {
+  // field_bound.caller calls `v.to_error` where `v` arrives as a parameter —
+  // no construction site, no `type` line. The hand-written field bound on the
+  // `check field_bound.caller(v.to_error: [Stdout]) : []` line resolves the
+  // field call to [Stdout], so the [] budget must fail with that precise
+  // effect (not the [Unknown] graded would otherwise fall back to).
+  let assert Ok(results) = graded.run("test/fixtures")
+  let field_bound_result =
+    list.find(results, fn(r) { r.file == "test/fixtures/field_bound.gleam" })
+  let assert Ok(r) = field_bound_result
+  { r.violations != [] } |> should.be_true()
+  let assert [v, ..] = r.violations
+  v.function |> should.equal("caller")
+  v.actual |> should.equal(types.Specific(set.from_list(["Stdout"])))
+}
+
 pub fn closure_field_effect_from_construction_test() {
   // A record field wired to an *inline closure* at construction resolves to the
   // closure body's effect ([Stdout]) without a hand-written `type` annotation —


### PR DESCRIPTION
## What

Adds **field bounds**: a `check` line can bound a function-typed field reached through a parameter, using a `param.field` path.

```
check myapp.view(handler.on_click: [Dom]) : [Dom]
```

A field call `handler.on_click(event)` inside `view` then resolves to `[Dom]` directly, taking priority over receiver-type resolution. This is the boundary-scoped counterpart to a `type` line: the `type` line declares a field's effect for every receiver of that type package-wide; the field bound scopes the assertion to one `check`'d function. It closes the [LIMITATIONS #1](docs/LIMITATIONS.md) case — a record field reached through a receiver graded can't trace to a construction site.

Alongside the feature, two **dead-bound warnings** that catch silent typos in `check`-line bounds:

- A **field bound** whose `param.field` path matches no field call in the body is flagged. When the receiver is a parameter the cause is a typo; when it isn't, the message also notes the call may have resolved through value provenance (a receiver traced to a construction site), which shadows the bound — so the warning doesn't misblame the path.
- A **plain parameter bound** whose name matches no declared parameter is flagged. Matched on parameter *existence*, not call presence: a callback forwarded to another function but never called directly is still a real parameter, so its bound stays load-bearing during substitution and is not flagged.

## How

- **Representation** — `ParamBound.name` carries the `param.field` path. Gleam identifiers can't contain dots, so field bounds and ordinary parameter bounds never collide, and the existing 36 `ParamBound` construction sites are untouched. The codebase already keys field calls as `object <> "." <> label`.
- **Parser/formatter: no changes** — the params section is split at the first `(`, so a dotted param name flows through `parse_single_param`/`format_param_bound` unchanged.
- **One logic change** — a short-circuit at the top of `resolve_field_call` (`checker.gleam`): if a `caller_param_bounds` entry matches `object.label`, return its effects ahead of the girard/type-registry lookup. The existing receiver-type logic moved verbatim into a new `resolve_field_call_by_type`.
- Field bounds ride the existing `param_bounds` list from `check` annotations into `collect_effects` → `resolve_field_call`, so no extra plumbing was needed.
- **Warnings** — both checks live in `check_annotation` over the parsed `check` line. The field-bound warning carries `receiver_is_param`, computed against the function's parameter-name set; the printer branches on it to pick the message. The parameter-bound warning reuses the same parameter-name set. New `Warning` variants `UnmatchedFieldBoundWarning` / `UnmatchedParamBoundWarning` in `types.gleam`.

## Tests

- Integration test (`field_bound.gleam` fixture): a parameter-typed receiver with no construction site and no `type` line resolves to `[Stdout]` only via the field bound. Verified load-bearing — removing the bound makes the call `[Unknown]`.
- Unit tests: parse, round-trip, and mixed parameter+field bound on one `check` line.
- Warning unit tests: field-bound typo warns; matched field bound stays silent; non-parameter (provenance-shadowed) receiver reports `receiver_is_param: False`; parameter-bound typo warns; forwarded-but-uncalled parameter stays silent.
- Full suite green (371 passed).

## Docs

Updated `docs/REFERENCE.md` (new Field bounds section + warning behavior), `docs/LIMITATIONS.md` (#1 escape hatch), `docs/FUTURE_WORK.md` (item shipped), and `CHANGELOG.md`.
