### PR TITLE
feat(graded): support the JavaScript target

### DIFF
--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -1424,8 +1424,10 @@ fn print_warning(file: String, warning: Warning) -> Nil {
 }
 
 @external(erlang, "erlang", "halt")
+@external(javascript, "./graded_ffi.mjs", "halt")
 fn halt(code: Int) -> Nil
 
 // Read all of standard input to EOF as a single string.
 @external(erlang, "graded_ffi", "read_stdin")
+@external(javascript, "./graded_ffi.mjs", "read_stdin")
 fn read_stdin() -> String

--- a/src/graded_ffi.mjs
+++ b/src/graded_ffi.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+// Read all of standard input to EOF and return it as a single string.
+export function read_stdin() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch (error) {
+    // EOF on an empty / closed stdin reads as no input.
+    if (error.code === "EOF" || error.code === "EAGAIN") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+export function halt(code) {
+  process.exit(code);
+  return undefined;
+}

--- a/test/fixtures/ffi_external.gleam
+++ b/test/fixtures/ffi_external.gleam
@@ -2,15 +2,23 @@
 // its effect is the conservative `[Unknown]`, not `[]`. This holds whether or not
 // the external carries a Gleam fallback body — the foreign implementation may
 // differ from the fallback. The caller `run` inherits `[Unknown]` either way.
+//
+// graded reads this file as text, so the Erlang-only externals exercise the
+// opaque-FFI path on either compilation target. The `@target(erlang)` gate keeps
+// the module out of the JavaScript build, where the bodyless external has no
+// implementation.
+@target(erlang)
 @external(erlang, "some_ffi_module", "do_native_io")
 pub fn ffi_op() -> Nil
 
 // `@external` WITH a pure-looking Gleam fallback body — still opaque.
+@target(erlang)
 @external(erlang, "some_ffi_module", "do_more")
 pub fn ffi_with_body() -> Nil {
   Nil
 }
 
+@target(erlang)
 pub fn run() -> Nil {
   ffi_op()
   ffi_with_body()


### PR DESCRIPTION
## Summary

graded now compiles and runs on the **JavaScript/Node** backend in addition to Erlang/BEAM, from the same source. The checker/inference core was already pure, target-agnostic Gleam, and every dependency (`simplifile`, `argv`, `filepath`, `tom`, `glance`, `girard`) already ships JavaScript support — the only Erlang-specific code was two FFI touchpoints.

## Changes

- **`src/graded_ffi.mjs`** (new) — JavaScript counterpart to `graded_ffi.erl`: `read_stdin()` reads stdin to EOF via `fs.readFileSync(0)`; `halt(code)` calls `process.exit`.
- **`src/graded.gleam`** — `halt` and `read_stdin` gain `@external(javascript, "./graded_ffi.mjs", ...)` declarations alongside their existing Erlang externals, so each compiles on both targets.
- **`test/fixtures/ffi_external.gleam`** — gated the deliberately Erlang-only FFI fixture with `@target(erlang)`. graded reads this file *as text*, so the gate only excludes it from the JavaScript compilation; the file stays on disk and the integration test still asserts its `[Unknown]` inference.

No production logic changed.

## Verification

Tested against Node v25.9.0.

| Check | Erlang | JavaScript/Node |
|---|---|---|
| `gleam build` | ✓ | ✓ |
| `gleam test` | 380 passed | 380 passed |
| `graded check` (file IO + exit code) | ✓ | ✓ (exit `1` on violations via `halt`) |
| `graded format --stdin` (exercises `read_stdin`) | ✓ | ✓ (identical output) |

Run on Node with: `gleam run --target javascript -m graded check [dir]`.

## Notes

- `.tool-versions` is left untouched (erlang + gleam only) so Erlang-only contributors aren't forced to install Node. The default target remains Erlang.