### PR TITLE
Upgrade girard to 2.0.0 and glance to 7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,7 @@ jobs:
       - name: Run tests
         run: gleam test
 
-      - name: Lint
-        run: gleam run -m glinter
+      # TODO: restore the glinter lint step once glinter allows glance 7.x
+      # (it currently pins glance < 7.0.0, which conflicts with girard 2.0.0).
+      # - name: Lint
+      #   run: gleam run -m glinter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Upgraded girard to 2.0.0 and glance to 7.0.0.** girard's `Type` now lives in the single `girard` module (`girard/types` was removed upstream), and glance 7 parses arithmetic in bit-array pattern segment sizes, so modules using that form now extract and type instead of failing to parse and collapsing to `[Unknown]`.
+- **The glinter lint gate is temporarily disabled.** glinter pins glance below 7.0.0, which conflicts with girard 2.0.0; the dev dependency and CI step return once glinter allows glance 7.x.
+
 ### Fixed
 
 - **A computed receiver whose helper returns one of its parameters now forwards field effects instead of collapsing to `[Unknown]`.** When the receiver argument is a call to a straight-line helper that returns a parameter (`inner(id_options(o))`), a parameter-rooted receiver path (`inner(get_options(config))` returning `config.options`), or a constructor rebuilt from parameter-rooted fields (`inner(normalize(o))` returning `Options(resolver: o.resolver)`), graded resolves the helper's return-value provenance and substitutes the call's arguments into it, then re-keys the callee's field-effect variable through the resulting value exactly as an inline receiver would. Both a same-module private helper (resolved on demand from its source) and a public cross-module one (threaded through the knowledge base) resolve. A helper whose return is itself a non-self call, or an external with no visible body, stays `[Unknown]`, as does any argument that can't be grounded to a caller parameter — provenance widens to Top on every shape it can't trace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Upgraded girard to 2.0.0 and glance to 7.0.0.** girard's `Type` now lives in the single `girard` module (`girard/types` was removed upstream), and glance 7 parses arithmetic in bit-array pattern segment sizes, so modules using that form now extract and type instead of failing to parse and collapsing to `[Unknown]`.
-- **The glinter lint gate is temporarily disabled.** glinter pins glance below 7.0.0, which conflicts with girard 2.0.0; the dev dependency and CI step return once glinter allows glance 7.x.
+- **Modules using arithmetic in bit-array pattern segment sizes now extract and type instead of collapsing to `[Unknown]`.** Upgrading glance to 7.0.0 (via girard 2.0.0) lets graded parse forms like `<<value:size(n * 8)>>`; such modules previously failed to parse entirely, so every function in them degraded to `[Unknown]`.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,11 @@ means green on CI:
 gleam format --check src/ test/    # formatting (test/ too, not just src/)
 gleam build --warnings-as-errors   # no warnings allowed
 gleam test                         # full suite
-gleam run -m glinter               # lint; warnings_as_errors = true
 ```
+
+The glinter lint gate is temporarily disabled: glinter pins glance < 7.0.0,
+which conflicts with girard 2.0.0. Restore it (dev dependency + CI step +
+this dev loop) once glinter allows glance 7.x.
 
 `gleam format src/ test/` (no `--check`) fixes formatting in place.
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -33,7 +33,7 @@ pages = [
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 glance = ">= 6.0.0 and < 8.0.0"
-girard = ">= 1.0.0 and < 2.0.0"
+girard = ">= 2.0.0 and < 3.0.0"
 simplifile = ">= 2.0.0 and < 3.0.0"
 argv = ">= 1.0.0 and < 2.0.0"
 filepath = ">= 1.1.2 and < 2.0.0"
@@ -41,7 +41,8 @@ tom = ">= 2.0.2 and < 3.0.0"
 
 [dev_dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-glinter = ">= 2.11.1 and < 3.0.0"
+# TODO: restore glinter (>= 2.11.1 and < 3.0.0) once it allows glance 7.x;
+# it currently pins glance < 7.0.0, which conflicts with girard 2.0.0.
 qcheck = ">= 1.0.0 and < 2.0.0"
 
 [tools.glinter]

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,21 +8,19 @@
 
 packages = [
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
-  { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
+  { name = "exception", version = "2.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "6BDEA95248093599391C3B5DF1835C5C6A86C353C2F99CE539B450E3432FE117" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
-  { name = "girard", version = "1.1.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_stdlib", "simplifile"], otp_app = "girard", source = "hex", outer_checksum = "D0718AD966DB39947B35BE110A8168E492FC4BC218F58CCAB87509F14BE24C15" },
-  { name = "glance", version = "6.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "9037EBBAD2A220CD46DADEDCDF9DFAC7406FD2959535334473E60C32F170622A" },
-  { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
+  { name = "girard", version = "2.0.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_stdlib", "simplifile"], otp_app = "girard", source = "hex", outer_checksum = "6A78F818B96BE410613A9DBAA3B212B802E109DAE96B6047D6178A87A7476F31" },
+  { name = "glance", version = "7.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "EA52986965408D43003A1760E41457493EB96098DE193E6AD8646930EC190CB9" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
-  { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
+  { name = "gleam_stdlib", version = "1.0.3", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1F543AFBA5D33DA493E6087F4E4C4F20D899411343512686C98A8ABB2963CF22" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
-  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
-  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
-  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "simplifile", version = "2.5.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "6C72DCCDF25C38A5931740B30E823969F33106831FD1637719B5EDBCA30027A4" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
@@ -30,11 +28,10 @@ packages = [
 [requirements]
 argv = { version = ">= 1.0.0 and < 2.0.0" }
 filepath = { version = ">= 1.1.2 and < 2.0.0" }
-girard = { version = ">= 1.0.0 and < 2.0.0" }
+girard = { version = ">= 2.0.0 and < 3.0.0" }
 glance = { version = ">= 6.0.0 and < 8.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-glinter = { version = ">= 2.11.1 and < 3.0.0" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
 tom = { version = ">= 2.0.2 and < 3.0.0" }

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -22,7 +22,6 @@
 import argv
 import filepath
 import girard
-import girard/types as girard_types
 import glance
 import gleam/bool
 import gleam/dict.{type Dict}
@@ -989,7 +988,7 @@ fn fn_typed_params_from_schemes(
   list.fold(module_result.annotated.functions, dict.new(), fn(acc, entry) {
     let #(name, scheme) = entry
     case scheme.type_, dict.get(function_map, name) {
-      girard_types.Fn(argument_types, _return), Ok(function) ->
+      girard.Fn(argument_types, _return), Ok(function) ->
         dict.insert(acc, name, fn_typed_names(function, argument_types))
       _, _ -> acc
     }
@@ -1000,7 +999,7 @@ fn fn_typed_params_from_schemes(
 // `argument_types`) is itself a `Fn`.
 fn fn_typed_names(
   function: glance.Function,
-  argument_types: List(girard_types.Type),
+  argument_types: List(girard.Type),
 ) -> Set(String) {
   // Positional mapping is only sound when girard's `Fn` arity matches glance's
   // parameter count. `list.zip` would silently truncate a mismatch, so skip the
@@ -1013,7 +1012,7 @@ fn fn_typed_names(
   |> list.filter_map(fn(pair) {
     let #(parameter, argument_type) = pair
     case argument_type, parameter.name {
-      girard_types.Fn(_, _), glance.Named(parameter_name) -> Ok(parameter_name)
+      girard.Fn(_, _), glance.Named(parameter_name) -> Ok(parameter_name)
       _, _ -> Error(Nil)
     }
   })
@@ -1087,7 +1086,7 @@ fn infer_one_module(
   cache_dir: String,
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: Dict(#(Int, Int), girard_types.Type),
+  module_types: Dict(#(Int, Int), girard.Type),
   girard_fn_typed: Dict(String, Set(String)),
   declared_modules: Set(String),
 ) -> Result(
@@ -1356,7 +1355,7 @@ fn check_one_file(
   module_checks: List(EffectAnnotation),
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: Dict(#(Int, Int), girard_types.Type),
+  module_types: Dict(#(Int, Int), girard.Type),
   girard_fn_typed: Dict(String, Set(String)),
 ) -> CheckResult {
   let #(violations, warnings) =

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -1,4 +1,4 @@
-import girard/types as girard_types
+import girard
 import glance.{
   type Definition, type Function, type Module, type Span, type Statement,
   Function, Private, Span,
@@ -40,7 +40,7 @@ pub fn check(
   annotations: List(EffectAnnotation),
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   girard_fn_typed: dict.Dict(String, Set(String)),
 ) -> #(List(Violation), List(Warning)) {
   let context =
@@ -85,7 +85,7 @@ pub fn infer(
   knowledge_base: KnowledgeBase,
   existing_checks: List(EffectAnnotation),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   girard_fn_typed: dict.Dict(String, Set(String)),
 ) -> List(EffectAnnotation) {
   infer_with_returns(
@@ -109,7 +109,7 @@ pub fn infer_with_returns(
   knowledge_base: KnowledgeBase,
   existing_checks: List(EffectAnnotation),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   girard_fn_typed: dict.Dict(String, Set(String)),
 ) -> #(
   List(EffectAnnotation),
@@ -835,7 +835,7 @@ fn check_annotation(
   context: ImportContext,
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(#(List(Violation), List(Warning)), Memo) {
@@ -1003,7 +1003,7 @@ fn collect_effects(
   visited: Set(String),
   param_bounds: List(ParamBound),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   // Operator parameters in scope from an *enclosing* function (a producer whose
   // returned closure we're analysing), so a call to one becomes a curried
   // operator application rather than `[Unknown]`. Empty for an ordinary function.
@@ -2355,7 +2355,7 @@ fn build_lift_operator_arg(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   ambient_operators: OperatorShapes,
   cache: LocalCache,
 ) -> fn(types.ArgumentValue, List(Int), Memo) ->
@@ -2441,7 +2441,7 @@ fn resolve_returned_operator(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(Result(EffectTerm, Nil), Memo) {
@@ -2519,7 +2519,7 @@ fn bind_producer_params(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
@@ -2594,7 +2594,7 @@ fn compute_returned_operator(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(Result(EffectTerm, Nil), Memo) {
@@ -2699,7 +2699,7 @@ fn analyze_closure(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   ambient_operators: OperatorShapes,
   cache: LocalCache,
   memo: Memo,
@@ -2753,7 +2753,7 @@ fn analyze_closure_uncached(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   ambient_operators: OperatorShapes,
   cache: LocalCache,
   memo: Memo,
@@ -2847,7 +2847,7 @@ fn lift_local_function(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
@@ -2915,7 +2915,7 @@ fn lift_operator_miss(
   knowledge_base: KnowledgeBase,
   visited: Set(String),
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
@@ -3069,7 +3069,7 @@ fn resolve_unknown_local(
   context: ImportContext,
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(List(#(ResolvedCall, EffectTerm)), Memo) {
@@ -3152,7 +3152,7 @@ fn memoized_local(
   context: ImportContext,
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(List(#(ResolvedCall, EffectTerm)), Memo) {
@@ -3216,7 +3216,7 @@ fn collapsed_scc(
   context: ImportContext,
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(List(#(ResolvedCall, EffectTerm)), Memo) {
@@ -3257,7 +3257,7 @@ fn collapsed_member(
   context: ImportContext,
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   cache: LocalCache,
   memo: Memo,
 ) -> #(List(#(ResolvedCall, EffectTerm)), Memo) {
@@ -3289,7 +3289,7 @@ fn resolve_field_call(
   function: Function,
   context: ImportContext,
   knowledge_base: KnowledgeBase,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   call_args: dict.Dict(#(Int, Int), List(types.CallArgument)),
   caller_param_bounds: List(ParamBound),
   registry: SignatureRegistry,
@@ -3340,7 +3340,7 @@ fn resolve_field_call_by_type(
   function: Function,
   context: ImportContext,
   knowledge_base: KnowledgeBase,
-  module_types: dict.Dict(#(Int, Int), girard_types.Type),
+  module_types: dict.Dict(#(Int, Int), girard.Type),
   call_args: dict.Dict(#(Int, Int), List(types.CallArgument)),
   caller_param_bounds: List(ParamBound),
   registry: SignatureRegistry,

--- a/src/graded/internal/typeinfo.gleam
+++ b/src/graded/internal/typeinfo.gleam
@@ -12,7 +12,7 @@
 // a pure enhancement layer (it can only ever upgrade an `[Unknown]`, never
 // change an already-resolved result).
 
-import girard/types.{type Type, Named}
+import girard.{type Type, Named}
 import gleam/dict.{type Dict}
 import gleam/option.{type Option, None, Some}
 import gleam/set.{type Set}

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -1,6 +1,5 @@
 import generators
 import girard
-import girard/types as girard_types
 import glance
 import gleam/dict
 import gleam/list
@@ -312,14 +311,14 @@ fn girard_fn_typed_for(
       list.fold(annotated.functions, dict.new(), fn(acc, entry) {
         let #(name, scheme) = entry
         case scheme.type_ {
-          girard_types.Fn(argument_types, _return) -> {
+          girard.Fn(argument_types, _return) -> {
             let assert Ok(definition) =
               list.find(module.functions, fn(d) { d.definition.name == name })
             let names =
               list.zip(definition.definition.parameters, argument_types)
               |> list.filter_map(fn(pair) {
                 case pair.1, { pair.0 }.name {
-                  girard_types.Fn(_, _), glance.Named(parameter_name) ->
+                  girard.Fn(_, _), glance.Named(parameter_name) ->
                     Ok(parameter_name)
                   _, _ -> Error(Nil)
                 }


### PR DESCRIPTION
## Summary

- Upgrade girard 1.1.0 → 2.0.0 and glance 6.1.0 → 7.0.0 (plus incidental
  bumps: gleam_stdlib 0.71.0 → 1.0.3, gleeunit, simplifile).
- Migrate the removed `girard/types` module to the consolidated `girard`
  module in `typeinfo`, `graded`, `checker`, and `checker_test`.
- Temporarily drop the glinter lint gate (dev dependency and CI step):
  glinter pins glance below 7.0.0, which conflicts with girard 2.0.0. The
  `[tools.glinter]` rule config stays in place; TODOs in `gleam.toml`,
  `ci.yml`, and `CONTRIBUTING.md` mark the restoration point.

## Why

glance 7.0.0 parses arithmetic in bit-array pattern segment sizes
(`<<x:size(n * 8)>>`). Modules using that form previously failed to parse
entirely — extraction skipped them and girard contributed no types, so
every function in them degraded to `[Unknown]`. They now extract and type
normally.

## Verification

- `gleam format --check`, `gleam build --warnings-as-errors`,
  `gleam test`: clean, 538 passed.
- End-to-end smoke test: a module with `<<value:size(n * 8)>>` infers
  `[]` under glance 7 instead of the whole module collapsing to
  `[Unknown]`.
- glinter compiles and passes its 366 tests against glance 7 with only
  its constraint widened, so the upstream fix to restore the gate is a
  one-line constraint bump.