### PR TITLE
chore: fail CI on glinter warnings and fix existing ones

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -44,6 +44,9 @@ gleeunit = ">= 1.0.0 and < 2.0.0"
 glinter = ">= 2.11.1 and < 3.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
 
+[tools.glinter]
+warnings_as_errors = true
+
 [tools.glinter.rules]
 unused_exports = "off"
 label_possible = "off"

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -1403,10 +1403,7 @@ fn print_warning(file: String, warning: Warning) -> Nil {
         // A non-parameter receiver can be traced to a construction site, so the
         // call may exist but resolve through value provenance, shadowing the bound.
         False ->
-          " matches no field call in its body — check the path,"
-          <> " or the receiver is traced to a construction site and resolved"
-          <> " through value provenance (field bounds apply only to untraceable"
-          <> " receivers)"
+          " matches no field call in its body — check the path, or the receiver is traced to a construction site and resolved through value provenance (field bounds apply only to untraceable receivers)"
       }
       io.println(
         file

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -1097,10 +1097,8 @@ fn positions_up_to(n: Int) -> List(Int) {
 }
 
 fn positions_loop(i: Int, acc: List(Int)) -> List(Int) {
-  case i < 0 {
-    True -> acc
-    False -> positions_loop(i - 1, [i, ..acc])
-  }
+  use <- bool.guard(when: i < 0, return: acc)
+  positions_loop(i - 1, [i, ..acc])
 }
 
 // The effect of an argument bound to a *first-order* fn-typed parameter. A


### PR DESCRIPTION
## Summary

Make glinter warnings fail the build, and clear the three existing ones.

`glinter` only exits non-zero on `Error`-severity findings, so the CI `Lint` step (`gleam run -m glinter`) passed despite 3 warnings. Setting `warnings_as_errors = true` under `[tools.glinter]` in `gleam.toml` promotes every warning to an error, so glinter exits 1 — failing the existing CI step. No `ci.yml` change is needed, and the same strictness now applies to local `gleam run -m glinter` runs.

## Warnings fixed

- **`src/graded.gleam`** — `unnecessary_string_concatenation`: combined four concatenated string literals in a warning message into a single literal (content unchanged).
- **`src/graded/internal/checker.gleam`** — `prefer_guard_clause`: rewrote `positions_loop`'s `case i < 0 { True -> … False -> … }` as `use <- bool.guard(when: i < 0, return: acc)`.

## Verification

Local run of the full CI sequence:

- `gleam format --check src/ test/` — clean
- `gleam build --warnings-as-errors` — clean
- `gleam test` — 383 passed, 0 failures
- `gleam run -m glinter` — `No issues found.` (exit 0); confirmed it exits 1 before the fixes

Independent of the let-bound-closures PR (#27); branched off `main`.