### PR TITLE
fix: apply external effects to same-module @external calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A same-module (unqualified) call into a bodyless `@external` now applies its `external effects` declaration, matching the cross-module (qualified) call path. The local-call path resolved opaque externals straight to `[Unknown]` without consulting the knowledge base, so a declared `external effects` entry took effect only for callers in other modules; the common FFI idiom of an `@external` binding plus a same-module wrapper cascaded to `[Unknown]`. Undeclared externals still resolve to `[Unknown]`.
+
 ## [0.9.2] - 2026-06-23
 
 ### Fixed

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -173,6 +173,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
       }
       check_one_file(
         gleam_path,
+        module_path,
         module,
         module_checks,
         knowledge_base,
@@ -702,6 +703,7 @@ fn infer_one_module(
   let #(inferred, returned_operators) =
     checker.infer_with_returns(
       module,
+      module_path,
       knowledge_base,
       [],
       registry,
@@ -799,6 +801,7 @@ fn fold_inferred_module(
   let #(inferred, returned_operators) =
     checker.infer_with_returns(
       module,
+      module_path,
       kb,
       [],
       registry,
@@ -916,6 +919,7 @@ fn checks_grouped_by_module(
 // annotations from the spec file that mention this file's module.
 fn check_one_file(
   gleam_path: String,
+  module_path: String,
   module: glance.Module,
   module_checks: List(EffectAnnotation),
   knowledge_base: KnowledgeBase,
@@ -926,6 +930,7 @@ fn check_one_file(
   let #(violations, warnings) =
     checker.check(
       module,
+      module_path,
       module_checks,
       knowledge_base,
       registry,
@@ -1229,6 +1234,7 @@ fn infer_path_dep_module(
       let #(annotations, returned_operators) =
         checker.infer_with_returns(
           module,
+          module_path,
           kb,
           checks,
           registry,

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2254,10 +2254,7 @@ fn resolve_unknown_local(
               module: context.module_path,
               function: local_call.function,
             )
-          let term = case effects.lookup(knowledge_base, qualified) {
-            effects.Known(declared) -> declared
-            effects.Unknown -> effect_term.unknown()
-          }
+          let term = effects.lookup_effects(knowledge_base, qualified)
           #(
             [
               #(

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -27,6 +27,7 @@ import graded/internal/types.{
 // Check a parsed module against its effect annotations.
 pub fn check(
   module: Module,
+  module_path: String,
   annotations: List(EffectAnnotation),
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
@@ -35,6 +36,7 @@ pub fn check(
 ) -> #(List(Violation), List(Warning)) {
   let context =
     extract.build_import_context(module)
+    |> extract.with_module_path(module_path)
     |> extract.with_factories(extract.factory_map(module))
     |> extract.with_cross_factories(effects.factories(knowledge_base))
   let function_map = build_function_map(module)
@@ -66,6 +68,7 @@ pub fn check(
 // Pass existing `check` annotations so their param bounds are used during inference.
 pub fn infer(
   module: Module,
+  module_path: String,
   knowledge_base: KnowledgeBase,
   existing_checks: List(EffectAnnotation),
   registry: SignatureRegistry,
@@ -74,6 +77,7 @@ pub fn infer(
 ) -> List(EffectAnnotation) {
   infer_with_returns(
     module,
+    module_path,
     knowledge_base,
     existing_checks,
     registry,
@@ -88,6 +92,7 @@ pub fn infer(
 // for downstream `let h = producer(); with(h)` consumers.
 pub fn infer_with_returns(
   module: Module,
+  module_path: String,
   knowledge_base: KnowledgeBase,
   existing_checks: List(EffectAnnotation),
   registry: SignatureRegistry,
@@ -96,6 +101,7 @@ pub fn infer_with_returns(
 ) -> #(List(EffectAnnotation), dict.Dict(String, EffectTerm)) {
   let context =
     extract.build_import_context(module)
+    |> extract.with_module_path(module_path)
     |> extract.with_factories(extract.factory_map(module))
     |> extract.with_cross_factories(effects.factories(knowledge_base))
   let function_map = build_function_map(module)
@@ -2237,23 +2243,31 @@ fn resolve_unknown_local(
     }
     Ok(local_definition) ->
       case is_opaque_external(local_definition) {
-        // A same-module call into a bodyless `@external` resolves to the
+        // A same-module call into a bodyless `@external` has no analysable body,
+        // so consult the knowledge base for a declared `external effects` entry —
+        // qualifying the bare name with the current module. A declaration wins;
+        // without one (or when the module is unknown) it falls back to the
         // conservative `[Unknown]`, not the `[]` its empty body would yield.
-        True -> #(
-          [
-            #(
-              types.ResolvedCall(
-                name: QualifiedName(
-                  module: "<local>",
-                  function: local_call.function,
-                ),
-                span: local_call.span,
+        True -> {
+          let qualified =
+            QualifiedName(
+              module: context.module_path,
+              function: local_call.function,
+            )
+          let term = case effects.lookup(knowledge_base, qualified) {
+            effects.Known(declared) -> declared
+            effects.Unknown -> effect_term.unknown()
+          }
+          #(
+            [
+              #(
+                types.ResolvedCall(name: qualified, span: local_call.span),
+                term,
               ),
-              effect_term.unknown(),
-            ),
-          ],
-          memo,
-        )
+            ],
+            memo,
+          )
+        }
         // A genuine same-module body: memoize its transitive analysis,
         // keyed by callee + same-SCC ancestors (see `memo_key`). The cached
         // list holds in-body call spans, which are call-site-independent, so

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -58,6 +58,11 @@ type Env =
 // call (`a.Validator(x)`) can still route `x` to the right field.
 pub type ImportContext {
   ImportContext(
+    // The path of the module being analysed (e.g. `myapp/router`), so a
+    // same-module bare call can be qualified back into a knowledge-base key.
+    // Empty when unknown (synthetic test modules); the empty path matches no
+    // entry, so resolution falls back exactly as before.
+    module_path: String,
     aliases: Dict(String, String),
     unqualified: Dict(String, QualifiedName),
     constructors: Dict(String, List(Option(String))),
@@ -68,6 +73,14 @@ pub type ImportContext {
     factories: Dict(String, FactorySignature),
     cross_factories: Dict(#(String, String), FactorySignature),
   )
+}
+
+// Record which module the context describes, so same-module bare calls qualify.
+pub fn with_module_path(
+  context: ImportContext,
+  module_path: String,
+) -> ImportContext {
+  ImportContext(..context, module_path:)
 }
 
 // Attach a package-wide `#(defining module, constructor) -> field labels` map
@@ -162,6 +175,7 @@ pub fn build_import_context(module: Module) -> ImportContext {
 
   let constructors = build_constructor_registry(module)
   ImportContext(
+    module_path: "",
     aliases:,
     unqualified:,
     constructors:,

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -763,25 +763,15 @@ pub fn fetch() { httpc.send(request) }"
   |> should.be_true()
 }
 
-// A same-module (unqualified) call into a bodyless `@external` inherits the
-// effects declared for it in the knowledge base — qualified by the current
-// module — not the `[Unknown]` an undeclared external yields. Regression for the
-// FFI idiom: an `@external` binding paired with a same-module wrapper.
-pub fn external_same_module_resolves_declared_effects_test() {
+// Infer `read_clock`'s effects in module `ffi_mod`, which wraps a bodyless
+// same-module `@external` (`now`), under the given knowledge base.
+fn infer_external_wrapper(kb: effects.KnowledgeBase) -> EffectSet {
   let source =
     "@external(erlang, \"ffi\", \"now\")
 pub fn now() -> Int
 
 pub fn read_clock() { now() }"
   let assert Ok(module) = glance.module(source)
-  let externals = [
-    types.ExternalAnnotation(
-      "ffi_mod",
-      types.FunctionExternal("now"),
-      Specific(set.from_list(["Time"])),
-    ),
-  ]
-  let kb = effects.with_externals(knowledge_base(), externals)
   let inferred =
     checker.infer(
       module,
@@ -795,6 +785,21 @@ pub fn read_clock() { now() }"
   let assert Ok(annotation) =
     list.find(inferred, fn(a) { a.function == "read_clock" })
   effect_term.to_effect_set(annotation.effects)
+}
+
+// A same-module (unqualified) call into a bodyless `@external` inherits the
+// effects declared for it in the knowledge base — qualified by the current
+// module — not the `[Unknown]` an undeclared external yields. Regression for the
+// FFI idiom: an `@external` binding paired with a same-module wrapper.
+pub fn external_same_module_resolves_declared_effects_test() {
+  let externals = [
+    types.ExternalAnnotation(
+      "ffi_mod",
+      types.FunctionExternal("now"),
+      Specific(set.from_list(["Time"])),
+    ),
+  ]
+  infer_external_wrapper(effects.with_externals(knowledge_base(), externals))
   |> should.equal(Specific(set.from_list(["Time"])))
 }
 
@@ -802,25 +807,7 @@ pub fn read_clock() { now() }"
 // `[Unknown]` — the opaque-FFI default (`module_path` qualifies the lookup, so a
 // wrong/absent entry never silently resolves to `[]`).
 pub fn external_same_module_without_declaration_is_unknown_test() {
-  let source =
-    "@external(erlang, \"ffi\", \"now\")
-pub fn now() -> Int
-
-pub fn read_clock() { now() }"
-  let assert Ok(module) = glance.module(source)
-  let inferred =
-    checker.infer(
-      module,
-      "ffi_mod",
-      knowledge_base(),
-      [],
-      signatures.empty(),
-      dict.new(),
-      dict.new(),
-    )
-  let assert Ok(annotation) =
-    list.find(inferred, fn(a) { a.function == "read_clock" })
-  effect_term.to_effect_set(annotation.effects)
+  infer_external_wrapper(knowledge_base())
   |> should.equal(Specific(set.from_list(["Unknown"])))
 }
 

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -35,6 +35,7 @@ fn check_source(
   let #(violations, _warnings) =
     checker.check(
       module,
+      "",
       annotations,
       knowledge_base(),
       signatures.empty(),
@@ -194,6 +195,7 @@ pub fn view(items) { list.map(items, fn(x) { x }) }"
   let inferred =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.empty(),
@@ -215,6 +217,7 @@ pub fn greet() { io.println(\"hi\") }"
   let inferred =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.empty(),
@@ -235,6 +238,7 @@ fn helper() { io.println(\"x\") }"
   let inferred =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.empty(),
@@ -266,6 +270,7 @@ pub fn infer_uses_param_bounds_test() {
   let inferred =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       existing_checks,
       signatures.empty(),
@@ -285,6 +290,7 @@ pub fn infer_without_bounds_gets_unknown_test() {
   let inferred =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.empty(),
@@ -336,6 +342,7 @@ pub fn infer_girard_detects_unannotated_fn_typed_param_test() {
   let inferred =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.empty(),
@@ -447,6 +454,7 @@ fn check_source_with_type_fields(
   let #(violations, _warnings) =
     checker.check(
       module,
+      "",
       annotations,
       kb,
       signatures.empty(),
@@ -506,6 +514,7 @@ fn check_source_with_girard(
   let #(violations, _warnings) =
     checker.check(
       module,
+      "",
       annotations,
       kb,
       signatures.empty(),
@@ -697,6 +706,7 @@ fn check_source_with_externals(
   let #(violations, _warnings) =
     checker.check(
       module,
+      "",
       annotations,
       kb,
       signatures.empty(),
@@ -753,6 +763,67 @@ pub fn fetch() { httpc.send(request) }"
   |> should.be_true()
 }
 
+// A same-module (unqualified) call into a bodyless `@external` inherits the
+// effects declared for it in the knowledge base — qualified by the current
+// module — not the `[Unknown]` an undeclared external yields. Regression for the
+// FFI idiom: an `@external` binding paired with a same-module wrapper.
+pub fn external_same_module_resolves_declared_effects_test() {
+  let source =
+    "@external(erlang, \"ffi\", \"now\")
+pub fn now() -> Int
+
+pub fn read_clock() { now() }"
+  let assert Ok(module) = glance.module(source)
+  let externals = [
+    types.ExternalAnnotation(
+      "ffi_mod",
+      types.FunctionExternal("now"),
+      Specific(set.from_list(["Time"])),
+    ),
+  ]
+  let kb = effects.with_externals(knowledge_base(), externals)
+  let inferred =
+    checker.infer(
+      module,
+      "ffi_mod",
+      kb,
+      [],
+      signatures.empty(),
+      dict.new(),
+      dict.new(),
+    )
+  let assert Ok(annotation) =
+    list.find(inferred, fn(a) { a.function == "read_clock" })
+  effect_term.to_effect_set(annotation.effects)
+  |> should.equal(Specific(set.from_list(["Time"])))
+}
+
+// Without a declaration, a same-module call into a bodyless `@external` stays
+// `[Unknown]` — the opaque-FFI default (`module_path` qualifies the lookup, so a
+// wrong/absent entry never silently resolves to `[]`).
+pub fn external_same_module_without_declaration_is_unknown_test() {
+  let source =
+    "@external(erlang, \"ffi\", \"now\")
+pub fn now() -> Int
+
+pub fn read_clock() { now() }"
+  let assert Ok(module) = glance.module(source)
+  let inferred =
+    checker.infer(
+      module,
+      "ffi_mod",
+      knowledge_base(),
+      [],
+      signatures.empty(),
+      dict.new(),
+      dict.new(),
+    )
+  let assert Ok(annotation) =
+    list.find(inferred, fn(a) { a.function == "read_clock" })
+  effect_term.to_effect_set(annotation.effects)
+  |> should.equal(Specific(set.from_list(["Unknown"])))
+}
+
 // Wildcard [_] tests
 
 pub fn wildcard_declared_passes_all_effects_test() {
@@ -807,6 +878,7 @@ fn check_warnings(
   let #(_violations, warnings) =
     checker.check(
       module,
+      "",
       annotations,
       knowledge_base(),
       signatures.empty(),
@@ -1138,6 +1210,7 @@ pub fn check_no_false_positives_test() {
       let #(violations, _) =
         checker.check(
           module,
+          "",
           [ann],
           kb,
           signatures.empty(),
@@ -1166,6 +1239,7 @@ pub fn check_wildcard_never_violates_test() {
       let #(violations, _) =
         checker.check(
           module,
+          "",
           [ann],
           kb,
           signatures.empty(),
@@ -1197,6 +1271,7 @@ pub fn check_empty_budget_detects_effects_test() {
           let #(violations, _) =
             checker.check(
               module,
+              "",
               [ann],
               kb,
               signatures.empty(),
@@ -1230,6 +1305,7 @@ pub fn check_violations_iff_not_subset_test() {
       let #(violations, _) =
         checker.check(
           module,
+          "",
           [ann],
           kb,
           signatures.empty(),
@@ -1254,6 +1330,7 @@ pub fn infer_matches_actual_effects_test() {
       let inferred =
         checker.infer(
           module,
+          "",
           kb,
           [],
           signatures.empty(),
@@ -1328,6 +1405,7 @@ pub fn infer_terminates_with_cycles_test() {
       let inferred =
         checker.infer(
           module,
+          "",
           bare_knowledge_base(),
           [],
           signatures.empty(),
@@ -1356,6 +1434,7 @@ pub fn check_terminates_with_cycles_test() {
       let #(violations, _) =
         checker.check(
           module,
+          "",
           [ann],
           bare_knowledge_base(),
           signatures.empty(),
@@ -1374,6 +1453,7 @@ fn infer_single(source: String) -> EffectAnnotation {
   let assert [ann] =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.empty(),
@@ -1472,6 +1552,7 @@ pub fn apply(f: fn(Int) -> Int, x: Int) -> Int {
   let assert [ann] =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [existing],
       signatures.empty(),
@@ -1539,6 +1620,7 @@ pub fn new() {
   let #(violations, _) =
     checker.check(
       module,
+      "",
       [
         EffectAnnotation(
           Check,
@@ -1570,6 +1652,7 @@ pub fn new() {
   let #(violations, _) =
     checker.check(
       module,
+      "",
       [
         EffectAnnotation(
           Check,
@@ -1600,6 +1683,7 @@ pub fn new() {
   let #(violations, _) =
     checker.check(
       module,
+      "",
       [
         EffectAnnotation(
           Check,
@@ -1630,6 +1714,7 @@ pub fn new() {
   let assert [ann] =
     checker.infer(
       module,
+      "",
       polymorphic_kb(),
       [],
       signatures.empty(),
@@ -1656,6 +1741,7 @@ pub fn new() {
   let assert [ann] =
     checker.infer(
       module,
+      "",
       polymorphic_kb(),
       [],
       signatures.empty(),
@@ -1723,6 +1809,7 @@ pub fn outer() -> MyError {
   let inferred =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.empty(),
@@ -1748,6 +1835,7 @@ pub fn run() {
   let assert [ann] =
     checker.infer(
       module,
+      "",
       two_callback_kb(),
       [],
       signatures.empty(),
@@ -1772,6 +1860,7 @@ fn infer_single_with_list(source: String) -> types.EffectAnnotation {
   let assert [ann] =
     checker.infer(
       module,
+      "",
       knowledge_base(),
       [],
       list_registry(),
@@ -1850,6 +1939,7 @@ pub fn run(x: Int) {
   let #(violations, _) =
     checker.check(
       module,
+      "",
       [EffectAnnotation(Check, "run", [], effect_term.from_effect_set(budget))],
       kb,
       reg,
@@ -1969,7 +2059,8 @@ pub fn run(h: fn(Int) -> Int, x: Int) -> Int {
 }
 "
   let assert Ok(module) = glance.module(source)
-  let assert [ann] = checker.infer(module, kb, [], reg, dict.new(), dict.new())
+  let assert [ann] =
+    checker.infer(module, "", kb, [], reg, dict.new(), dict.new())
   ann.function |> should.equal("run")
   effect_term.to_effect_set(ann.effects)
   |> should.equal(Polymorphic(set.new(), set.from_list(["h"])))
@@ -2019,6 +2110,7 @@ pub fn main(t: Task, msg: String) {
   let #(violations, _warnings) =
     checker.check(
       module,
+      "",
       [
         EffectAnnotation(
           Check,
@@ -2126,7 +2218,7 @@ pub fn caller() -> Nil {
       effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
     )
   let #(violations, _) =
-    checker.check(module, [pass], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [pass], kb, registry, dict.new(), dict.new())
   violations |> should.equal([])
   let fail =
     EffectAnnotation(
@@ -2136,7 +2228,7 @@ pub fn caller() -> Nil {
       effect_term.from_effect_set(types.empty()),
     )
   let #(failed, _) =
-    checker.check(module, [fail], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [fail], kb, registry, dict.new(), dict.new())
   { failed != [] } |> should.be_true()
 }
 
@@ -2236,7 +2328,7 @@ pub fn caller() -> Nil { app.with_logger(app.runner) }"
       effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
     )
   let #(violations, _) =
-    checker.check(module, [ann], kb, reg, dict.new(), dict.new())
+    checker.check(module, "", [ann], kb, reg, dict.new(), dict.new())
   violations |> should.equal([])
 }
 
@@ -2256,7 +2348,7 @@ pub fn caller() -> Nil { app.with_logger(app.runner) }"
       effect_term.from_effect_set(types.empty()),
     )
   let #(violations, _) =
-    checker.check(module, [ann], kb, reg, dict.new(), dict.new())
+    checker.check(module, "", [ann], kb, reg, dict.new(), dict.new())
   { violations != [] } |> should.be_true()
 }
 
@@ -2277,7 +2369,7 @@ pub fn caller() -> Nil { app.with_logger(fn(logger) { logger(\"hi\") }) }"
       effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
     )
   let #(violations, _) =
-    checker.check(module, [ann], kb, reg, dict.new(), dict.new())
+    checker.check(module, "", [ann], kb, reg, dict.new(), dict.new())
   violations |> should.equal([])
 }
 
@@ -2339,7 +2431,15 @@ pub fn run(action: fn(fn(String) -> Nil, fn(String) -> Nil) -> Nil) -> Nil {
 "
   let assert Ok(module) = glance.module(source)
   let assert [ann] =
-    checker.infer(module, kb, [], signatures.empty(), dict.new(), dict.new())
+    checker.infer(
+      module,
+      "",
+      kb,
+      [],
+      signatures.empty(),
+      dict.new(),
+      dict.new(),
+    )
   ann.effects
   |> effect_term.normalize
   |> should.equal(types.TApp(
@@ -2364,7 +2464,15 @@ pub fn run(
 "
   let assert Ok(module) = glance.module(source)
   let assert [ann] =
-    checker.infer(module, kb, [], signatures.empty(), dict.new(), dict.new())
+    checker.infer(
+      module,
+      "",
+      kb,
+      [],
+      signatures.empty(),
+      dict.new(),
+      dict.new(),
+    )
   ann.effects
   |> effect_term.normalize
   |> should.equal(types.TApp(
@@ -3005,7 +3113,7 @@ pub fn caller() -> Nil {
       effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
     )
   let #(violations, _) =
-    checker.check(module, [pass], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [pass], kb, registry, dict.new(), dict.new())
   violations |> should.equal([])
   let fail =
     EffectAnnotation(
@@ -3015,7 +3123,7 @@ pub fn caller() -> Nil {
       effect_term.from_effect_set(types.empty()),
     )
   let #(fail_violations, _) =
-    checker.check(module, [fail], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [fail], kb, registry, dict.new(), dict.new())
   { fail_violations != [] } |> should.be_true()
 }
 
@@ -3060,7 +3168,7 @@ pub fn caller() -> Nil {
       effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
     )
   let #(violations, _) =
-    checker.check(module, [pass], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [pass], kb, registry, dict.new(), dict.new())
   violations |> should.equal([])
 }
 
@@ -3079,6 +3187,7 @@ pub fn pick() -> fn(fn(String) -> Nil) -> Nil {
   let #(_annotations, returns) =
     checker.infer_with_returns(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.from_glance_module("app", module),
@@ -3103,6 +3212,7 @@ pub fn make_printer() -> fn() -> Nil {
   let #(_annotations, returns) =
     checker.infer_with_returns(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.from_glance_module("app", module),
@@ -3158,7 +3268,7 @@ pub fn caller() -> Nil {
       effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
     )
   let #(violations, _) =
-    checker.check(module, [pass], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [pass], kb, registry, dict.new(), dict.new())
   violations |> should.equal([])
   let fail =
     EffectAnnotation(
@@ -3168,7 +3278,7 @@ pub fn caller() -> Nil {
       effect_term.from_effect_set(types.empty()),
     )
   let #(failed, _) =
-    checker.check(module, [fail], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [fail], kb, registry, dict.new(), dict.new())
   { failed != [] } |> should.be_true()
 }
 
@@ -3193,6 +3303,7 @@ pub fn pick(
   let #(_annotations, returns) =
     checker.infer_with_returns(
       module,
+      "",
       knowledge_base(),
       [],
       signatures.from_glance_module("app", module),
@@ -3307,7 +3418,7 @@ fn second_order_violations(
       effect_term.from_effect_set(Specific(set.from_list(budget))),
     )
   let #(violations, _) =
-    checker.check(module, [ann], kb, registry, dict.new(), dict.new())
+    checker.check(module, "", [ann], kb, registry, dict.new(), dict.new())
   violations
 }
 

--- a/test/fixtures/external_same_module.gleam
+++ b/test/fixtures/external_same_module.gleam
@@ -1,0 +1,16 @@
+// A same-module call into a bodyless `@external` that carries an
+// `external effects` declaration inherits the DECLARED effects, not the
+// conservative `[Unknown]` an undeclared external yields. This is the common
+// FFI idiom: an `@external` binding paired with a same-module wrapper.
+//
+// graded reads this file as text, so the Erlang-only external exercises the
+// path on either compilation target. The `@target(erlang)` gate keeps the
+// bodyless external out of the JavaScript build.
+@target(erlang)
+@external(erlang, "some_ffi_module", "now")
+pub fn now() -> Int
+
+@target(erlang)
+pub fn read_clock() -> Int {
+  now()
+}

--- a/test/fixtures/fixtures.graded
+++ b/test/fixtures/fixtures.graded
@@ -16,6 +16,10 @@ check named_fn_arg.run : []
 check labeled_callback.run : []
 check record_update.run : []
 check shadow_param.run(handler: []) : []
+check external_same_module.read_clock : []
+
+// External effects (third-party / FFI functions graded can't see into).
+external effects external_same_module.now : [Time]
 
 // Type field annotations (the effect source for type-directed field calls).
 type opaque_receiver.Validator.to_error : [Stdout]

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -95,6 +95,24 @@ pub fn external_is_unknown_test() {
   v.actual |> should.equal(types.Specific(set.from_list(["Unknown"])))
 }
 
+pub fn external_same_module_declared_effects_test() {
+  // A same-module (unqualified) call into a bodyless `@external` that carries an
+  // `external effects` declaration inherits the DECLARED effects, not the
+  // `[Unknown]` an undeclared external yields. `read_clock` calls `now()` bare,
+  // so against a `[]` budget the actual must be the declared `[Time]`. Without
+  // the fix the local path bypassed the knowledge base and reported `[Unknown]`.
+  let assert Ok(results) = graded.run("test/fixtures")
+  let same_module_result =
+    list.find(results, fn(r) {
+      r.file == "test/fixtures/external_same_module.gleam"
+    })
+  let assert Ok(r) = same_module_result
+  { r.violations != [] } |> should.be_true()
+  let assert [v, ..] = r.violations
+  v.function |> should.equal("read_clock")
+  v.actual |> should.equal(types.Specific(set.from_list(["Time"])))
+}
+
 pub fn opaque_receiver_violation_detected_test() {
   // opaque_receiver.run binds its Validator from make() — a *cross-function*
   // construction the syntax-level path can't see. girard types the receiver,


### PR DESCRIPTION
## Problem

A function marked `@external` that is called from **within its own module** ignored its `external effects` declaration and resolved to `[Unknown]`, even though the declaration worked correctly for **cross-module** callers. The common FFI idiom — an `@external` binding paired with a same-module wrapper — cascaded the wrapper and all its callers to `[Unknown]`.

Reported in [this issue](https://gist.githubusercontent.com/alvivi/60529d3daae6ea1fd3b1b43f3faece85/raw/47075347594c9817fde7667c29793f7ecef797aa/graded-issue-samemodule-external.md).

## Root cause

Qualified (cross-module) calls go through `effects.lookup_effects`, which consults the knowledge base. The local (unqualified) path in `resolve_unknown_local` instead detected the opaque `@external` and **hardcoded** `[Unknown]`, never querying the knowledge base — so a declared `external effects` entry could not reach a same-module caller.

## Fix

The opaque-external branch now qualifies the bare callee with the **current module** and looks it up in the knowledge base: a declared entry wins, and resolution falls back to `[Unknown]` when there is no declaration (or the module is unknown). This preserves the existing soundness behavior for *undeclared* externals.

The current module path is threaded into `check` / `infer` / `infer_with_returns` and carried on `ImportContext` (empty for synthetic test modules — the empty path matches no entry, so behavior is unchanged there).

## Tests

- `integration_test.external_same_module_declared_effects_test` — end-to-end fixture (`external_same_module.gleam` + `fixtures.graded`): a same-module wrapper now reports the declared `[Time]`, not `[Unknown]`.
- `checker_test.external_same_module_resolves_declared_effects_test` — unit test with a real (non-empty) module path, asserting `infer` produces the declared effect.
- `checker_test.external_same_module_without_declaration_is_unknown_test` — regression guard: an undeclared same-module external stays `[Unknown]`.

All 383 tests pass.