### PR TITLE
Upgrade to Gleam 1.18 and restore the glinter lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,5 @@ jobs:
       - name: Run tests
         run: gleam test
 
-      # TODO: restore the glinter lint step once glinter allows glance 7.x
-      # (it currently pins glance < 7.0.0, which conflicts with girard 2.0.0).
-      # - name: Lint
-      #   run: gleam run -m glinter
+      - name: Lint
+        run: gleam run -m glinter

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 28.4.2
-gleam 1.17.0
+gleam 1.18.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,11 @@ means green on CI:
 gleam format --check src/ test/    # formatting (test/ too, not just src/)
 gleam build --warnings-as-errors   # no warnings allowed
 gleam test                         # full suite
+gleam run -m glinter               # lint (warnings are errors)
 ```
 
-The glinter lint gate is temporarily disabled: glinter pins glance < 7.0.0,
-which conflicts with girard 2.0.0. Restore it (dev dependency + CI step +
-this dev loop) once glinter allows glance 7.x.
-
-`gleam format src/ test/` (no `--check`) fixes formatting in place.
+`gleam format src/ test/` (no `--check`) fixes formatting in place. Lint rules and
+the `warnings_as_errors` setting live under `[tools.glinter]` in `gleam.toml`.
 
 ## Adding a catalog entry
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -41,8 +41,7 @@ tom = ">= 2.0.2 and < 3.0.0"
 
 [dev_dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-# TODO: restore glinter (>= 2.11.1 and < 3.0.0) once it allows glance 7.x;
-# it currently pins glance < 7.0.0, which conflicts with girard 2.0.0.
+glinter = ">= 2.19.2 and < 3.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
 
 [tools.glinter]

--- a/manifest.toml
+++ b/manifest.toml
@@ -12,12 +12,14 @@ packages = [
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "girard", version = "2.0.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_stdlib", "simplifile"], otp_app = "girard", source = "hex", outer_checksum = "6A78F818B96BE410613A9DBAA3B212B802E109DAE96B6047D6178A87A7476F31" },
   { name = "glance", version = "7.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "EA52986965408D43003A1760E41457493EB96098DE193E6AD8646930EC190CB9" },
+  { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "1.0.3", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1F543AFBA5D33DA493E6087F4E4C4F20D899411343512686C98A8ABB2963CF22" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
   { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
+  { name = "glinter", version = "2.19.2", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "19CBB4D78E58E54D6B0E8554C389DC01071334FB11E9140C9487C9A4BBCA6158" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.5.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "6C72DCCDF25C38A5931740B30E823969F33106831FD1637719B5EDBCA30027A4" },
@@ -32,6 +34,7 @@ girard = { version = ">= 2.0.0 and < 3.0.0" }
 glance = { version = ">= 6.0.0 and < 8.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.2 and < 3.0.0" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
 tom = { version = ">= 2.0.2 and < 3.0.0" }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -4059,30 +4059,40 @@ fn resolve_unproven_field(
             memo,
           )
         None ->
-          case field_call.provenance {
-            // Rule 4: the receiver is rooted at a live parameter — stay
-            // polymorphic in the field, forwarding a receiver-keyed field
-            // variable that grounds to `[Unknown]` if never bound. Keyed on the
-            // canonical parameter path (an alias `let f = options` resolves to
-            // `options.field`, not the dead `f.field`).
-            types.ParameterRoot(path) -> {
-              let #(module, type_name) = option.unwrap(receiver_type, #("", ""))
-              #(
-                field_fallback(
-                  path,
-                  field_call.label,
-                  module,
-                  type_name,
-                  context,
-                ),
-                memo,
-              )
-            }
-            // Rule 5: an untraceable/opaque/computed receiver — `[Unknown]`.
-            _ -> #(effect_term.unknown(), memo)
-          }
+          resolve_undeclared_field(field_call, receiver_type, context, memo)
       }
     }
+  }
+}
+
+// Rules 4 and 5, for a field call with no `check` bound, no declared `type` line,
+// and no proven value.
+//
+// Rule 4: a receiver rooted at a live parameter stays polymorphic in the field —
+// a receiver-keyed field variable that grounds to `[Unknown]` if never bound,
+// keyed on the canonical parameter path (an alias `let f = options` resolves to
+// `options.field`, not the dead `f.field`). Rule 5: any other receiver
+// (untraceable, opaque, computed) is `[Unknown]`. A proven provenance never
+// reaches here — `resolve_unproven_field` runs only after the proven path
+// declines — and resolves to `[Unknown]` if it somehow does.
+fn resolve_undeclared_field(
+  field_call: types.FieldCall,
+  receiver_type: option.Option(#(String, String)),
+  context: ImportContext,
+  memo: Memo,
+) -> #(EffectTerm, Memo) {
+  case field_call.provenance {
+    types.ParameterRoot(path) -> {
+      let #(module, type_name) = option.unwrap(receiver_type, #("", ""))
+      #(
+        field_fallback(path, field_call.label, module, type_name, context),
+        memo,
+      )
+    }
+    types.ProvenValue(..) | types.ProvenReceiver(..) | types.Untraceable -> #(
+      effect_term.unknown(),
+      memo,
+    )
   }
 }
 

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -1448,10 +1448,8 @@ fn unshadowed(
   env: Env,
   then: fn() -> Result(a, Nil),
 ) -> Result(a, Nil) {
-  case dict.has_key(env, name) {
-    True -> Error(Nil)
-    False -> then()
-  }
+  use <- bool.guard(dict.has_key(env, name), Error(Nil))
+  then()
 }
 
 // The signature for a bare callee — a same-module one from `local`, or an

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -388,14 +388,19 @@ pub fn returned_callback_positions(
   type_: glance.Type,
   alias_map: Dict(String, glance.Type),
 ) -> Result(List(Int), Nil) {
-  use resolved <- result.map(resolve_function_type(type_, alias_map))
-  let assert FunctionType(_, param_types, _) = resolved
-  param_types
-  |> list.index_map(fn(t, i) {
-    #(i, resolve_function_type(t, alias_map) |> result.is_ok)
-  })
-  |> list.filter(fn(pair) { pair.1 })
-  |> list.map(fn(pair) { pair.0 })
+  use resolved <- result.try(resolve_function_type(type_, alias_map))
+  case resolved {
+    FunctionType(_, param_types, _) ->
+      Ok(
+        param_types
+        |> list.index_map(fn(t, i) {
+          #(i, resolve_function_type(t, alias_map) |> result.is_ok)
+        })
+        |> list.filter(fn(pair) { pair.1 })
+        |> list.map(fn(pair) { pair.0 }),
+      )
+    _ -> Error(Nil)
+  }
 }
 
 pub fn assignment_name(name: glance.AssignmentName) -> Option(String) {


### PR DESCRIPTION
Bumps the pinned toolchain to Gleam 1.18.0 and brings the glinter lint gate back
now that its glance constraint no longer conflicts with girard.

## Gleam 1.18.0

Released 2026-07-29. Clean upgrade: no new warnings under
`--warnings-as-errors`, no formatter churn across `src/` and `test/`, and the
full suite passing.

## glinter

The gate was disabled because glinter pinned `glance < 7.0.0` while girard 2.0.0
needs glance 7.x. **glinter 2.19.2** (2026-07-26) widened this to
`glance >= 6.0.0 and < 8.0.0` — the same range graded declares — so it now
resolves alongside glance 7.0.0 and girard 2.0.0. 2.19.1 and earlier still pin
`< 7.0.0`, which is why the dev dependency is `>= 2.19.2`.

Restored the dev dependency, the CI `Lint` step, and the pre-flight checklist in
CONTRIBUTING, which claimed four gates while listing three.

## Lint findings fixed

Its first run back found three issues:

| Site | Rule | Fix |
|---|---|---|
| `checker.gleam` | `deep_nesting` (6 levels) | Rules 4-5 extracted into `resolve_undeclared_field` |
| `signatures.gleam` | `assert_ok_pattern` | `let assert FunctionType(..)` replaced by a `case` returning `Error(Nil)` |
| `extract.gleam` | `prefer_guard_clause` | `case dict.has_key(..) { True/False }` replaced by `use <- bool.guard` |

`gleam run -m glinter` now reports no issues.

The `assert_ok_pattern` finding was a latent crash-on-mismatch inside a
`Result`-returning function. It was unreachable in practice —
`resolve_function_type` only returns `Ok` for a `FunctionType` — so all three
fixes are behavior-preserving.

## No changelog entry

Everything here is dev tooling (a toolchain pin, a dev dependency, a CI step) and
the three code fixes have no observable effect, so nothing belongs in the
user-facing changelog.

## Checks

`gleam format --check src/ test/`, `gleam build --warnings-as-errors`,
`gleam test` (598 passed), and `gleam run -m glinter` all green locally on
Gleam 1.18.0.