### PR TITLE
Drop stdin dependency to unblock gleam_stdlib 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dropped the `stdin` and `gleam_yielder` dependencies.** `graded format --stdin` now reads standard input through a small built-in Erlang FFI. The `stdin` package capped `gleam_stdlib` below `1.0.0`, which made graded uninstallable alongside packages that require `gleam_stdlib >= 1.0.0`.
+
 ## [0.8.0] - 2026-06-21
 
 ### Added

--- a/gleam.toml
+++ b/gleam.toml
@@ -38,8 +38,6 @@ simplifile = ">= 2.0.0 and < 3.0.0"
 argv = ">= 1.0.0 and < 2.0.0"
 filepath = ">= 1.1.2 and < 2.0.0"
 tom = ">= 2.0.2 and < 3.0.0"
-stdin = ">= 2.0.2 and < 3.0.0"
-gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [dev_dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -24,7 +24,6 @@ packages = [
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
-  { name = "stdin", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "stdin", source = "hex", outer_checksum = "437084939CE094E06D32D07EB19B74473D08895AB817C03550CEDFDBF0DFDC19" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
@@ -34,10 +33,8 @@ filepath = { version = ">= 1.1.2 and < 2.0.0" }
 girard = { version = ">= 1.0.0 and < 2.0.0" }
 glance = { version = ">= 6.0.0 and < 8.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
-gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.11.1 and < 3.0.0" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
-stdin = { version = ">= 2.0.2 and < 3.0.0" }
 tom = { version = ">= 2.0.2 and < 3.0.0" }

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -86,16 +86,14 @@ pub fn main() -> Nil {
           halt(1)
         }
       }
-    ["format", "--stdin", ..] -> {
-      let input = read_stdin()
-      case annotation.parse_file(input) {
-        Ok(file) -> io.print(annotation.format_sorted(file))
+    ["format", "--stdin", ..] ->
+      case run_format_stdin(read_stdin()) {
+        Ok(output) -> io.print(output)
         Error(_) -> {
           io.println_error("graded: error: could not parse stdin")
           halt(1)
         }
       }
-    }
     ["format", "--check", ..rest] ->
       case run_format_check(target_directory(rest)) {
         Ok(Nil) -> Nil
@@ -280,6 +278,16 @@ pub fn run_format(directory: String) -> Result(Nil, GradedError) {
       simplifile.write(cfg.spec_file, formatted)
       |> result.map_error(FileWriteError(cfg.spec_file, _))
   }
+}
+
+/// Format a `.graded` spec given as a string, as `graded format --stdin` does
+/// for editor integration: parse the input, then sort and reformat it. Returns
+/// the input's parse error if it doesn't parse.
+pub fn run_format_stdin(
+  input: String,
+) -> Result(String, annotation.ParseError) {
+  use file <- result.map(annotation.parse_file(input))
+  annotation.format_sorted(file)
 }
 
 /// Check that the project's spec file is already formatted. Returns error

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -33,7 +33,6 @@ import gleam/option.{None, Some}
 import gleam/result
 import gleam/set.{type Set}
 import gleam/string
-import gleam/yielder
 import graded/internal/annotation
 import graded/internal/checker
 import graded/internal/config
@@ -49,7 +48,6 @@ import graded/internal/types.{
   GradedFile, QualifiedName,
 }
 import simplifile
-import stdin
 
 /// Errors that can occur during checking, inference, or formatting.
 pub type GradedError {
@@ -89,7 +87,7 @@ pub fn main() -> Nil {
         }
       }
     ["format", "--stdin", ..] -> {
-      let input = stdin.read_lines() |> yielder.to_list() |> string.join("")
+      let input = read_stdin()
       case annotation.parse_file(input) {
         Ok(file) -> io.print(annotation.format_sorted(file))
         Error(_) -> {
@@ -1222,3 +1220,7 @@ fn print_warning(file: String, warning: Warning) -> Nil {
 
 @external(erlang, "erlang", "halt")
 fn halt(code: Int) -> Nil
+
+// Read all of standard input to EOF as a single string.
+@external(erlang, "graded_ffi", "read_stdin")
+fn read_stdin() -> String

--- a/src/graded_ffi.erl
+++ b/src/graded_ffi.erl
@@ -1,0 +1,13 @@
+-module(graded_ffi).
+-export([read_stdin/0]).
+
+% Read all of standard input to EOF and return it as a single binary.
+read_stdin() ->
+    unicode:characters_to_binary(read_lines(standard_io)).
+
+read_lines(Device) ->
+    case io:get_line(Device, "") of
+        eof -> [];
+        {error, _} -> [];
+        Line -> [Line | read_lines(Device)]
+    end.

--- a/test/format_cli_test.gleam
+++ b/test/format_cli_test.gleam
@@ -39,3 +39,16 @@ pub fn format_fails_on_unparseable_spec_test() {
     simplifile.write(dir <> "/graded_fmt_bad.graded", bad_spec)
   graded.run_format(dir) |> should.be_error
 }
+
+// `graded format --stdin` reads a spec on standard input and prints the
+// formatted result, for editor integration. `run_format_stdin` is the pure
+// transform behind it: parse, sort, reformat.
+
+pub fn format_stdin_sorts_and_normalizes_test() {
+  graded.run_format_stdin("effects myapp.b:[Http]\ncheck  myapp.a : []")
+  |> should.equal(Ok("check myapp.a : []\n\neffects myapp.b : [Http]\n"))
+}
+
+pub fn format_stdin_fails_on_unparseable_input_test() {
+  graded.run_format_stdin(bad_spec) |> should.be_error
+}


### PR DESCRIPTION
## Problem

graded depends on `stdin >= 2.0.2 and < 3.0.0`, and the latest published `stdin` (2.0.2) caps its stdlib dependency:

```toml
gleam_stdlib = ">= 0.50.0 and < 1.0.0"
```

That `< 1.0.0` ceiling transitively pins every project that depends on graded below stdlib 1.0. Modern packages — lustre 5.5, gleam_time, and others — require `gleam_stdlib >= 1.0.0`, so the two constraints have no overlap and Gleam's resolver fails. **As-is, no project on stdlib 1.0 can add graded.** The fix has to live in graded, since `stdin` itself hasn't been updated for stdlib 1.0.

## Change

`stdin` was used in exactly one place — reading standard input for `graded format --stdin`. This replaces it with a small built-in Erlang FFI (`src/graded_ffi.erl`) that reads stdin to EOF. graded targets the BEAM only, so the FFI is safe.

This also drops `gleam_yielder`, which was only pulled in to drain `stdin`'s iterator. (It survives as a transitive dev-dependency of qcheck, which has no stdlib cap.)

After this change, graded's only stdlib constraint is its own `>= 0.44.0 and < 2.0.0`, which happily allows 1.0.

## Verification

- `gleam build` — clean, `stdin` removed from the resolved manifest.
- `gleam test` — all 360 tests pass.
- `printf '...' | gleam run -m graded format --stdin` — reads, parses, and formats correctly (exit 0).