### PR TITLE
fix(checker): bind a labeled higher-order callback argument to its parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added catalog entries for the pure value libraries `bigi`, `glearray`, `iv`, and `gleam_community_maths` — calls into them now resolve to `[]` instead of `[Unknown]`.
 
+### Fixed
+
+- A higher-order callback passed with a Gleam label (`apply(with: parser)`) now binds to its parameter, so the parameter's effect variable resolves instead of leaking into the fully-applied caller. Previously only positional callback arguments were matched; a labelled call site left the variable unresolved (e.g. `[parser]`).
+
 ## [0.9.0] - 2026-06-22
 
 ### Added

--- a/docs/FUTURE_WORK.md
+++ b/docs/FUTURE_WORK.md
@@ -11,8 +11,8 @@ items push into different territory.
 graded reads expression types from [girard](https://hexdocs.pm/girard), which
 already resolves field calls without explicit parameter annotations and detects
 fn-typed parameters. The one piece not taken: replacing the positional/label
-argument-matching heuristics (`find_matching_arg` / `position_from_registry` in
-`signatures.gleam` and `checker.gleam`). They drive polymorphic call-site
+argument-matching heuristics (`find_matching_arg` / `param_info` in
+`checker.gleam`). They drive polymorphic call-site
 substitution — a subsystem girard's expression types don't cleanly map onto — so
 they were kept deliberately. Revisit only if a concrete imprecision surfaces.
 

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2124,18 +2124,22 @@ fn find_matching_arg(
   args: List(types.CallArgument),
   registry: SignatureRegistry,
 ) -> option.Option(types.CallArgument) {
-  // Try two strategies in order:
-  //   1. Label match (caller used an explicit argument label)
-  //   2. Registry-backed position (authoritative when available)
-  // We deliberately do not fall back to the bound's index in the
-  // bounds list — that's only correct when every parameter has a
-  // bound, and silently picks the wrong argument when bounds are
-  // sparse. If the registry has no entry, the variable stays
-  // unresolved and surfaces as part of the result.
-  let by_label = find_arg_by_label(args, bound.name)
-  use <- option.lazy_or(by_label)
-  position_from_registry(callee_name, bound.name, registry)
-  |> option.then(fn(pos) { find_arg_at_position(args, pos) })
+  // Match the argument bound to this parameter, in order:
+  //   1. An argument the caller labelled with the bound's own name.
+  //   2. The callee's signature: an argument carrying the parameter's
+  //      declared Gleam label (a labelled call site, `f(with: cb)`), or the
+  //      argument at the parameter's real position (a positional call site).
+  // We deliberately do not fall back to the bound's index in the bounds
+  // list — that's only correct when every parameter has a bound, and
+  // silently picks the wrong argument when bounds are sparse. If the
+  // registry has no entry, the variable stays unresolved and surfaces as
+  // part of the result.
+  let by_bound_name = find_arg_by_label(args, bound.name)
+  use <- option.lazy_or(by_bound_name)
+  use param <- option.then(param_info(callee_name, bound.name, registry))
+  let by_param_label = param.label |> option.then(find_arg_by_label(args, _))
+  use <- option.lazy_or(by_param_label)
+  find_arg_at_position(args, param.position)
 }
 
 fn find_arg_by_label(
@@ -2154,32 +2158,23 @@ fn find_arg_at_position(
   |> option.from_result
 }
 
-// Look up the real parameter position of a named parameter in the
-// callee's signature. Returns `None` when the callee is not in the
-// registry or the parameter name doesn't match any labeled parameter.
-fn position_from_registry(
+// Look up the parameter in the callee's signature matching the bound's name.
+// Tries the in-body parameter name first (auto-inferred bounds key off the
+// name, not the Gleam argument label), then falls back to label matching for
+// JSON-sourced signatures where in-body names aren't available. Returns `None`
+// when the callee is not in the registry or nothing matches.
+fn param_info(
   callee_name: types.QualifiedName,
   param_name: String,
   registry: SignatureRegistry,
-) -> option.Option(Int) {
-  // Try in-body parameter name first (auto-inferred bounds key off
-  // the name, not the Gleam argument label). Fall back to label
-  // matching for JSON-sourced signatures where name info isn't
-  // available.
+) -> option.Option(signatures.ParameterInfo) {
   use params <- option.then(signatures.lookup(registry, callee_name))
-  let by_name =
-    find_param_position(params, fn(p) { p.name == Some(param_name) })
-  use <- option.lazy_or(by_name)
-  find_param_position(params, fn(p) { p.label == Some(param_name) })
-}
-
-fn find_param_position(
-  params: List(signatures.ParameterInfo),
-  predicate: fn(signatures.ParameterInfo) -> Bool,
-) -> option.Option(Int) {
-  list.find(params, predicate)
-  |> result.map(fn(p) { p.position })
-  |> option.from_result
+  case list.find(params, fn(p) { p.name == Some(param_name) }) {
+    Ok(param) -> option.Some(param)
+    Error(Nil) ->
+      list.find(params, fn(p) { p.label == Some(param_name) })
+      |> option.from_result
+  }
 }
 
 // Look up the effects of an argument value. Function references →

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2115,9 +2115,10 @@ fn ordered_fn_typed_param_names(function: Function) -> List(String) {
   })
 }
 
-// Find the argument that matches a given param bound. Prefers label
-// match; falls back to positional match using the bound's index in
-// the bound list (which mirrors the parameter order).
+// Find the argument that matches a given param bound, via the bound's
+// own label, then the callee signature's declared label, then the
+// parameter's real position. See the body for why the bound's index in
+// the bound list is deliberately not used as a fallback.
 fn find_matching_arg(
   callee_name: types.QualifiedName,
   bound: ParamBound,
@@ -2169,12 +2170,12 @@ fn param_info(
   registry: SignatureRegistry,
 ) -> option.Option(signatures.ParameterInfo) {
   use params <- option.then(signatures.lookup(registry, callee_name))
-  case list.find(params, fn(p) { p.name == Some(param_name) }) {
-    Ok(param) -> option.Some(param)
-    Error(Nil) ->
-      list.find(params, fn(p) { p.label == Some(param_name) })
-      |> option.from_result
-  }
+  let by_name =
+    list.find(params, fn(p) { p.name == Some(param_name) })
+    |> option.from_result
+  use <- option.lazy_or(by_name)
+  list.find(params, fn(p) { p.label == Some(param_name) })
+  |> option.from_result
 }
 
 // Look up the effects of an argument value. Function references →

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -88,7 +88,7 @@ pub fn lookup(
 // Names of a function's fn-typed parameters. Returns an empty set if
 // the function isn't in the registry (conservative: "we don't know").
 // Prefers the argument label (canonical for cross-module calls), falling
-// back to the in-body name when no label is declared. `position_from_registry`
+// back to the in-body name when no label is declared. `param_info`
 // matches by either, so both forms round-trip.
 pub fn fn_typed_param_names(
   registry: SignatureRegistry,

--- a/test/fixtures/fixtures.graded
+++ b/test/fixtures/fixtures.graded
@@ -13,6 +13,7 @@ check field_union.run : []
 check ffi_external.run : []
 check field_bound.caller(v.to_error: [Stdout]) : []
 check named_fn_arg.run : []
+check labeled_callback.run : []
 check shadow_param.run(handler: []) : []
 
 // Type field annotations (the effect source for type-directed field calls).

--- a/test/fixtures/labeled_callback.gleam
+++ b/test/fixtures/labeled_callback.gleam
@@ -1,0 +1,18 @@
+import gleam/io
+
+// A first-order higher-order helper whose callback carries a Gleam label
+// (`with`). The label at the call site, not the definition, is what used to
+// block argument-to-parameter matching.
+pub fn apply_labeled(input: String, with parser: fn(String) -> Int) -> Int {
+  parser(input)
+}
+
+// An effectful same-module named function, passed with the `with:` label.
+fn logging_parser(s: String) -> Int {
+  io.println(s)
+  1
+}
+
+pub fn run() -> Int {
+  apply_labeled("x", with: logging_parser)
+}

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -202,6 +202,20 @@ pub fn named_fn_arg_resolves_test() {
   v.actual |> should.equal(types.Specific(set.from_list(["Stdout"])))
 }
 
+pub fn labeled_callback_resolves_test() {
+  // labeled_callback.run passes an effectful callback (logging_parser :
+  // [Stdout]) with a Gleam label (`with:`). Argument-to-parameter matching now
+  // binds the labelled argument, so the parameter's effect variable discharges
+  // to [Stdout] instead of leaking unresolved into the fully-applied caller.
+  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(r) =
+    list.find(results, fn(r) {
+      r.file == "test/fixtures/labeled_callback.gleam"
+    })
+  let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
+  v.actual |> should.equal(types.Specific(set.from_list(["Stdout"])))
+}
+
 pub fn shadowed_param_resolves_through_bound_test() {
   // shadow_param.run takes a fn-typed parameter `handler` that shadows a
   // same-module function of the same name (handler : [Stdout]). The forwarded


### PR DESCRIPTION
## Problem

Follow-up to Issue 1 (HOF parameter-variable leak). The original positional repro resolves correctly on 0.9.0, but the real codebase uses **labeled** callback arguments (`apply(with: parser)`), and those still leak: the parameter's effect variable survives unresolved into every fully-applied caller (e.g. `[parser]`).

The reporter isolated it precisely — the trigger is the label **at the call site**, not the definition:

| Caller | Call shape | Before | After |
|---|---|---|---|
| `call_positional_inline` | `po(x, fn(s){…})` | `[]` | `[]` |
| `call_positional_named` | `po(x, int.parse)` | `[]` | `[]` |
| `call_labeleddef_positionalcall` | `po_labeled(x, fn(s){…})` (label omitted) | `[]` | `[]` |
| `call_labeled_inline` | `po_labeled(x, with: fn(s){…})` | **`[parser]`** | `[]` |
| `call_labeled_named` | `po_labeled(x, with: int.parse)` | **`[parser]`** | `[]` |

Because `with:`/`using:`-style labels are idiomatic Gleam, this is what produced the original "~46 functions with `[parser]`" count.

## Root cause

`find_matching_arg` matched a call argument to a callee parameter two ways, and both miss a labeled argument:

1. `find_arg_by_label(args, bound.name)` matched the argument label against the **in-body parameter name** (`parser`) — but a Gleam label uses the **label** (`with`), so it never matched.
2. `find_arg_at_position` explicitly required `label == None`, skipping labeled arguments.

No match → the parameter's effect variable was never discharged to the actual argument.

## Fix

Resolve the parameter from the signature registry, then match the argument by its **declared Gleam label** (labeled call site) or its **real position** (positional call site). This collapses the old `position_from_registry` / `find_param_position` pair into a single `param_info` helper.

The change is at the matching layer, so it covers labeled callbacks uniformly (inline or named) rather than special-casing the call shape.

## Tests

- New fixture `labeled_callback.gleam` + `labeled_callback_resolves_test`: an effectful `with:` callback now resolves to the precise `[Stdout]`. Confirmed it **fails without the fix** (the variable leaks) and passes with it.
- Parametric HOF signatures (`po_labeled`, `po_positional`) still correctly keep `[parser]`.
- Full suite: **374 passed, no failures.**

Closes the follow-up to Issue 1.