### PR TITLE
Add CONTRIBUTING guide and commit/branch CI checks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Lint the commit message against the seven rules (config in .gitlint).
+# Skips with a warning if gitlint is not installed; CI enforces regardless.
+
+if command -v gitlint >/dev/null 2>&1; then
+	gitlint --msg-filename "$1" || exit 1
+else
+	echo "commit-msg: gitlint not found, skipping local check (CI still enforces)." >&2
+	echo "commit-msg: install with 'pip install gitlint' for local feedback." >&2
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Reject pushing a branch whose name uses a git-flow / conventional prefix.
+# Mirrors the branch-name job in .github/workflows/commit-checks.yml.
+
+forbidden='^(feat|feature|fix|bugfix|hotfix|release|chore|docs|refactor|test|ci|build|perf|style)/'
+status=0
+
+while read -r local_ref _local_sha _remote_ref _remote_sha; do
+	case "$local_ref" in
+		refs/heads/*) branch=${local_ref#refs/heads/} ;;
+		*) continue ;;
+	esac
+	if printf '%s' "$branch" | grep -qiE "$forbidden"; then
+		echo "pre-push: branch '$branch' uses a git-flow/conventional prefix." >&2
+		echo "pre-push: rename it to a short, descriptive kebab-case name." >&2
+		status=1
+	fi
+done
+
+exit $status

--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -1,0 +1,36 @@
+name: Commit checks
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  commit-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install gitlint
+        run: pip install gitlint
+
+      - name: Lint commit messages
+        run: gitlint --commits ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+
+  branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject git-flow / conventional branch prefixes
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          if printf '%s' "$BRANCH" | grep -qiE '^(feat|feature|fix|bugfix|hotfix|release|chore|docs|refactor|test|ci|build|perf|style)/'; then
+            echo "::error::Branch '$BRANCH' uses a git-flow/conventional prefix. Use a short, descriptive kebab-case name (e.g. dependency-field-resolution)."
+            exit 1
+          fi
+          echo "Branch name '$BRANCH' OK"

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,26 @@
+# gitlint config — enforces the mechanical half of the seven rules
+# (https://chris.beams.io/posts/git-commit/#seven-rules). Imperative mood and
+# "what & why, not how" are not machine-checkable; CONTRIBUTING.md covers them.
+
+[general]
+# Single-line commits are fine; don't require a body.
+ignore=body-is-missing
+ignore-merge-commits=true
+ignore-fixup-commits=true
+ignore-revert-commits=true
+
+# Rule 2 (target is 50; 72 is Beams' hard limit and matches this repo's style).
+[title-max-length]
+line-length=72
+
+[title-min-length]
+min-length=5
+
+# Rule 3: capitalized subject. A capital first letter also rejects the
+# lowercase Conventional Commits prefixes (feat:, fix:, chore:, …).
+[title-match-regex]
+regex=^[A-Z]
+
+# Rule 6: wrap the body at 72.
+[body-max-line-length]
+line-length=72

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ gleam run -m graded format --check [dir]   # CI mode, exits non-zero on diffs
 gleam run -m graded format --stdin         # editor integration: format from stdin
 ```
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the local dev loop (the CI gates to run before pushing), how to add a catalog entry, and the code/changelog/commit conventions.
+
 Tests use **gleeunit** with **qcheck** property generators in `test/generators.gleam`. Gleam fixture sources live in `test/fixtures/` with a single `test/fixtures/fixtures.graded` spec file containing all the integration test annotations (qualified by source module). Integration tests load these real fixtures end-to-end.
 
 ## Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to graded
+
+Thanks for helping out. This file is the dev loop and house conventions; for
+*what the code is* (architecture, design decisions, effect resolution) read
+[AGENTS.md](AGENTS.md) and [docs/](docs/).
+
+The audience here is both human contributors and coding agents, so it is
+command-first: run the commands, match the conventions, and a change is
+mergeable.
+
+## Setup
+
+Versions are pinned in [`.tool-versions`](.tool-versions). With `asdf` or
+`mise`:
+
+```sh
+asdf install                 # Erlang + Gleam at the pinned versions
+gleam deps download
+gleam build
+gleam test
+git config core.hooksPath .githooks   # local commit-msg + branch-name hooks
+pip install gitlint                    # optional: local commit-message linting
+```
+
+The hooks in [`.githooks/`](.githooks/) mirror the `Commit checks` CI: a
+`commit-msg` hook runs gitlint (a no-op if gitlint is not installed) and a
+`pre-push` hook rejects git-flow / conventional branch prefixes. `core.hooksPath`
+is per-clone, so the `git config` line above is needed once after cloning.
+
+## Pre-flight checklist
+
+CI runs four gates, in this order. Run them locally before pushing — green here
+means green on CI:
+
+```sh
+gleam format --check src/ test/    # formatting (test/ too, not just src/)
+gleam build --warnings-as-errors   # no warnings allowed
+gleam test                         # full suite
+gleam run -m glinter               # lint; warnings_as_errors = true
+```
+
+`gleam format src/ test/` (no `--check`) fixes formatting in place.
+
+## Adding a catalog entry
+
+The versioned catalog under [`priv/catalog/`](priv/catalog/) ships effect specs
+for third-party Gleam packages, so consumers resolve calls into those packages
+without writing their own annotations. Adding one is the most self-contained way
+to contribute.
+
+1. Create `priv/catalog/{package}@{version}.graded`. The version is the lowest
+   release whose surface the file describes; at resolution time graded picks the
+   highest catalog version `<= ` the consumer's installed version.
+2. Write `effects` / `external effects` / `type` lines with **module-qualified**
+   names. The grammar, every annotation kind, and the effect-set syntax are in
+   [docs/REFERENCE.md](docs/REFERENCE.md); existing entries (e.g.
+   `gleam_stdlib@0.70.0.graded`, `lustre@5.0.0.graded`) are working examples.
+3. `gleam test` — [`test/release_test.gleam`](test/release_test.gleam)
+   validates catalog entries and lints spec lines that match nothing.
+
+## Tests
+
+- gleeunit, one `*_test.gleam` per module under [`test/`](test/); public test
+  functions are suffixed `_test`.
+- Property tests use [qcheck](https://hexdocs.pm/qcheck/); generators live in
+  [`test/generators.gleam`](test/generators.gleam).
+- Integration fixtures: put Gleam sources under
+  [`test/fixtures/`](test/fixtures/) and their annotations (module-qualified)
+  into the single `test/fixtures/fixtures.graded`. Integration tests load these
+  end-to-end.
+
+Add or update a test with every behaviour change.
+
+## Conventions
+
+- **Gleam idioms.** Follow Gleam's
+  [conventions, patterns, and anti-patterns](https://gleam.run/documentation/conventions-patterns-and-anti-patterns/).
+  The ones that come up most here:
+  - Return `Result` for fallible functions; never `panic` to signal an error
+    a caller could handle.
+  - Replace `Bool` with custom types, and make invalid states impossible —
+    encode the rule in the type rather than checking it at runtime.
+  - Match all variants explicitly; avoid catch-all `_` patterns so the compiler
+    keeps flagging unhandled cases.
+  - Annotate every module function's arguments and return type.
+
+  Keep new code reading like its neighbours.
+- **Comments say what, not why.** Same for changelog and doc prose. Don't
+  reference internal planning docs or this guide from code.
+- **Doc-comment slashes.** `///` / `////` only on the public API
+  (`src/graded.gleam`); use `//` everywhere internal — private entities,
+  `src/graded/internal/`, and tests.
+- **No circular dependencies** between the modules under `src/graded/internal/`.
+
+## Changelog & commits
+
+- Record every notable change in [CHANGELOG.md](CHANGELOG.md). The format is
+  [Keep a Changelog](https://keepachangelog.com/) and the project follows
+  [SemVer](https://semver.org/). Entries lead with a **bold one-sentence
+  summary** of the observable change, then explain — match the existing style.
+- Version bumps and `Release vX.Y.Z` commits are cut by the maintainer.
+- Branch off `main` with a short, descriptive kebab-case name
+  (`dependency-field-resolution`). This project does not use git-flow — no
+  `feature/`, `fix/`, `release/`, or similar prefixes.
+
+### Commit messages
+
+Follow [the seven rules of a great commit message](https://chris.beams.io/posts/git-commit/#seven-rules):
+
+1. Separate subject from body with a blank line.
+2. Limit the subject line to 50 characters.
+3. Capitalize the subject line.
+4. Do not end the subject line with a period.
+5. Use the imperative mood in the subject line ("Resolve …", not "Resolved …").
+6. Wrap the body at 72 characters.
+7. Use the body to explain what and why, not how.
+
+Do **not** use [Conventional Commits](https://www.conventionalcommits.org/) —
+no `feat:` / `fix:` / `chore:` prefixes. Write commit messages and PR
+descriptions as your own work, and do not add AI-attribution trailers
+(`Co-Authored-By: Claude …`, "Generated with …", and the like).
+
+A `Commit checks` workflow enforces the mechanical rules on every PR via
+[gitlint](https://jorisroovers.github.io/gitlint/) (subject ≤ 72, capitalized,
+no trailing period, body wrapped at 72; config in [`.gitlint`](.gitlint)) and
+rejects git-flow / conventional branch prefixes. Imperative mood and the
+what-and-why body are on you.


### PR DESCRIPTION
## What

- **CONTRIBUTING.md** — local setup, the four CI pre-flight gates, how to add a
  `priv/catalog/` entry, testing conventions, Gleam idioms (linking the official
  conventions page), the seven-rule commit style, and kebab-case branch naming.
  Referenced from `AGENTS.md`.
- **Commit checks workflow** (`.github/workflows/commit-checks.yml`) — runs on
  PRs: `gitlint` lints commit messages against the mechanical seven rules, and a
  dependency-free step rejects git-flow / conventional branch prefixes.
- **`.gitlint`** — encodes the rules (subject ≤ 72, capitalized, no trailing
  period, body wrapped at 72; single-line commits allowed).
- **`.githooks/`** — `commit-msg` (gitlint, no-op if not installed) and
  `pre-push` (branch-name check) mirror the CI locally, wired via
  `core.hooksPath`.

## Notes

- Subject hard-limit is **72**, not Beams' 50, because existing commits run
  54–66 chars. Flip `title-max-length` in `.gitlint` to tighten.
- The workflow runs on `pull_request` only — direct pushes to `main` are not
  checked.
