### PR TITLE
fix(graded): resolve dependency roots from the project, not the cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Record update expressions (`Rec(..base, field: expr)`) now have their updated field values walked, so effects in those expressions are counted. Previously only the base record was extracted, under-approximating the effect set and letting a `check ... : []` pass over a record update whose field called an effectful function.
+- Dependency, catalog, and path-dependency resolution now read from the checked project's own root (`build/packages`, `manifest.toml`, and the path-dep `gleam.toml`), found by walking up from the source directory to the nearest `gleam.toml`. Previously these paths were resolved relative to the process working directory, so checking a project from a different directory loaded the wrong dependency specs, installed versions, or path dependencies.
 
 ## [0.9.1] - 2026-06-23
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -929,10 +929,7 @@ fn check_one_file(
 // Resolved paths are returned in the same `GradedConfig` shape so callers
 // can use them as-is for I/O without further joining.
 fn read_config(directory: String) -> Result(config.GradedConfig, GradedError) {
-  let project_root = case directory {
-    "src" -> "."
-    _ -> directory
-  }
+  let project_root = source_root_for(directory)
   let toml_path = filepath.join(project_root, "gleam.toml")
   use raw <- result.try(case config.read(toml_path) {
     Ok(cfg) -> Ok(cfg)
@@ -956,11 +953,19 @@ fn read_config(directory: String) -> Result(config.GradedConfig, GradedError) {
 // process cwd's. Falls back to the source directory when no `gleam.toml` is
 // found anywhere up the tree.
 fn resolve_package_root(directory: String) -> String {
-  let source_root = case directory {
+  let source_root = source_root_for(directory)
+  find_gleam_toml_dir(source_root, source_root)
+}
+
+// The directory a source argument is rooted at. `src` is the production layout,
+// whose root is the current directory; any other directory acts as its own
+// root. Shared by spec/cache resolution (`read_config`) and the dependency-root
+// walk-up so the two stay in step.
+fn source_root_for(directory: String) -> String {
+  case directory {
     "src" -> "."
     _ -> directory
   }
-  find_gleam_toml_dir(source_root, source_root, 64)
 }
 
 // Dependency `.graded` specs live under `<root>/build/packages/<dep>/`.
@@ -974,7 +979,7 @@ fn manifest_path(package_root: String) -> String {
   filepath.join(package_root, "manifest.toml")
 }
 
-fn find_gleam_toml_dir(dir: String, original: String, fuel: Int) -> String {
+fn find_gleam_toml_dir(dir: String, original: String) -> String {
   let dir = case dir {
     "" -> "."
     _ -> dir
@@ -986,9 +991,12 @@ fn find_gleam_toml_dir(dir: String, original: String, fuel: Int) -> String {
         "" -> "."
         other -> other
       }
-      case fuel <= 0 || parent == dir {
+      // `.` (and `/`) is a fixed point of `directory_name`, so `parent == dir`
+      // always halts the walk — at which point no `gleam.toml` was found and we
+      // fall back to the source dir.
+      case parent == dir {
         True -> original
-        False -> find_gleam_toml_dir(parent, original, fuel - 1)
+        False -> find_gleam_toml_dir(parent, original)
       }
     }
   }

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -1053,8 +1053,9 @@ fn enrich_with_path_deps(
     effects.parse_path_dependencies(filepath.join(package_root, "gleam.toml"))
   list.fold(path_deps, knowledge_base, fn(kb, dep) {
     let #(name, dep_path) = dep
-    // Path dependency locations are declared relative to the project root.
-    let resolved_dep_path = filepath.join(package_root, dep_path)
+    // Path dependency locations are declared relative to the project root,
+    // except an absolute `path`, which `resolve_path` leaves untouched.
+    let resolved_dep_path = resolve_path(package_root, dep_path)
     let spec_path = config.spec_file_for(resolved_dep_path, name)
     case simplifile.is_file(spec_path) {
       Ok(True) ->

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -124,20 +124,25 @@ pub fn main() -> Nil {
 /// file.
 pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
   use cfg <- result.try(read_config(directory))
+  let package_root = resolve_package_root(directory)
   let spec = read_spec(cfg.spec_file)
   let checks_by_module = checks_grouped_by_module(spec)
 
   use gleam_files <- result.try(find_gleam_files(directory))
   use parsed <- result.try(parse_all_files(gleam_files))
   let index = build_module_index(parsed, directory)
-  let dep_registry = signatures.load_from_packages_dir("build/packages")
+  let dep_registry =
+    signatures.load_from_packages_dir(packages_dir(package_root))
   let registry = signatures.merge(dep_registry, build_project_registry(index))
   let type_info = build_type_index(index)
 
   // Hand-written `type` lines (last) win over the inferred construction index.
   let kb_base =
-    effects.load_knowledge_base("build/packages")
-    |> enrich_with_path_deps()
+    effects.load_knowledge_base(
+      packages_dir(package_root),
+      manifest_path(package_root),
+    )
+    |> enrich_with_path_deps(package_root)
     |> effects.with_inferred(effects.load_spec_effects_from_file(spec))
     |> effects.with_inferred_returned_operators(
       effects.load_spec_returns_from_file(spec),
@@ -195,6 +200,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
 /// resolves transitive chains of any depth.
 pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
   use cfg <- result.try(read_config(directory))
+  let package_root = resolve_package_root(directory)
   let spec = read_spec(cfg.spec_file)
 
   use gleam_files <- result.try(find_gleam_files(directory))
@@ -202,8 +208,11 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
   let index = build_module_index(parsed, directory)
 
   let kb_base =
-    effects.load_knowledge_base("build/packages")
-    |> enrich_with_path_deps()
+    effects.load_knowledge_base(
+      packages_dir(package_root),
+      manifest_path(package_root),
+    )
+    |> enrich_with_path_deps(package_root)
     |> effects.with_externals(annotation.extract_externals(spec))
   // Resolve constructor-field values against the same view `run` uses — catalog
   // + externals + the spec's *existing* inferred effects — so `infer` and
@@ -233,7 +242,8 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
   // Build a signature registry covering every project module so the
   // checker can do positional argument matching for cross-module
   // polymorphic calls.
-  let dep_registry = signatures.load_from_packages_dir("build/packages")
+  let dep_registry =
+    signatures.load_from_packages_dir(packages_dir(package_root))
   let registry = signatures.merge(dep_registry, build_project_registry(index))
   let type_info = build_type_index(index)
 
@@ -938,6 +948,52 @@ fn read_config(directory: String) -> Result(config.GradedConfig, GradedError) {
   ))
 }
 
+// The Gleam project root: where dependency state lives — `build/packages`,
+// `manifest.toml`, and the `gleam.toml` that lists path dependencies. Found by
+// walking up from the source directory to the nearest ancestor holding a
+// `gleam.toml`, so a source directory nested inside a project (e.g. a test
+// fixture tree) inherits that project's installed dependencies rather than the
+// process cwd's. Falls back to the source directory when no `gleam.toml` is
+// found anywhere up the tree.
+fn resolve_package_root(directory: String) -> String {
+  let source_root = case directory {
+    "src" -> "."
+    _ -> directory
+  }
+  find_gleam_toml_dir(source_root, source_root, 64)
+}
+
+// Dependency `.graded` specs live under `<root>/build/packages/<dep>/`.
+fn packages_dir(package_root: String) -> String {
+  filepath.join(package_root, "build/packages")
+}
+
+// `manifest.toml` (installed dependency versions, for catalog selection) sits
+// at the project root next to `gleam.toml`.
+fn manifest_path(package_root: String) -> String {
+  filepath.join(package_root, "manifest.toml")
+}
+
+fn find_gleam_toml_dir(dir: String, original: String, fuel: Int) -> String {
+  let dir = case dir {
+    "" -> "."
+    _ -> dir
+  }
+  case simplifile.is_file(filepath.join(dir, "gleam.toml")) {
+    Ok(True) -> dir
+    _ -> {
+      let parent = case filepath.directory_name(dir) {
+        "" -> "."
+        other -> other
+      }
+      case fuel <= 0 || parent == dir {
+        True -> original
+        False -> find_gleam_toml_dir(parent, original, fuel - 1)
+      }
+    }
+  }
+}
+
 // Join a path against a root, but leave it untouched if it's already
 // absolute (starts with `/`) or if the root is `.` (so production paths
 // stay short and unprefixed).
@@ -981,16 +1037,22 @@ fn read_spec(spec_path: String) -> GradedFile {
 //    `infer_path_dep` so path deps without graded set up still work.
 //    Cross-path-dep imports are not currently merged into a single graph
 //    — each dep is processed sequentially.
-fn enrich_with_path_deps(knowledge_base: KnowledgeBase) -> KnowledgeBase {
-  let path_deps = effects.parse_path_dependencies("gleam.toml")
+fn enrich_with_path_deps(
+  knowledge_base: KnowledgeBase,
+  package_root: String,
+) -> KnowledgeBase {
+  let path_deps =
+    effects.parse_path_dependencies(filepath.join(package_root, "gleam.toml"))
   list.fold(path_deps, knowledge_base, fn(kb, dep) {
     let #(name, dep_path) = dep
-    let spec_path = config.spec_file_for(dep_path, name)
+    // Path dependency locations are declared relative to the project root.
+    let resolved_dep_path = filepath.join(package_root, dep_path)
+    let spec_path = config.spec_file_for(resolved_dep_path, name)
     case simplifile.is_file(spec_path) {
       Ok(True) ->
         effects.with_inferred(kb, effects.load_spec_effects(spec_path))
       _ ->
-        case infer_path_dep(dep_path, kb) {
+        case infer_path_dep(resolved_dep_path, kb) {
           Error(Nil) -> kb
           Ok(inferred) -> effects.with_inferred(kb, inferred)
         }

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -49,14 +49,18 @@ pub type KnowledgeBase {
   )
 }
 
-// Build a knowledge base by scanning dependency .graded files
-// and loading versioned catalog files from priv/catalog/.
-pub fn load_knowledge_base(packages_directory: String) -> KnowledgeBase {
+// Build a knowledge base by scanning dependency .graded files under
+// `packages_directory` and loading versioned catalog files from priv/catalog/,
+// selecting versions from the manifest at `manifest_path`.
+pub fn load_knowledge_base(
+  packages_directory: String,
+  manifest_path: String,
+) -> KnowledgeBase {
   let #(dep_effects, dep_params, dep_returns) =
     load_dependencies(packages_directory)
   let catalog_dir = find_catalog_directory()
   let #(cat_effects, cat_pure, cat_params) =
-    load_catalog(catalog_dir, "manifest.toml")
+    load_catalog(catalog_dir, manifest_path)
   KnowledgeBase(
     // Dependency entries win on a clash: dict.merge keeps its second argument.
     all_effects: dict.merge(cat_effects, dep_effects),

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -272,3 +272,39 @@ pub fn infer_then_check_round_trip_test() {
   // Restore the captured fixture so subsequent test runs start clean.
   let assert Ok(Nil) = simplifile.write(spec_path, original)
 }
+
+pub fn run_resolves_deps_from_target_dir_test() {
+  // graded.run is handed a project directory that is NOT the process cwd (which
+  // stays at the repository root under `gleam test`). Dependency specs must be
+  // read from THAT directory's `build/packages`, not the repo's. We build a
+  // throwaway project under the gitignored `build/` whose own `build/packages`
+  // declares `dep.fetch : [Http]`; `run` calls it, so the `[]` budget must fail
+  // with the precise [Http]. When dependency loading is cwd-relative, the repo
+  // has no such dep and the call leaks as [Unknown] instead.
+  let root = "build/cwd_dep_fixture"
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) =
+    simplifile.create_directory_all(root <> "/build/packages/dep")
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/gleam.toml", "name = \"proj\"\n")
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/proj.graded", "check proj.run : []\n")
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/proj.gleam",
+      "import dep\n\npub fn run() -> Nil {\n  dep.fetch()\n}\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/build/packages/dep/dep.graded",
+      "effects dep.fetch : [Http]\n",
+    )
+
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/proj.gleam" })
+  let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
+  v.actual |> should.equal(types.Specific(set.from_list(["Http"])))
+
+  let assert Ok(Nil) = simplifile.delete(root)
+}

--- a/test/topo_test.gleam
+++ b/test/topo_test.gleam
@@ -28,7 +28,22 @@ import simplifile
 // ----- helpers -----
 
 fn make_fixture(name: String, files: List(#(String, String))) -> String {
-  write_fixture("/tmp/graded_topo_" <> name, files)
+  write_fixture("/tmp/graded_topo_" <> name, [stdlib_manifest(), ..files])
+}
+
+// A minimal `manifest.toml` so a fixture project selects the bundled catalog
+// (which marks `gleam/io.println : [Stdout]`, `gleam/string` pure, …) the same
+// way a real installed project would. Dependency resolution now reads the
+// project's own root, so a fixture without this would see an empty catalog. A
+// fixture can override it by listing its own `manifest.toml` entry.
+fn stdlib_manifest() -> #(String, String) {
+  #(
+    "manifest.toml",
+    "packages = [
+  { name = \"gleam_stdlib\", version = \"0.71.0\" },
+]
+",
+  )
 }
 
 // Materialise a tree of files at `directory`, replacing any prior contents.
@@ -663,8 +678,9 @@ pub fn run(value: String) -> Nil {
 
   // load_knowledge_base from a missing dir falls back to the bundled
   // catalog (which has io.println marked [Stdout]) without any project
-  // externals layered on.
-  let base_kb = effects.load_knowledge_base("nonexistent_packages_dir")
+  // externals layered on. The manifest selects catalog versions.
+  let base_kb =
+    effects.load_knowledge_base("nonexistent_packages_dir", "manifest.toml")
 
   let assert Ok(inferred) = graded.infer_path_dep(dep_path, base_kb)
 

--- a/test/topo_test.gleam
+++ b/test/topo_test.gleam
@@ -699,6 +699,48 @@ pub fn run(value: String) -> Nil {
   Nil
 }
 
+// A path dependency declared with an ABSOLUTE `path` must resolve against that
+// path as-is, not be re-rooted under the project directory. Exercises the
+// gleam.toml-driven `enrich_with_path_deps` resolution end-to-end (unlike the
+// chain test above, which calls `infer_path_dep` directly). The dep ships a
+// spec marking `dep.shout : [Stdout]`; the app calls it, so the [] budget must
+// fail with [Stdout] — a clobbered absolute path would not find the spec and
+// the call would leak [Unknown].
+pub fn run_resolves_absolute_path_dependency_test() {
+  let dep_dir =
+    write_fixture("/tmp/graded_pathdep_abs_dep", [
+      #("gleam.toml", "name = \"dep\"\n"),
+      #("dep.graded", "effects dep.shout : [Stdout]\n"),
+      #(
+        "src/dep.gleam",
+        "import gleam/io\n\npub fn shout() -> Nil {\n  io.println(\"x\")\n}\n",
+      ),
+    ])
+  let app_dir =
+    write_fixture("/tmp/graded_pathdep_abs_app", [
+      #(
+        "gleam.toml",
+        "name = \"app\"\n\n[dependencies]\ndep = { path = \""
+          <> dep_dir
+          <> "\" }\n",
+      ),
+      #("app.graded", "check src/main.run : []\n"),
+      #(
+        "src/main.gleam",
+        "import dep\n\npub fn run() -> Nil {\n  dep.shout()\n}\n",
+      ),
+    ])
+
+  let assert Ok(results) = graded.run(app_dir)
+  let assert Ok(r) =
+    list.find(results, fn(r) { string.ends_with(r.file, "src/main.gleam") })
+  let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
+  v.actual |> should.equal(Specific(set.from_list(["Stdout"])))
+
+  cleanup(dep_dir)
+  cleanup(app_dir)
+}
+
 // ----- polymorphic end-to-end -----
 
 // Caller passes a pure type constructor to a fn-typed parameter.


### PR DESCRIPTION
## Problem

`graded.run`/`run_infer` thread the target `directory` into spec/cache resolution, but **dependency resolution was hardcoded relative to the process working directory**:

- `build/packages` — dependency `.graded` specs (knowledge base + signature registry)
- `manifest.toml` — installed versions, used to select catalog file versions
- `gleam.toml` — path-dependency discovery

Checking a project from a different directory therefore loaded the wrong dependency specs, wrong installed versions, or ignored that project's path dependencies. It only worked in practice because the cwd happened to be the project root in normal use.

This is finding #2 from the project review (after #20 record-update and #21/#22 labeled-callback).

## Fix

Resolve a **project root** by walking up from the source directory to the nearest ancestor holding a `gleam.toml`, and thread it through all three loaders.

Crucially, the **spec/cache stay relative to the passed `directory`** while the **dependency root is the walked-up project root** — these can legitimately differ. A source tree nested inside a project (e.g. a test-fixture tree with no `gleam.toml` of its own) inherits that project's installed dependencies, while a self-contained project resolves against itself.

| Invocation | dependency root | result |
|---|---|---|
| `run("src")` (production) | `.` | unchanged |
| `run("test/fixtures")` | walks up → repo root | inherits repo deps |
| `run("/path/to/otherproject")` | that project | **fixed** |

`load_knowledge_base` now takes an explicit manifest path rather than hardcoding `"manifest.toml"`.

## Tests

- New `run_resolves_deps_from_target_dir_test`: builds a throwaway project under `build/` whose own `build/packages` declares `dep.fetch : [Http]`, and asserts `run` resolves the call to `[Http]`. Confirmed it **fails without the fix** (the call leaks as `[Unknown]` because deps were read from the repo's cwd) and passes with it.
- The `topo_test` end-to-end fixtures gain a `manifest.toml` (via the shared `make_fixture` helper) so they select the bundled catalog the way a real installed project does, instead of borrowing the repo's manifest through the cwd. Verified no test asserts `[Unknown]` for a catalog call, so restoring catalog resolution only sharpens results.
- Full suite: **376 passed, no failures.**