### PR TITLE
Apply module-level externals to the consumer's own project modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **A module-level `external effects <module>` declaration now governs a path dependency's inferred module, with its full effect set.** Previously the declared set was flattened to pure (so `dep.*` calls resolved to `[]`), and graded's own source-inference of the path dependency shadowed the declaration — leaving the module and its in-dependency callers at `[Unknown]`. The declaration now applies during the dependency's inference, so both resolve to the declared set. A per-function `external effects mod.fn` or an authoritative dependency spec/catalog effect still takes precedence.
+- **A module-level external now governs the consumer's own project modules too.** A declaration for a project module (`external effects myapp/db : [Database]`) was shadowed by graded's in-memory inference of that module's source, so its functions resolved to the inferred effect rather than the declared set. The inferred call effect is now dropped for a declared module — at both `check` and `infer` time, so a sibling module calling into it agrees — and `graded infer` writes no per-function `effects` lines for it, matching how a per-function external suppresses its own line. Returned-operator and parameter-bound metadata are kept.
 
 ## [0.9.4] - 2026-06-24
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -293,15 +293,15 @@ external effects gleam/list : []           // the whole module is pure
 external effects some_db/client : [Database] // every client function does Database I/O
 ```
 
-Module-level externals describe **dependency** modules (hex or path) — code graded
-doesn't infer itself; a declaration for one of your own project modules is shadowed
-by graded's inference of that module's source. Use the per-function form when
-functions in a module differ; use the module-level form when one budget fits the
-module. A per-function `external effects mod.fn` or a catalog `effects` line for the
-same function takes precedence over a module-level external. The module-level form
-applies uniformly to hex and path dependencies: a module-level external on a path
-dependency suppresses graded's source inference for that module, so it resolves to
-the declared set instead of an inferred `[Unknown]`.
+Module-level externals work on dependency modules (hex or path) **and on your own
+project modules**. For a dependency or project module graded would otherwise infer,
+the declaration suppresses that inference: every function in the module resolves to
+the declared set instead of an inferred `[Unknown]`, and `graded infer` writes no
+per-function `effects` lines for it (just as a per-function external suppresses its
+own line). Use the per-function form when functions in a module differ; use the
+module-level form when one budget fits the module. A per-function
+`external effects mod.fn` or a catalog `effects` line for the same function takes
+precedence over a module-level external.
 
 This is also the mechanism for **FFI**. A bodyless `@external` function is opaque —
 graded infers `[Unknown]`, never the `[]` an empty body would suggest, since the

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -567,8 +567,17 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
   // `check` agree on a field wired to a qualified project function, converging
   // across runs. The inferred effects are NOT seeded into `base_kb` below: the
   // topo loop recomputes them fresh, threading each module's result forward.
+  // Stale `effects` lines for a module-level-external module are dropped, exactly
+  // as `run` does, so a field wired to such a function resolves to the
+  // declaration rather than the outranking-but-stale per-function effect.
   let construction_kb =
-    effects.with_inferred(kb_base, effects.load_spec_effects_from_file(spec))
+    effects.with_inferred(
+      kb_base,
+      drop_declared_modules(
+        effects.load_spec_effects_from_file(spec),
+        declared_modules,
+      ),
+    )
   let base_kb =
     kb_base
     |> effects.with_inferred_type_fields(build_constructor_field_index(

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -128,6 +128,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
   let package_root = resolve_package_root(directory)
   let spec = read_spec(cfg.spec_file)
   let checks_by_module = checks_grouped_by_module(spec)
+  let declared_modules = annotation.module_external_modules(spec)
 
   use gleam_files <- result.try(find_gleam_files(directory))
   use parsed <- result.try(parse_all_files(gleam_files))
@@ -148,11 +149,15 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.
     |> effects.with_externals(annotation.extract_externals(spec))
-    |> enrich_with_path_deps(
-      package_root,
-      annotation.module_external_modules(spec),
-    )
-    |> effects.with_inferred(effects.load_spec_effects_from_file(spec))
+    |> enrich_with_path_deps(package_root, declared_modules)
+    // Committed `effects` lines for a module-level-external module are dropped
+    // so they can't reshadow the declaration (which lives in `module_effects`,
+    // consulted only when `all_effects` misses). `graded infer` no longer writes
+    // such lines; this guards a stale or hand-written one.
+    |> effects.with_inferred(drop_declared_modules(
+      effects.load_spec_effects_from_file(spec),
+      declared_modules,
+    ))
     |> effects.with_inferred_returned_operators(
       effects.load_spec_returns_from_file(spec),
     )
@@ -160,7 +165,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
     // in memory, so `check` resolves cross-module calls without a prior
     // `graded infer`. Spec entries above take priority — committed effects are
     // never overridden — and nothing is written to disk.
-    |> infer_project_in_memory(index, registry, type_info)
+    |> infer_project_in_memory(index, registry, type_info, declared_modules)
   let knowledge_base =
     kb_base
     |> effects.with_inferred_type_fields(build_constructor_field_index(
@@ -541,6 +546,7 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
   use cfg <- result.try(read_config(directory))
   let package_root = resolve_package_root(directory)
   let spec = read_spec(cfg.spec_file)
+  let declared_modules = annotation.module_external_modules(spec)
 
   use gleam_files <- result.try(find_gleam_files(directory))
   use parsed <- result.try(parse_all_files(gleam_files))
@@ -555,10 +561,7 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.
     |> effects.with_externals(annotation.extract_externals(spec))
-    |> enrich_with_path_deps(
-      package_root,
-      annotation.module_external_modules(spec),
-    )
+    |> enrich_with_path_deps(package_root, declared_modules)
   // Resolve constructor-field values against the same view `run` uses — catalog
   // + externals + the spec's *existing* inferred effects — so `infer` and
   // `check` agree on a field wired to a qualified project function, converging
@@ -607,6 +610,7 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
             registry,
             typeinfo.for_module(type_info, module_path),
             typeinfo.fn_typed_for_module(type_info, module_path),
+            declared_modules,
           ))
           // Prepend new entries so each iteration is O(|new|) instead of
           // O(|acc|); final order doesn't matter, merge_inferred keys by name.
@@ -1039,6 +1043,7 @@ fn infer_one_module(
   registry: SignatureRegistry,
   module_types: Dict(#(Int, Int), girard_types.Type),
   girard_fn_typed: Dict(String, Set(String)),
+  declared_modules: Set(String),
 ) -> Result(
   #(KnowledgeBase, List(EffectAnnotation), List(types.ReturnsAnnotation)),
   GradedError,
@@ -1073,13 +1078,16 @@ fn infer_one_module(
 
   // Thread inferred effects, polymorphic param bounds, and returned-operator
   // signatures into the KB so later modules in the topo-sort pass can resolve
-  // call sites targeting this module's functions.
+  // call sites targeting this module's functions. A module-level-external module
+  // resolves via its declaration, so later modules calling into it agree with
+  // `check`.
   let new_kb =
     thread_inferred_into_kb(
       knowledge_base,
       inferred,
       returned_operators,
       module_path,
+      declared_modules,
     )
 
   let public_names = public_function_names(module)
@@ -1117,6 +1125,7 @@ fn infer_project_in_memory(
   index: Dict(String, #(String, glance.Module)),
   registry: SignatureRegistry,
   type_info: typeinfo.TypeInfo,
+  declared_modules: Set(String),
 ) -> KnowledgeBase {
   case topo.sort(build_dependency_graph(index)) {
     Error(_) -> base_kb
@@ -1125,7 +1134,14 @@ fn infer_project_in_memory(
         case dict.get(index, module_path) {
           Error(_) -> kb
           Ok(#(_gleam_path, module)) ->
-            fold_inferred_module(kb, module, module_path, registry, type_info)
+            fold_inferred_module(
+              kb,
+              module,
+              module_path,
+              registry,
+              type_info,
+              declared_modules,
+            )
         }
       })
   }
@@ -1140,6 +1156,7 @@ fn fold_inferred_module(
   module_path: String,
   registry: SignatureRegistry,
   type_info: typeinfo.TypeInfo,
+  declared_modules: Set(String),
 ) -> KnowledgeBase {
   let #(inferred, returned_operators) =
     checker.infer_with_returns(
@@ -1151,20 +1168,35 @@ fn fold_inferred_module(
       typeinfo.for_module(type_info, module_path),
       typeinfo.fn_typed_for_module(type_info, module_path),
     )
-  thread_inferred_into_kb(kb, inferred, returned_operators, module_path)
+  thread_inferred_into_kb(
+    kb,
+    inferred,
+    returned_operators,
+    module_path,
+    declared_modules,
+  )
 }
 
 // Thread a module's freshly inferred effects, polymorphic param bounds, and
 // returned-operator signatures (all qualified by `module_path`) into the
 // knowledge base. Existing entries win.
+//
+// A module the consumer declared with a module-level external (in
+// `declared_modules`) has its inferred *call effect* dropped so lookup falls
+// through to the declared set — the project-module counterpart of the path-dep
+// `drop_declared_modules` in `infer_path_dep_module`. Returned-operator and
+// parameter-bound metadata describe what a function returns and how it consumes
+// operator arguments, not its call effect, so they are kept.
 fn thread_inferred_into_kb(
   knowledge_base: KnowledgeBase,
   inferred: List(EffectAnnotation),
   returned_operators: Dict(String, types.EffectTerm),
   module_path: String,
+  declared_modules: Set(String),
 ) -> KnowledgeBase {
   let #(effects_dict, params_dict, returns_dict) =
     qualified_inferred(inferred, returned_operators, module_path)
+  let effects_dict = drop_declared_modules(effects_dict, declared_modules)
   fold_inferred_into_kb(knowledge_base, effects_dict, params_dict, returns_dict)
 }
 

--- a/src/graded/internal/annotation.gleam
+++ b/src/graded/internal/annotation.gleam
@@ -195,6 +195,20 @@ pub fn module_external_modules(file: GradedFile) -> set.Set(String) {
   |> set.from_list()
 }
 
+// Whether a qualified function name's module carries a module-level external.
+// Short-circuits when nothing is declared (the common case), so the qualified
+// name isn't split needlessly.
+fn in_external_module(
+  function: String,
+  external_modules: set.Set(String),
+) -> Bool {
+  use <- bool.guard(set.is_empty(external_modules), False)
+  case split_qualified_name(function) {
+    Ok(#(module, _function)) -> set.contains(external_modules, module)
+    Error(Nil) -> False
+  }
+}
+
 // Render a full GradedFile back to a string, preserving structure.
 pub fn format_file(file: GradedFile) -> String {
   file.lines
@@ -245,12 +259,8 @@ pub fn merge_inferred(
   let external_modules = module_external_modules(file)
   let inferred =
     list.filter(inferred, fn(annotation) {
-      let in_external_module = case split_qualified_name(annotation.function) {
-        Ok(#(module, _function)) -> set.contains(external_modules, module)
-        Error(Nil) -> False
-      }
       !set.contains(external_functions, annotation.function)
-      && !in_external_module
+      && !in_external_module(annotation.function, external_modules)
     })
 
   let inferred_map =

--- a/src/graded/internal/annotation.gleam
+++ b/src/graded/internal/annotation.gleam
@@ -239,9 +239,18 @@ pub fn merge_inferred(
       }
     })
     |> set.from_list()
+  // A module-level `external effects mod : [...]` declares the whole module's
+  // effect, so every inferred `effects mod.fn` line is likewise redundant and
+  // would shadow the declaration. Drop them all for the declared module.
+  let external_modules = module_external_modules(file)
   let inferred =
     list.filter(inferred, fn(annotation) {
+      let in_external_module = case split_qualified_name(annotation.function) {
+        Ok(#(module, _function)) -> set.contains(external_modules, module)
+        Error(Nil) -> False
+      }
       !set.contains(external_functions, annotation.function)
+      && !in_external_module
     })
 
   let inferred_map =

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -1011,6 +1011,38 @@ pub fn project_module_external_infer_omits_lines_and_governs_test() {
   go.effects |> should.equal(types.TLabels(set.from_list(["Database"])))
 }
 
+pub fn project_module_external_infer_filters_construction_kb_test() {
+  // A field wired to a declared-external module's function resolves through the
+  // construction index. The spec still carries a STALE `effects db.touch :
+  // [Stdout]` line; since function effects outrank module effects, that stale
+  // entry would pollute the construction knowledge base and make `graded infer`
+  // resolve `Runner.act` (and its caller `go`) to [Stdout] — disagreeing with
+  // `check`, which filters it. With the stale line dropped from the construction
+  // KB too, the field resolves to the declared [Database].
+  let root = "build/modext_construction_proj"
+  write_project(
+    root,
+    [
+      #("db.gleam", ffi_touch),
+      #(
+        "app.gleam",
+        "import db\n\n"
+          <> "pub type Runner {\n  Runner(act: fn() -> Nil)\n}\n\n"
+          <> "pub fn make() -> Runner {\n  Runner(act: db.touch)\n}\n\n"
+          <> "pub fn go(r: Runner) -> Nil {\n  r.act()\n}\n",
+      ),
+    ],
+    "external effects db : [Database]\neffects db.touch : [Stdout]\n",
+  )
+  let assert Ok(Nil) = graded.run_infer(root)
+
+  let assert Ok(content) = simplifile.read(root <> "/proj.graded")
+  let assert Ok(file) = annotation.parse_file(content)
+  let annotations = annotation.extract_annotations(file)
+  let assert Ok(go) = list.find(annotations, fn(a) { a.function == "app.go" })
+  go.effects |> should.equal(types.TLabels(set.from_list(["Database"])))
+}
+
 pub fn path_dep_cross_module_positional_discharges_test() {
   // Source-only path dep whose module `b` calls another module `a`'s
   // higher-order function POSITIONALLY (`a.apply(pure_cb)`). Inferring the dep

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -860,17 +860,17 @@ pub fn path_dep_module_external_keeps_returned_operator_test() {
   |> should.be_false()
 }
 
-// Write a multi-module project (each `#(filename, source)` at the project root)
-// plus its spec, run graded, and return the CheckResult for app.gleam. The
-// project-module counterpart of `run_path_dep_fixture`: the declared-external
-// module is a sibling project module, not a path dependency.
-fn run_project_module_fixture(
-  name: String,
+// An opaque FFI body graded infers as [Unknown]: the canonical declared-external
+// target across the module-external project fixtures below.
+const ffi_touch = "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n"
+
+// Write a fresh project at `root`: `name = "proj"` gleam.toml, each
+// `#(filename, source)` module at the root, and the `proj.graded` spec.
+fn write_project(
+  root: String,
   modules: List(#(String, String)),
   spec: String,
-  app_src: String,
-) -> types.CheckResult {
-  let root = "build/" <> name <> "_proj"
+) -> Nil {
   let _ = simplifile.delete(root)
   let assert Ok(Nil) = simplifile.create_directory_all(root)
   let assert Ok(Nil) =
@@ -881,7 +881,21 @@ fn run_project_module_fixture(
     Nil
   })
   let assert Ok(Nil) = simplifile.write(root <> "/proj.graded", spec)
-  let assert Ok(Nil) = simplifile.write(root <> "/app.gleam", app_src)
+  Nil
+}
+
+// Write a multi-module project (the extra `modules` plus an `app.gleam`) and its
+// spec, run graded, and return the CheckResult for app.gleam. The project-module
+// counterpart of `run_path_dep_fixture`: the declared-external module is a
+// sibling project module, not a path dependency.
+fn run_project_module_fixture(
+  name: String,
+  modules: List(#(String, String)),
+  spec: String,
+  app_src: String,
+) -> types.CheckResult {
+  let root = "build/" <> name <> "_proj"
+  write_project(root, [#("app.gleam", app_src), ..modules], spec)
 
   let assert Ok(results) = graded.run(root)
   let assert Ok(r) =
@@ -899,12 +913,7 @@ pub fn project_module_level_external_marks_pure_test() {
   let r =
     run_project_module_fixture(
       "modext_pure",
-      [
-        #(
-          "db.gleam",
-          "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
-        ),
-      ],
+      [#("db.gleam", ffi_touch)],
       "external effects db : []\n\ncheck app.caller : []\n",
       "import db\n\npub fn caller() -> Nil {\n  db.touch()\n}\n",
     )
@@ -920,12 +929,7 @@ pub fn project_module_level_external_preserves_effect_test() {
   let r =
     run_project_module_fixture(
       "modext_eff",
-      [
-        #(
-          "db.gleam",
-          "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
-        ),
-      ],
+      [#("db.gleam", ffi_touch)],
       "external effects db : [Database]\n\ncheck app.caller : []\n",
       "import db\n\npub fn caller() -> Nil {\n  db.touch()\n}\n",
     )
@@ -943,10 +947,7 @@ pub fn project_module_external_propagates_through_wrapper_test() {
     run_project_module_fixture(
       "modext_wrap",
       [
-        #(
-          "db.gleam",
-          "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
-        ),
+        #("db.gleam", ffi_touch),
         #(
           "wrapper.gleam",
           "import db\n\npub fn go() -> Nil {\n  db.touch()\n}\n",
@@ -990,25 +991,14 @@ pub fn project_module_external_infer_omits_lines_and_governs_test() {
   // calling into `db` inherits the declared [Database] — so `infer` and `check`
   // agree on the cross-module effect.
   let root = "build/modext_infer_proj"
-  let _ = simplifile.delete(root)
-  let assert Ok(Nil) = simplifile.create_directory_all(root)
-  let assert Ok(Nil) =
-    simplifile.write(root <> "/gleam.toml", "name = \"proj\"\n")
-  let assert Ok(Nil) =
-    simplifile.write(
-      root <> "/db.gleam",
-      "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
-    )
-  let assert Ok(Nil) =
-    simplifile.write(
-      root <> "/wrapper.gleam",
-      "import db\n\npub fn go() -> Nil {\n  db.touch()\n}\n",
-    )
-  let assert Ok(Nil) =
-    simplifile.write(
-      root <> "/proj.graded",
-      "external effects db : [Database]\n",
-    )
+  write_project(
+    root,
+    [
+      #("db.gleam", ffi_touch),
+      #("wrapper.gleam", "import db\n\npub fn go() -> Nil {\n  db.touch()\n}\n"),
+    ],
+    "external effects db : [Database]\n",
+  )
   let assert Ok(Nil) = graded.run_infer(root)
 
   let assert Ok(content) = simplifile.read(root <> "/proj.graded")

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -3,6 +3,7 @@ import gleam/dict
 import gleam/list
 import gleam/result
 import gleam/set
+import gleam/string
 import gleeunit/should
 import graded
 import graded/internal/annotation
@@ -857,6 +858,167 @@ pub fn path_dep_module_external_keeps_returned_operator_test() {
     )
   list.any(r.violations, fn(v) { v.function == "caller" })
   |> should.be_false()
+}
+
+// Write a multi-module project (each `#(filename, source)` at the project root)
+// plus its spec, run graded, and return the CheckResult for app.gleam. The
+// project-module counterpart of `run_path_dep_fixture`: the declared-external
+// module is a sibling project module, not a path dependency.
+fn run_project_module_fixture(
+  name: String,
+  modules: List(#(String, String)),
+  spec: String,
+  app_src: String,
+) -> types.CheckResult {
+  let root = "build/" <> name <> "_proj"
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) = simplifile.create_directory_all(root)
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/gleam.toml", "name = \"proj\"\n")
+  list.each(modules, fn(file) {
+    let #(path, content) = file
+    let assert Ok(Nil) = simplifile.write(root <> "/" <> path, content)
+    Nil
+  })
+  let assert Ok(Nil) = simplifile.write(root <> "/proj.graded", spec)
+  let assert Ok(Nil) = simplifile.write(root <> "/app.gleam", app_src)
+
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  r
+}
+
+pub fn project_module_level_external_marks_pure_test() {
+  // A project module `db` with an opaque FFI body graded would infer as
+  // [Unknown]. `external effects db : []` declares the whole module pure, so
+  // `db.touch` resolves to [] and `check caller : []` holds — the
+  // project-module counterpart of `path_dep_module_level_external_marks_pure`.
+  // Before the fix the in-memory inference of `db` left an [Unknown] in
+  // `all_effects` that shadowed the declaration.
+  let r =
+    run_project_module_fixture(
+      "modext_pure",
+      [
+        #(
+          "db.gleam",
+          "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
+        ),
+      ],
+      "external effects db : []\n\ncheck app.caller : []\n",
+      "import db\n\npub fn caller() -> Nil {\n  db.touch()\n}\n",
+    )
+  list.any(r.violations, fn(v) { v.function == "caller" })
+  |> should.be_false()
+}
+
+pub fn project_module_level_external_preserves_effect_test() {
+  // A non-empty module-level external propagates that exact set, it does not
+  // collapse to pure or stay an inferred [Unknown]. `external effects db :
+  // [Database]` makes `db.touch` resolve to [Database], so `check caller : []`
+  // fails with [Database].
+  let r =
+    run_project_module_fixture(
+      "modext_eff",
+      [
+        #(
+          "db.gleam",
+          "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
+        ),
+      ],
+      "external effects db : [Database]\n\ncheck app.caller : []\n",
+      "import db\n\npub fn caller() -> Nil {\n  db.touch()\n}\n",
+    )
+  let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "caller" })
+  v.actual |> should.equal(types.Specific(set.from_list(["Database"])))
+}
+
+pub fn project_module_external_propagates_through_wrapper_test() {
+  // A module-level external governs its module DURING the project's in-memory
+  // inference. The sibling `wrapper.go` calls the declared-pure `db.touch`; were
+  // `db.touch` inferred [Unknown] and only dropped at final lookup, `wrapper.go`
+  // would be polluted. It resolves to [] instead, so `check caller : []` holds
+  // through the wrapper.
+  let r =
+    run_project_module_fixture(
+      "modext_wrap",
+      [
+        #(
+          "db.gleam",
+          "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
+        ),
+        #(
+          "wrapper.gleam",
+          "import db\n\npub fn go() -> Nil {\n  db.touch()\n}\n",
+        ),
+      ],
+      "external effects db : []\n\ncheck app.caller : []\n",
+      "import wrapper\n\npub fn caller() -> Nil {\n  wrapper.go()\n}\n",
+    )
+  list.any(r.violations, fn(v) { v.function == "caller" })
+  |> should.be_false()
+}
+
+pub fn project_module_external_keeps_returned_operator_test() {
+  // A module-level external suppresses only the call effect, not the
+  // returned-operator metadata. `db.make` returns a pure closure; `wrapper` does
+  // `let action = db.make()  action()`. With `external effects db : []`, the call
+  // to `make` resolves to [] and `action()` resolves through `make`'s kept
+  // returned operator, so `check caller : []` holds. Dropping the returned
+  // operator would leave `action()` as [Unknown] and fail the check.
+  let r =
+    run_project_module_fixture(
+      "modext_ret",
+      [
+        #("db.gleam", "pub fn make() -> fn() -> Nil {\n  fn() { Nil }\n}\n"),
+        #(
+          "wrapper.gleam",
+          "import db\n\npub fn go() -> Nil {\n  let action = db.make()\n  action()\n}\n",
+        ),
+      ],
+      "external effects db : []\n\ncheck app.caller : []\n",
+      "import wrapper\n\npub fn caller() -> Nil {\n  wrapper.go()\n}\n",
+    )
+  list.any(r.violations, fn(v) { v.function == "caller" })
+  |> should.be_false()
+}
+
+pub fn project_module_external_infer_omits_lines_and_governs_test() {
+  // `graded infer` over a project with `external effects db : [Database]` writes
+  // no inferred `effects db.*` lines (the declaration governs the module, like a
+  // function-level external suppresses its own line), and a sibling `wrapper.go`
+  // calling into `db` inherits the declared [Database] — so `infer` and `check`
+  // agree on the cross-module effect.
+  let root = "build/modext_infer_proj"
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) = simplifile.create_directory_all(root)
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/gleam.toml", "name = \"proj\"\n")
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/db.gleam",
+      "@external(erlang, \"d\", \"t\")\npub fn touch() -> Nil\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/wrapper.gleam",
+      "import db\n\npub fn go() -> Nil {\n  db.touch()\n}\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/proj.graded",
+      "external effects db : [Database]\n",
+    )
+  let assert Ok(Nil) = graded.run_infer(root)
+
+  let assert Ok(content) = simplifile.read(root <> "/proj.graded")
+  let assert Ok(file) = annotation.parse_file(content)
+  let annotations = annotation.extract_annotations(file)
+  list.any(annotations, fn(a) { string.starts_with(a.function, "db.") })
+  |> should.be_false()
+  let assert Ok(go) =
+    list.find(annotations, fn(a) { a.function == "wrapper.go" })
+  go.effects |> should.equal(types.TLabels(set.from_list(["Database"])))
 }
 
 pub fn path_dep_cross_module_positional_discharges_test() {


### PR DESCRIPTION
## Problem

A module-level `external effects myapp/db : [Database]` was honored for dependencies (#32) but **shadowed for the consumer's own project modules**. The knowledge base resolves a name by checking per-function `all_effects` before module-level `module_effects` (`effects.lookup`), and graded's in-memory inference of the project module's source left a per-function entry in `all_effects` that won over the declaration — so a declared module's functions resolved to the inferred effect (e.g. an FFI `[Unknown]`) rather than the declared set.

## Fix

Mirrors the path-dependency `drop_declared_modules` handling, extended to project modules:

- **Check path** — `infer_project_in_memory` threads the declared modules through and drops the inferred *call effect* for them, so lookup falls through to the declared set in `module_effects`.
- **Infer path** — `infer_one_module` drops the same when threading into the KB, so a sibling module calling into a declared module agrees between `check` and `infer`.
- **Shared `thread_inferred_into_kb`** carries the drop, keeping returned-operator and parameter-bound metadata (those describe what a function returns / how it consumes operator arguments, not its call effect).
- **`merge_inferred`** stops `graded infer` writing per-function `effects` lines for a declared module, matching how a per-function external already suppresses its own line.
- **Committed-spec read** is guarded so a stale or hand-written `effects` line can't reshadow.

A per-function `external effects mod.fn` or an authoritative dependency spec/catalog effect still takes precedence.

## Tests

Five new integration tests mirroring the path-dep module-external tests, but with the declared module being a sibling **project** module:

- module-level external marks a project module pure;
- non-empty external propagates the exact set (`[Database]`, not flattened to `[]` or left `[Unknown]`);
- governs through a project wrapper during in-memory inference;
- keeps returned-operator metadata (`let action = db.make(); action()`);
- `graded infer` round-trip: no `effects db.*` lines written and a sibling caller inherits the declared `[Database]`.

Confirmed 4/5 fail without the core drop. Full suite **458 pass**, glinter and format clean.

## Docs

- `CHANGELOG.md` (Unreleased → Fixed) entry.
- `docs/REFERENCE.md` corrected — it previously documented the shadowing as intended behavior.