### PR TITLE
Fix out-of-tree catalog resolution and project-root conflation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **graded finds its bundled catalog regardless of the working directory.** The catalog was resolved relative to the process's current directory, so running graded from another project's directory (for example via an Erlang shipment) resolved to an empty catalog and collapsed every catalogued call to `[Unknown]`. The catalog is now located relative to graded's own install directory; when no catalog directory can be found at all, graded warns on standard error instead of degrading silently.
+- **`infer` and `check` against an out-of-tree source directory root the spec and cache at the project, not the passed directory.** The project root is resolved by walking up to the nearest `gleam.toml`, so `graded infer ../other/src` writes `../other`'s spec and cache under its package name rather than scattering `../other/src/src.graded` and `../other/src/build/`. A relative source directory inside the current project whose only ancestor `gleam.toml` is the working directory still acts as its own root, so pointing graded at a subtree doesn't write into the surrounding project.
+
 ## [0.10.1] - 2026-06-26
 
 ### Fixed

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -1338,18 +1338,15 @@ fn check_one_file(
 }
 
 // Read the project's `[tools.graded]` config and return spec/cache paths
-// already resolved relative to the project root. The "project root" is
-// the directory containing `gleam.toml`:
-//
-// - When `directory == "src"` (the production case), project root is `.`
-//   and gleam.toml lives at `./gleam.toml`.
-// - Otherwise (tests against ad-hoc directories), the source directory
-//   itself acts as the project root and gleam.toml is looked up there.
+// already resolved relative to the project root. The root is the nearest
+// ancestor of the source directory holding a `gleam.toml` (see `spec_root_for`),
+// so a source directory like `../other/src` resolves its spec and cache under
+// `../other`, not under the passed directory.
 //
 // Resolved paths are returned in the same `GradedConfig` shape so callers
 // can use them as-is for I/O without further joining.
 fn read_config(directory: String) -> Result(config.GradedConfig, GradedError) {
-  let project_root = source_root_for(directory)
+  let project_root = spec_root_for(directory)
   let toml_path = filepath.join(project_root, "gleam.toml")
   use raw <- result.try(case config.read(toml_path) {
     Ok(cfg) -> Ok(cfg)
@@ -1363,6 +1360,23 @@ fn read_config(directory: String) -> Result(config.GradedConfig, GradedError) {
     spec_file: resolve_path(project_root, raw.spec_file),
     cache_dir: resolve_path(project_root, raw.cache_dir),
   ))
+}
+
+// Where the spec and cache live: the nearest ancestor `gleam.toml`, found by
+// the same walk-up `resolve_package_root` uses for dependency state, so an
+// out-of-tree source like `../other/src` roots its spec under `../other` rather
+// than writing it back under the passed directory. The one exception is a
+// relative source directory nested in the current project whose only ancestor
+// `gleam.toml` is the cwd: it keeps acting as its own root (the `src` layout
+// aside), so pointing graded at a subtree of the current project — e.g. a test
+// fixture directory — doesn't write the spec into the surrounding project.
+fn spec_root_for(directory: String) -> String {
+  let walked = resolve_package_root(directory)
+  let source_root = source_root_for(directory)
+  case walked == "." && source_root != "." {
+    True -> source_root
+    False -> walked
+  }
 }
 
 // The Gleam project root: where dependency state lives — `build/packages`,
@@ -1411,10 +1425,12 @@ fn find_gleam_toml_dir(dir: String, original: String) -> String {
         "" -> "."
         other -> other
       }
-      // `.` (and `/`) is a fixed point of `directory_name`, so `parent == dir`
-      // always halts the walk — at which point no `gleam.toml` was found and we
-      // fall back to the source dir.
-      case parent == dir {
+      // Halt at a fixed point so an exhausted walk falls back to the source dir.
+      // `.` is its own fixed point, halting a relative walk at the cwd. An
+      // absolute walk halts at `/`, whose `directory_name` is `""` → `.`: left
+      // unchecked it would fold into the cwd and wrongly adopt that project's
+      // root, so `/` halts explicitly.
+      case parent == dir || dir == "/" {
         True -> original
         False -> find_gleam_toml_dir(parent, original)
       }

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -606,6 +606,7 @@ fn is_existing_directory(path: String) -> Bool {
 }
 
 @external(erlang, "graded_ffi", "priv_directory")
+@external(javascript, "../../graded_ffi.mjs", "priv_directory")
 fn priv_directory() -> Result(String, Nil)
 
 type CatalogAcc {

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1,5 +1,7 @@
+import filepath
 import gleam/dict.{type Dict}
 import gleam/int
+import gleam/io
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/order
@@ -559,13 +561,52 @@ fn fold_qualified_annotation(
   }
 }
 
+// The resolved bundled-catalog directory (see `find_catalog_directory`).
+pub fn catalog_directory() -> String {
+  find_catalog_directory()
+}
+
+// Resolve graded's bundled `priv/catalog`. The install location (via
+// `code:priv_dir`) is tried first so the catalog is found regardless of the
+// process's working directory; the cwd-relative layouts follow as a fallback.
+// When no candidate exists, warn and return the cwd-relative default — an empty
+// catalog collapses every catalogued call to `[Unknown]`, so the degradation is
+// surfaced instead of silent.
 fn find_catalog_directory() -> String {
-  let installed = "build/packages/graded/priv/catalog"
-  case simplifile.is_directory(installed) {
-    Ok(True) -> installed
-    _ -> "priv/catalog"
+  let candidates =
+    list.append(bundled_catalog_candidates(), [
+      "build/packages/graded/priv/catalog",
+      "priv/catalog",
+    ])
+  case list.find(candidates, is_existing_directory) {
+    Ok(directory) -> directory
+    Error(Nil) -> {
+      io.println_error(
+        "graded: warning: catalog directory not found; catalogued calls will resolve to [Unknown]",
+      )
+      "priv/catalog"
+    }
   }
 }
+
+// graded's own `priv/catalog`, anchored on its install location. Empty when the
+// application priv directory can't be located.
+fn bundled_catalog_candidates() -> List(String) {
+  case priv_directory() {
+    Ok(priv) -> [filepath.join(priv, "catalog")]
+    Error(Nil) -> []
+  }
+}
+
+fn is_existing_directory(path: String) -> Bool {
+  case simplifile.is_directory(path) {
+    Ok(True) -> True
+    _ -> False
+  }
+}
+
+@external(erlang, "graded_ffi", "priv_directory")
+fn priv_directory() -> Result(String, Nil)
 
 type CatalogAcc {
   CatalogAcc(

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -573,11 +573,14 @@ pub fn catalog_directory() -> String {
 // catalog collapses every catalogued call to `[Unknown]`, so the degradation is
 // surfaced instead of silent.
 fn find_catalog_directory() -> String {
-  let candidates =
-    list.append(bundled_catalog_candidates(), [
-      "build/packages/graded/priv/catalog",
-      "priv/catalog",
-    ])
+  let cwd_relative = ["build/packages/graded/priv/catalog", "priv/catalog"]
+  // The install-location candidate (anchored on graded's own priv) is tried
+  // ahead of the cwd-relative ones; absent when the priv directory can't be
+  // located.
+  let candidates = case priv_directory() {
+    Ok(priv) -> [filepath.join(priv, "catalog"), ..cwd_relative]
+    Error(Nil) -> cwd_relative
+  }
   case list.find(candidates, is_existing_directory) {
     Ok(directory) -> directory
     Error(Nil) -> {
@@ -586,15 +589,6 @@ fn find_catalog_directory() -> String {
       )
       "priv/catalog"
     }
-  }
-}
-
-// graded's own `priv/catalog`, anchored on its install location. Empty when the
-// application priv directory can't be located.
-fn bundled_catalog_candidates() -> List(String) {
-  case priv_directory() {
-    Ok(priv) -> [filepath.join(priv, "catalog")]
-    Error(Nil) -> []
   }
 }
 

--- a/src/graded_ffi.erl
+++ b/src/graded_ffi.erl
@@ -1,9 +1,19 @@
 -module(graded_ffi).
--export([read_stdin/0]).
+-export([read_stdin/0, priv_directory/0]).
 
 % Read all of standard input to EOF and return it as a single binary.
 read_stdin() ->
     unicode:characters_to_binary(read_lines(standard_io)).
+
+% graded's own `priv` directory, located via the loaded application rather than
+% the process working directory. Absolute when graded runs from a release or
+% erlang-shipment, relative when run in-tree, but always anchored on the install
+% location. `{error, nil}` when the application is not loaded.
+priv_directory() ->
+    case code:priv_dir(graded) of
+        {error, _} -> {error, nil};
+        Dir -> {ok, unicode:characters_to_binary(Dir)}
+    end.
 
 read_lines(Device) ->
     case io:get_line(Device, "") of

--- a/src/graded_ffi.mjs
+++ b/src/graded_ffi.mjs
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { Error as GError } from "./gleam.mjs";
 
 // Read all of standard input to EOF and return it as a single string.
 export function read_stdin() {
@@ -16,4 +17,11 @@ export function read_stdin() {
 export function halt(code) {
   process.exit(code);
   return undefined;
+}
+
+// graded's bundled catalog is located via the Erlang application on the BEAM
+// target; on JavaScript the install location isn't resolved, so callers fall
+// back to the working-directory layouts.
+export function priv_directory() {
+  return new GError(undefined);
 }

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -545,3 +545,24 @@ pub fn load_knowledge_base_loads_dependency_type_fields_test() {
   let _ = simplifile.delete("build/eff_dep_typefield")
   Nil
 }
+
+// The catalog directory resolves via graded's own install location (its bundled
+// `priv`), not a bare cwd-relative path — so an out-of-tree run still finds the
+// catalog instead of silently degrading every catalogued call to [Unknown].
+pub fn catalog_directory_anchored_on_install_location_test() {
+  let directory = effects.catalog_directory()
+
+  // The bundled path ends at `priv/catalog` but is prefixed by the install
+  // location, so it differs from the bare cwd-relative fallback.
+  string.ends_with(directory, "priv/catalog")
+  |> should.be_true()
+  { directory != "priv/catalog" }
+  |> should.be_true()
+
+  // It points at a real directory holding catalog spec files.
+  simplifile.is_directory(directory)
+  |> should.equal(Ok(True))
+  let assert Ok(files) = simplifile.get_files(directory)
+  list.any(files, string.ends_with(_, ".graded"))
+  |> should.be_true()
+}

--- a/test/topo_test.gleam
+++ b/test/topo_test.gleam
@@ -929,3 +929,48 @@ fn indices_loop(n: Int, acc: List(Int)) -> List(Int) {
     False -> indices_loop(n - 1, [n, ..acc])
   }
 }
+
+// ----- out-of-tree project root resolution (BUG B) -----
+
+// `infer` against a source directory whose project root is an ancestor (where
+// `gleam.toml` lives) must write the spec and cache under that root, not under
+// the passed source directory. Pre-fix, a non-"src" source argument was treated
+// as the project root itself, scattering `src/src.graded` and `src/build/` into
+// the wrong place with the wrong package name.
+pub fn infer_roots_spec_at_nearest_gleam_toml_test() {
+  let root =
+    write_fixture("/tmp/graded_outoftree_root", [
+      stdlib_manifest(),
+      #("gleam.toml", "name = \"myproj\"\n"),
+      #(
+        "src/app.gleam",
+        "import gleam/string
+
+pub fn shout(value: String) -> String {
+  string.uppercase(value)
+}
+",
+      ),
+    ])
+
+  let assert Ok(Nil) = graded.run_infer(root <> "/src")
+
+  // Spec lands at the project root under the package name from gleam.toml.
+  simplifile.is_file(root <> "/myproj.graded")
+  |> should.equal(Ok(True))
+  // Not under the source directory with the basename-derived "src" name.
+  simplifile.is_file(root <> "/src/src.graded")
+  |> should.equal(Ok(False))
+
+  // Cache lands under the project root, not the source directory.
+  simplifile.is_directory(root <> "/build/.graded")
+  |> should.equal(Ok(True))
+  simplifile.is_directory(root <> "/src/build")
+  |> should.equal(Ok(False))
+
+  // Inference actually ran: the pure function reads back as pure.
+  effects_of(read_inferred(root <> "/build/.graded/app.graded"), "shout")
+  |> should.equal(pure())
+
+  cleanup(root)
+}


### PR DESCRIPTION
Fixes the two prerequisite bugs surfaced by the spec-distribution pilot, both of which degrade graded when it runs against a project other than the one in the current working directory.

## BUG A — catalog path was cwd-relative

`find_catalog_directory` resolved `priv/catalog` relative to the process working directory, so running graded from another project's directory (e.g. via an Erlang shipment) resolved to an empty catalog and collapsed every catalogued call to `[Unknown]` — a silent 3× inflation of `[Unknown]` readings in the pilot.

- New `priv_directory/0` FFI locates graded's own `priv` via `code:priv_dir(graded)` (absolute under a release/shipment, relative in-tree, always anchored on the install location).
- `find_catalog_directory` now tries the install-anchored path first, then the cwd-relative layouts as fallback, and **warns on stderr** when no catalog directory can be found instead of degrading silently.

## BUG B — out-of-tree project-root conflation

`read_config` treated any non-`src` source argument as the project root, so `infer ../other/src` wrote the spec/cache into the wrong place (`../other/src/src.graded`, `../other/src/build/`) under a basename-derived package name.

- `read_config` now resolves the spec/cache root by walking up to the nearest ancestor `gleam.toml` (the same logic dependency resolution already uses), via the new `spec_root_for`.
- Fixed a latent quirk in `find_gleam_toml_dir`: `directory_name("/")` returns `""`, which the walk mapped to `"."`, letting an absolute walk fold into the cwd and wrongly adopt graded's own root. The walk now halts explicitly at `/`.
- A relative subtree of the current project whose only ancestor `gleam.toml` is the cwd keeps acting as its own root, so `src`, the no-arg default, and the integration fixtures are unaffected.

## Tests

- `effects_test.catalog_directory_anchored_on_install_location_test` — asserts the catalog resolves via the install location (differs from the bare cwd fallback, exists, holds `.graded` files).
- `topo_test.infer_roots_spec_at_nearest_gleam_toml_test` — runs `infer` against a `src` subdir whose root holds `gleam.toml`, asserts the spec/cache land at the root, not the source directory.

Both were verified to fail against the unfixed code. Full suite: 465 passed, no failures; `format --check`, `build --warnings-as-errors`, and `glinter` all green.