### PR TITLE
fix(extract): count effects in record update field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Record update expressions (`Rec(..base, field: expr)`) now have their updated field values walked, so effects in those expressions are counted. Previously only the base record was extracted, under-approximating the effect set and letting a `check ... : []` pass over a record update whose field called an effectful function.
+
 ## [0.9.1] - 2026-06-23
 
 ### Added

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -1199,9 +1199,16 @@ fn extract_from_expression(
     glance.NegateBool(value:, ..) ->
       extract_from_expression(value, context, env)
 
-    // Record update
-    glance.RecordUpdate(record:, ..) ->
-      extract_from_expression(record, context, env)
+    // Record update: walk the base record and every updated field value
+    // (a field item is absent only for shorthand `Rec(..base, field:)`).
+    glance.RecordUpdate(record:, fields:, ..) ->
+      list.fold(
+        fields,
+        extract_from_expression(record, context, env),
+        fn(accumulated, field) {
+          merge_optional(accumulated, field.item, context, env)
+        },
+      )
 
     // Function reference: qualified name used as a value (not called).
     glance.FieldAccess(

--- a/test/fixtures/fixtures.graded
+++ b/test/fixtures/fixtures.graded
@@ -14,6 +14,7 @@ check ffi_external.run : []
 check field_bound.caller(v.to_error: [Stdout]) : []
 check named_fn_arg.run : []
 check labeled_callback.run : []
+check record_update.run : []
 check shadow_param.run(handler: []) : []
 
 // Type field annotations (the effect source for type-directed field calls).

--- a/test/fixtures/record_update.gleam
+++ b/test/fixtures/record_update.gleam
@@ -1,0 +1,18 @@
+import gleam/io
+
+pub type Config {
+  Config(name: String, count: Int)
+}
+
+// An effectful same-module helper used as a record-update field value.
+fn shout(s: String) -> String {
+  io.println(s)
+  s
+}
+
+// Updates a field with an effectful expression. The call in the field value
+// (`shout : [Stdout]`) sits inside a record update, so it is only seen if the
+// extractor walks the updated fields, not just the base record.
+pub fn run(base: Config) -> Config {
+  Config(..base, name: shout("x"))
+}

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -216,6 +216,19 @@ pub fn labeled_callback_resolves_test() {
   v.actual |> should.equal(types.Specific(set.from_list(["Stdout"])))
 }
 
+pub fn record_update_field_walked_test() {
+  // record_update.run updates a field with an effectful expression (shout :
+  // [Stdout]). The call sits inside a record update, so its effect surfaces
+  // only if the extractor walks the updated field values, not just the base
+  // record. Without that, the [Stdout] is silently dropped and `run` wrongly
+  // resolves to [].
+  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == "test/fixtures/record_update.gleam" })
+  let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
+  v.actual |> should.equal(types.Specific(set.from_list(["Stdout"])))
+}
+
 pub fn shadowed_param_resolves_through_bound_test() {
   // shadow_param.run takes a fn-typed parameter `handler` that shadows a
   // same-module function of the same name (handler : [Stdout]). The forwarded


### PR DESCRIPTION
## Problem

The extractor walked only the **base record** of a record update, dropping any effects in the **updated field values**:

```gleam
Config(..base, name: shout("x"))   // shout : [Stdout]
```

The call in the `name:` field value was never seen, so the function's effect set was under-approximated. Because the checker compares by subset inclusion, this is a **soundness false-negative**: a `check ... : []` could pass over a record update whose field calls an effectful function.

## Root cause

In `extract_from_expression` (`src/graded/internal/extract.gleam`), the `RecordUpdate` arm matched only `record:` and recursed into the base:

```gleam
glance.RecordUpdate(record:, ..) ->
  extract_from_expression(record, context, env)
```

The `fields` list — each carrying an updated field value — was discarded. The constructor-provenance walker (`ctor_in_expression`) already folded over `fields`, so the two extraction paths disagreed.

## Fix

Fold every updated field value into the base record's result via the existing `merge_optional` helper, which also handles the shorthand `Rec(..base, field:)` form where the value is absent. This brings the normal extractor in line with the provenance walker.

## Tests

- New fixture `record_update.gleam` + `record_update_field_walked_test`: an effectful field value (`shout : [Stdout]`) now surfaces as `[Stdout]`. Confirmed it **fails without the fix** (no violation recorded — the effect is dropped) and passes with it.
- Full suite: **375 passed, no failures.**