### PR TITLE
Resolve function-typed fields on dependency-defined types

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -270,6 +270,15 @@ isn't a traceable function — it falls back to `[Unknown]`. The escape hatch is
 `type` line, or a [field bound](#field-bounds) when the assertion belongs at a single
 function boundary; see [LIMITATIONS.md](./LIMITATIONS.md).
 
+**Dependency-defined types.** The receiver type a field call resolves to can belong
+to a dependency, so a `type` line may name a dependency module
+(`type dep/repo.Repo.find : [Storage]`). This works for both path and published
+dependencies — girard reads the dependency's source to type the receiver. A
+dependency can also **ship** its own `type` lines in its committed spec file; a
+consumer picks them up automatically, the same way it inherits a dependency's
+`effects` and `external` annotations, so the capability-record pattern needs no
+per-consumer re-declaration. A consumer's own `type` line still wins on a clash.
+
 ## External declarations and FFI
 
 `external effects` annotates a function graded can't see into, without touching the

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -137,7 +137,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
     signatures.load_from_packages_dir(packages_dir(package_root))
     |> signatures.merge(path_dep_registry(package_root))
   let registry = signatures.merge(dep_registry, build_project_registry(index))
-  let type_info = build_type_index(index)
+  let type_info = build_type_index(index, package_root)
 
   // Hand-written `type` lines (last) win over the inferred construction index.
   let kb_base =
@@ -603,7 +603,7 @@ pub fn run_infer(directory: String) -> Result(Nil, GradedError) {
     signatures.load_from_packages_dir(packages_dir(package_root))
     |> signatures.merge(path_dep_registry(package_root))
   let registry = signatures.merge(dep_registry, build_project_registry(index))
-  let type_info = build_type_index(index)
+  let type_info = build_type_index(index, package_root)
 
   use #(_kb, public_annotations, public_returns) <- result.try(
     list.try_fold(sorted, #(base_kb, [], []), fn(state, module_path) {
@@ -905,10 +905,14 @@ fn merge_field_effect(
 // so the checker silently falls back to syntax-level resolution for it.
 fn build_type_index(
   index: Dict(String, #(String, glance.Module)),
+  package_root: String,
 ) -> typeinfo.TypeInfo {
   let options =
     girard.default_options()
-    |> girard.with_resolver(build_girard_resolver(index))
+    |> girard.with_resolver(build_girard_resolver(
+      index,
+      dependency_module_files(package_root),
+    ))
   let entries =
     dict.to_list(index)
     |> list.map(fn(pair) {
@@ -993,18 +997,27 @@ fn fn_typed_names(
 }
 
 // A girard `Resolver` that resolves graded's own project modules from `index`
-// first (so non-`src` layouts like `test/fixtures` work), then falls through
-// to girard's stock disk resolver for dependencies and stdlib under
-// `build/packages`.
+// first (so non-`src` layouts like `test/fixtures` work), then dependency
+// modules from `dep_files` (installed deps under `build/packages` and path deps
+// at their declared location, both keyed package-root-relative). The stock disk
+// resolver is the last resort: it reads `build/packages` relative to the process
+// cwd, which misses path deps entirely and misses installed deps when graded is
+// invoked from outside the package root — so a dependency-defined type on a
+// parameter would leave the receiver untyped and its field calls `[Unknown]`.
 fn build_girard_resolver(
   index: Dict(String, #(String, glance.Module)),
+  dep_files: Dict(String, String),
 ) -> fn(String) -> Result(String, Nil) {
   let disk = girard.disk_resolver()
   fn(module_path) {
     case dict.get(index, module_path) {
       Ok(#(gleam_path, _module)) ->
         simplifile.read(gleam_path) |> result.replace_error(Nil)
-      Error(Nil) -> disk(module_path)
+      Error(Nil) ->
+        case dict.get(dep_files, module_path) {
+          Ok(file) -> simplifile.read(file) |> result.replace_error(Nil)
+          Error(Nil) -> disk(module_path)
+        }
     }
   }
 }
@@ -1472,9 +1485,14 @@ fn enrich_with_path_deps(
     let spec_path = config.spec_file_for(resolved_dep_path, name)
     case simplifile.is_file(spec_path) {
       Ok(True) -> {
-        let #(effs, params, returns) =
+        // A committed path-dep spec can also ship `type` field effects for the
+        // dep's own types; load them so a consumer resolves those fields without
+        // re-declaring them. The infer-from-source fallback has no spec, so no
+        // hand-written `type` lines to load.
+        let #(effs, params, returns, type_fields) =
           effects.load_dep_spec(resolved_dep_path, name)
         fold_inferred_into_kb(kb, effs, params, returns)
+        |> effects.with_type_fields(type_fields)
       }
       _ ->
         case infer_path_dep(resolved_dep_path, kb, consumer_modules) {

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -59,10 +59,10 @@ pub fn load_knowledge_base(
   packages_directory: String,
   manifest_path: String,
 ) -> KnowledgeBase {
-  let #(dep_effects, dep_params, dep_returns) =
+  let #(dep_effects, dep_params, dep_returns, dep_type_fields) =
     load_dependencies(packages_directory)
   let catalog_dir = find_catalog_directory()
-  let #(cat_effects, cat_module_effects, cat_params) =
+  let #(cat_effects, cat_module_effects, cat_params, cat_type_fields) =
     load_catalog(catalog_dir, manifest_path)
   KnowledgeBase(
     // Dependency entries win on a clash: dict.merge keeps its second argument.
@@ -73,12 +73,15 @@ pub fn load_knowledge_base(
     factories: dict.new(),
     module_effects: cat_module_effects,
   )
+  // Catalog `type` fields first, then dependency ones (appended last, so they
+  // win on a clash) — matching the effect priority (dependency spec > catalog).
+  |> with_type_fields(list.append(cat_type_fields, dep_type_fields))
 }
 
 // Build a knowledge base from the catalog only (no dependency scanning).
 pub fn empty_knowledge_base() -> KnowledgeBase {
   let catalog_dir = find_catalog_directory()
-  let #(cat_effects, cat_module_effects, cat_params) =
+  let #(cat_effects, cat_module_effects, cat_params, cat_type_fields) =
     load_catalog(catalog_dir, "manifest.toml")
   KnowledgeBase(
     all_effects: cat_effects,
@@ -88,6 +91,7 @@ pub fn empty_knowledge_base() -> KnowledgeBase {
     factories: dict.new(),
     module_effects: cat_module_effects,
   )
+  |> with_type_fields(cat_type_fields)
 }
 
 // Look up a type field's resolved effect (with any polymorphic bounds/source).
@@ -339,13 +343,17 @@ pub fn load_spec_effects_from_file(
   fold_spec_effects(annotation.extract_annotations(file))
 }
 
-// Load one package's spec into its effects, polymorphic param bounds, and
-// returned-operator maps, keyed by `QualifiedName`. Reads the spec via the
-// package's own `[tools.graded]` config (defaulting to `<package_name>.graded`)
-// at `dep_root`. Empty maps when the spec is missing or unparseable. Shared by
-// the `build/packages` dependency scan and path-dependency enrichment so both
-// dep kinds load identical metadata — effects alone would drop the bounds a
-// higher-order callee needs to discharge its callback's effect at the call site.
+// Load one package's spec into its effects, polymorphic param bounds,
+// returned-operator maps, and hand-written `type` field annotations. The first
+// three are keyed by `QualifiedName`; the `type` fields stay a list (applied via
+// `with_type_fields`, whose insert order decides priority against the project
+// spec). Reads the spec via the package's own `[tools.graded]` config
+// (defaulting to `<package_name>.graded`) at `dep_root`, once. Empty when the
+// spec is missing or unparseable. Shared by the `build/packages` dependency scan
+// and path-dependency enrichment so both dep kinds load identical metadata —
+// effects alone would drop the bounds a higher-order callee needs to discharge
+// its callback's effect, or the `type` fields a capability record on the dep's
+// own types needs to resolve at a consumer's call site.
 pub fn load_dep_spec(
   dep_root: String,
   package_name: String,
@@ -353,9 +361,10 @@ pub fn load_dep_spec(
   Dict(QualifiedName, EffectTerm),
   Dict(QualifiedName, List(ParamBound)),
   Dict(QualifiedName, EffectTerm),
+  List(TypeFieldAnnotation),
 ) {
   case read_spec_file(config.spec_file_for(dep_root, package_name)) {
-    Error(_) -> #(dict.new(), dict.new(), dict.new())
+    Error(_) -> #(dict.new(), dict.new(), dict.new(), [])
     Ok(file) -> {
       let #(effect_map, param_map) =
         list.fold(
@@ -363,7 +372,12 @@ pub fn load_dep_spec(
           #(dict.new(), dict.new()),
           fold_qualified_annotation,
         )
-      #(effect_map, param_map, load_spec_returns_from_file(file))
+      #(
+        effect_map,
+        param_map,
+        load_spec_returns_from_file(file),
+        annotation.extract_type_fields(file),
+      )
     }
   }
 }
@@ -483,15 +497,17 @@ pub fn lookup_returned_operator(
 // For each installed package, locate its spec file via the package's own
 // `[tools.graded]` config (defaulting to `<package_name>.graded`), then read
 // and parse it *once*, folding its qualified `effects`/`check` annotations
-// into the global effect/param maps and its `returns` lines into the
-// returned-operator map. Packages with no spec file are silently skipped —
-// same fail-soft semantics as the catalog and the old per-module reader.
+// into the global effect/param maps, its `returns` lines into the
+// returned-operator map, and its `type` field lines into a flat list. Packages
+// with no spec file are silently skipped — same fail-soft semantics as the
+// catalog and the old per-module reader.
 fn load_dependencies(
   packages_directory: String,
 ) -> #(
   Dict(QualifiedName, EffectTerm),
   Dict(QualifiedName, List(ParamBound)),
   Dict(QualifiedName, EffectTerm),
+  List(TypeFieldAnnotation),
 ) {
   let entries = case simplifile.read_directory(packages_directory) {
     Ok(found) -> found
@@ -499,16 +515,17 @@ fn load_dependencies(
   }
   list.fold(
     entries,
-    #(dict.new(), dict.new(), dict.new()),
+    #(dict.new(), dict.new(), dict.new(), []),
     fn(acc, package_name) {
-      let #(effect_map, param_map, returns_map) = acc
+      let #(effect_map, param_map, returns_map, type_fields) = acc
       let dep_root = packages_directory <> "/" <> package_name
-      let #(new_effects, new_params, new_returns) =
+      let #(new_effects, new_params, new_returns, new_type_fields) =
         load_dep_spec(dep_root, package_name)
       #(
         dict.merge(effect_map, new_effects),
         dict.merge(param_map, new_params),
         dict.merge(returns_map, new_returns),
+        list.append(type_fields, new_type_fields),
       )
     },
   )
@@ -556,6 +573,7 @@ type CatalogAcc {
     module_effects: Dict(String, EffectTerm),
     poly_effects: Dict(QualifiedName, EffectTerm),
     poly_params: Dict(QualifiedName, List(ParamBound)),
+    type_fields: List(TypeFieldAnnotation),
   )
 }
 
@@ -566,6 +584,7 @@ fn load_catalog(
   Dict(QualifiedName, EffectTerm),
   Dict(String, EffectTerm),
   Dict(QualifiedName, List(ParamBound)),
+  List(TypeFieldAnnotation),
 ) {
   let installed_versions = parse_manifest_versions(manifest_path)
   let catalog_files = case simplifile.get_files(catalog_dir) {
@@ -574,12 +593,12 @@ fn load_catalog(
     Error(_) -> []
   }
   let selected = resolve_catalog_files(catalog_files, installed_versions)
-  let initial = CatalogAcc(dict.new(), dict.new(), dict.new(), dict.new())
+  let initial = CatalogAcc(dict.new(), dict.new(), dict.new(), dict.new(), [])
   let acc = list.fold(selected, initial, fold_catalog_file)
   // Explicit `effects` annotations in the catalog take precedence over the
   // module-level `external effects` markers.
   let all_effects = dict.merge(acc.ext_effects, acc.poly_effects)
-  #(all_effects, acc.module_effects, acc.poly_params)
+  #(all_effects, acc.module_effects, acc.poly_params, acc.type_fields)
 }
 
 // Fold one catalog file into the accumulator. `external effects` lines
@@ -616,6 +635,10 @@ fn fold_catalog_file(acc: CatalogAcc, file_path: String) -> CatalogAcc {
             module_effects: kb.module_effects,
             poly_effects:,
             poly_params:,
+            type_fields: list.append(
+              acc.type_fields,
+              annotation.extract_type_fields(graded_file),
+            ),
           )
         }
       }

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -521,3 +521,27 @@ pub fn type_fields_distinguish_modules_test() {
   effect_term.to_effect_set(b.effects)
   |> should.equal(Specific(set.from_list(["Stdout"])))
 }
+
+pub fn load_knowledge_base_loads_dependency_type_fields_test() {
+  // A dependency's committed spec under `build/packages` carries a module-
+  // qualified `type` line. `load_knowledge_base` must fold it into the registry
+  // so a consumer's field call against that dependency type resolves, rather
+  // than dropping `type` lines as it did before.
+  let packages = "build/eff_dep_typefield/packages"
+  let _ = simplifile.delete("build/eff_dep_typefield")
+  let assert Ok(Nil) = simplifile.create_directory_all(packages <> "/dep")
+  let assert Ok(Nil) =
+    simplifile.write(
+      packages <> "/dep/dep.graded",
+      "type dep/repo.Repo.find : [Storage]\n",
+    )
+
+  let kb = effects.load_knowledge_base(packages, "missing_manifest.toml")
+  let assert Ok(field) =
+    effects.lookup_type_field(kb, "dep/repo", "Repo", "find")
+  effect_term.to_effect_set(field.effects)
+  |> should.equal(Specific(set.from_list(["Storage"])))
+
+  let _ = simplifile.delete("build/eff_dep_typefield")
+  Nil
+}

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -1095,3 +1095,121 @@ pub fn path_dep_cross_module_positional_discharges_test() {
   let _ = simplifile.delete(dep_root)
   Nil
 }
+
+// ----- function-typed fields on dependency-defined types -----
+
+pub fn path_dep_type_field_resolves_from_consumer_spec_test() {
+  // A path dep defines a capability record `Repo(find: fn(String) -> Int)`. The
+  // consumer calls `r.find(...)` through a parameter typed by the dependency,
+  // and annotates that field in its OWN spec with a module-qualified `type`
+  // line. graded must type the receiver as the dependency's nominal type
+  // (`dep/repo.Repo`) so the `#(module, type, field)` lookup hits — which means
+  // girard has to read the path dependency's source, not just `build/packages`.
+  // Before the fix the receiver type was unresolved and the call leaked
+  // [Unknown]; now it resolves to the annotated [Storage].
+  let r =
+    run_path_dep_fixture(
+      "pd_typefield_consumer",
+      [#("repo.gleam", "pub type Repo {\n  Repo(find: fn(String) -> Int)\n}\n")],
+      "type repo.Repo.find : [Storage]\n\ncheck app.use_field : []\n",
+      "import repo.{type Repo}\n\n"
+        <> "pub fn use_field(r: Repo) -> Int {\n  r.find(\"x\")\n}\n",
+    )
+  let assert Ok(v) =
+    list.find(r.violations, fn(v) { v.function == "use_field" })
+  v.actual |> should.equal(types.Specific(set.from_list(["Storage"])))
+}
+
+pub fn path_dep_ships_type_field_test() {
+  // The dependency itself ships the `type` annotation in its committed
+  // `dep.graded`; the consumer declares no field annotation at all. graded must
+  // load the dependency spec's `type` lines (not just its `effects`) so the
+  // consumer's `r.find(...)` resolves to the dependency-declared [Storage].
+  let app_root = "build/pd_ships_typefield_app"
+  let dep_root = "build/pd_ships_typefield_dep"
+  let _ = simplifile.delete(app_root)
+  let _ = simplifile.delete(dep_root)
+
+  let assert Ok(Nil) = simplifile.create_directory_all(dep_root <> "/src/dep")
+  let assert Ok(Nil) =
+    simplifile.write(dep_root <> "/gleam.toml", "name = \"dep\"\n")
+  let assert Ok(Nil) =
+    simplifile.write(
+      dep_root <> "/src/dep/repo.gleam",
+      "pub type Repo {\n  Repo(find: fn(String) -> Int)\n}\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      dep_root <> "/dep.graded",
+      "type dep/repo.Repo.find : [Storage]\n",
+    )
+
+  let assert Ok(Nil) = simplifile.create_directory_all(app_root)
+  let assert Ok(Nil) =
+    simplifile.write(
+      app_root <> "/gleam.toml",
+      "name = \"app\"\n\n[dependencies]\ndep = { path = \"../pd_ships_typefield_dep\" }\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(app_root <> "/app.graded", "check app.use_field : []\n")
+  let assert Ok(Nil) =
+    simplifile.write(
+      app_root <> "/app.gleam",
+      "import dep/repo.{type Repo}\n\n"
+        <> "pub fn use_field(r: Repo) -> Int {\n  r.find(\"x\")\n}\n",
+    )
+
+  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
+  let assert Ok(v) =
+    list.find(r.violations, fn(v) { v.function == "use_field" })
+  v.actual |> should.equal(types.Specific(set.from_list(["Storage"])))
+
+  let _ = simplifile.delete(app_root)
+  let _ = simplifile.delete(dep_root)
+  Nil
+}
+
+pub fn installed_dep_ships_type_field_test() {
+  // The reporter's primary case: a published (under `build/packages`) dependency
+  // ships its own `type` field effects. The fixture lives under the gitignored
+  // `build/` so its `build/packages` resolves package-root-relative — exercising
+  // both the dependency-aware girard resolver (to type the receiver) and
+  // dependency `type`-field loading (to resolve the field). The consumer writes
+  // no annotation; `r.find(...)` must resolve to the dependency's [Storage].
+  let root = "build/installed_typefield_fixture"
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) =
+    simplifile.create_directory_all(root <> "/build/packages/dep/src/dep")
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/gleam.toml", "name = \"app\"\n")
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/app.graded", "check app.use_field : []\n")
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/build/packages/dep/src/dep/repo.gleam",
+      "pub type Repo {\n  Repo(find: fn(String) -> Int)\n}\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/build/packages/dep/dep.graded",
+      "type dep/repo.Repo.find : [Storage]\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/app.gleam",
+      "import dep/repo.{type Repo}\n\n"
+        <> "pub fn use_field(r: Repo) -> Int {\n  r.find(\"x\")\n}\n",
+    )
+
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert Ok(v) =
+    list.find(r.violations, fn(v) { v.function == "use_field" })
+  v.actual |> should.equal(types.Specific(set.from_list(["Storage"])))
+
+  let _ = simplifile.delete(root)
+  Nil
+}


### PR DESCRIPTION
## Problem

A function-typed record field called through a receiver whose type is **defined in a dependency** resolved to `[Unknown]`, even with a module-qualified `type` line. The capability-record / DI pattern (`Repo(find: fn(String) -> Int)`) is idiomatic in Gleam, so this forced consumers into repetitive per-call-site `check` bounds. Reported in https://gist.github.com/alvivi/324042bd0e6aee23a5c357d1520ba49a.

Two independent gaps caused it.

## Fix 1 — dependency-aware girard resolver

graded types receivers via girard, which resolved imports through its stock disk resolver. That resolver reads `build/packages` **relative to the process cwd**, so it never saw path dependencies, and missed installed dependencies whenever graded ran from outside the package root. The receiver stayed untyped, and `receiver.field(...)` fell back to `[Unknown]`.

`build_girard_resolver` now consults a package-root-relative dependency module map (path deps at their declared location, installed deps under `build/packages`) before the disk resolver — reusing the map already built for the spec lint.

## Fix 2 — load dependency-shipped `type` fields

`type` field annotations were only ever loaded from the project's own spec. They now also load from:

- installed dependency specs (`build/packages/<dep>/<dep>.graded`)
- path-dependency specs
- the versioned catalog

so a dependency can ship the effects of its own types' fields and consumers inherit them automatically — the same way `effects`/`external` annotations already flow. Priority is preserved: project spec > path dep > installed dep > catalog; a consumer's own `type` line wins on a clash.

## Tests

Four regression tests (written first, confirmed red before the fix):

- `path_dep_type_field_resolves_from_consumer_spec_test` — consumer-declared field on a path-dep type (Fix 1)
- `path_dep_ships_type_field_test` — path dep ships its own `type` line; consumer declares nothing
- `installed_dep_ships_type_field_test` — the reporter's `build/packages` case, end-to-end
- `load_knowledge_base_loads_dependency_type_fields_test` — unit-level pin for dep-spec loading

Full suite: 463 passing, format clean. Also verified the reporter's exact repro through the real CLI — a dependency shipping its own `type` line, consumer declaring nothing, resolves to the dependency-declared effect.

REFERENCE.md gains a section documenting dependency-defined type fields.