### PR TITLE
Patch cleanups for v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   higher-order entry another package declares `external effects` no longer
   loses its bounds — and with them its callers' effects — depending on which
   catalog file was read last.
+- A stale duplicate copy of a dependency module left under `build/packages` —
+  a dependency moved to a path dependency without a `gleam clean` — no longer
+  has a say in anything graded reads from dependency source. The copy the build
+  compiles against alone decides whether an `external effects` line naming one
+  of its functions is dead, which parameter signatures match at call sites,
+  which update builders resolve, and which of its functions are foreign; a
+  winning copy graded cannot read contributes nothing and still shadows the
+  stale one beside it.
 
 ## [0.12.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A catalog entry that both declares a function `external effects` and carries
+  an `effects` line for it now resolves to the declaration, so the function's
+  effects no longer come from a term whose parameter bounds were dropped.
+
 ## [0.12.0] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A catalog entry that both declares a function `external effects` and carries
   an `effects` line for it now resolves to the declaration, so the function's
   effects no longer come from a term whose parameter bounds were dropped.
+- Two catalog files keying the same function now settle it whole: the file
+  whose `effects` line wins the term supplies its parameter bounds too. A
+  higher-order entry another package declares `external effects` no longer
+  loses its bounds — and with them its callers' effects — depending on which
+  catalog file was read last.
 
 ## [0.12.0] - 2026-08-18
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -253,6 +253,39 @@ closures, `case`/`if` branches over function-like options, blocks, and functions
 returned from a call. The full design and the property suite are in
 [docs/SECOND_ORDER_EFFECTS.md](./SECOND_ORDER_EFFECTS.md).
 
+### References passed as values
+
+A function *reference* passed as a value rather than called — `list.map(lines,
+io.println)`, `Handler(on_click: dom.focus)` — carries its effects to wherever
+that value is finally called, which may be past anything graded checks. When the
+reference's effects are known and not pure, graded warns at the site that passes
+it:
+
+```
+src/app.gleam: warning: greet_all passes gleam/io.println as a value — its effects [Stdout] won't be tracked
+```
+
+The quoted set is what a *call* to that name resolves to, read through the same
+boundary a call goes through: a stale `effects` line over an `@external` is never
+quoted, since no caller of that name is charged it either.
+
+A set that mixes a known effect with `[Unknown]` warns and quotes both halves —
+the known half is a real effect travelling past whatever would track it:
+
+```
+src/app.gleam: warning: pass_loud passes dep/fs.read as a value — its effects [Disk, Unknown] won't be tracked
+```
+
+A reference whose whole effect set is `[Unknown]` stays **silent**, as does a
+pure one: an unresolved reference has nothing to report, and warning about it
+would read as a quoted effect. So does any reference in a body that never runs —
+an `@external` covering every target the build compiles keeps its Gleam body as
+dead text.
+
+Warnings are counted separately from violations and never fail a check: `graded
+check` prints them, reports `graded: N warning(s)`, and still exits zero when no
+budget was exceeded.
+
 ## Type field effects
 
 Custom types can have function-typed fields (a `Handler` with an `on_click`, a

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -1739,20 +1739,21 @@ fn function_effect(
   // that nothing declares it named a cause the other surfaces do not.
   use <- bool.guard(
     when: charge.declaration != effects.DeclarationCharged,
-    return: Ok(answer.FunctionAnswer(
-      name:,
-      module:,
-      bounds: fallback_bounds,
-      term: charge.term,
-      source: case fallback {
-        // The body running in the declaration's place is the whole of the
-        // term, not a half added to it, so it is named as the source and not
-        // beside one.
-        Some(_) -> answer.RunningFallbackBody
-        None -> answer.UnreachedDeclaration
-      },
-      fallback: None,
-    )),
+    return: Ok(
+      answer.FunctionAnswer(
+        name:,
+        module:,
+        bounds: fallback_bounds,
+        term: charge.term,
+        source: case fallback {
+          // The body running in the declaration's place is the whole of the
+          // term, not a half added to it, so it is named as the source and not
+          // beside one.
+          Some(_) -> answer.RunningFallbackBody
+          None -> answer.UnreachedDeclaration
+        },
+      ),
+    ),
   )
   use <- bool.guard(
     when: checker.undeclared_external(knowledge_base, qualified),
@@ -1761,8 +1762,7 @@ fn function_effect(
       module:,
       bounds: fallback_bounds,
       term: charge.term,
-      source: answer.UndeclaredExternal,
-      fallback:,
+      source: answer.UndeclaredExternal(fallback:),
     )),
   )
   case effects.lookup_declared(knowledge_base, qualified) {
@@ -1775,8 +1775,7 @@ fn function_effect(
         module:,
         bounds: fallback_bounds,
         term:,
-        source: answer.Entry(types.ModuleExternalEntry(origin:)),
-        fallback:,
+        source: answer.Entry(types.ModuleExternalEntry(origin:), fallback:),
       ))
     effects.Known(term, types.FunctionEntry(origin:)) ->
       Ok(answer.FunctionAnswer(
@@ -1784,8 +1783,7 @@ fn function_effect(
         module:,
         bounds: effects.lookup_param_bounds(knowledge_base, qualified),
         term:,
-        source: answer.Entry(types.FunctionEntry(origin:)),
-        fallback:,
+        source: answer.Entry(types.FunctionEntry(origin:), fallback:),
       ))
   }
 }

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -471,6 +471,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
     stale_externals:,
     knowledge_base:,
     catalog:,
+    dependencies:,
   ) = ctx
   let ProjectSources(
     source_directory: directory,
@@ -526,6 +527,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
       package_root,
       stale_externals,
       catalog,
+      dependencies,
     )
   {
     [] -> results
@@ -559,6 +561,11 @@ type ProjectContext {
     // base was built from — and which, reading it a second time, reported a
     // missing catalog twice.
     catalog: effects.BundledCatalog,
+    // The dependency scan this context was assembled from. Held for the spec
+    // lint, which decides whether a dependency module defines the name an
+    // `external effects` line gives it — a question this walk already parsed
+    // every dependency module to answer for the registry.
+    dependencies: DependencySources,
   )
 }
 
@@ -704,6 +711,7 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     stale_externals:,
     knowledge_base:,
     catalog:,
+    dependencies: dep_sources,
   )
 }
 
@@ -864,6 +872,7 @@ fn validate_spec_annotations(
   package_root: String,
   stale_externals: Set(String),
   catalog: effects.BundledCatalog,
+  dependencies: DependencySources,
 ) -> List(Warning) {
   let known_functions = known_function_names(index)
 
@@ -892,6 +901,7 @@ fn validate_spec_annotations(
       stale_externals,
       dep_files,
       catalog,
+      dependencies,
     )
 
   // Resolving `type` lines also needs per-module type info; build it only when
@@ -943,6 +953,7 @@ fn external_warnings(
   stale: Set(String),
   dep_files: Dict(String, String),
   catalog: effects.BundledCatalog,
+  dependencies: DependencySources,
 ) -> List(Warning) {
   use <- bool.guard(when: externals == [], return: [])
   // The catalog the knowledge base was assembled from, selected against *this*
@@ -962,7 +973,6 @@ fn external_warnings(
     dict.fold(catalog_functions, set.new(), fn(acc, name, _entry) {
       set.insert(acc, name.module)
     })
-  let dep_functions = dependency_function_names(externals, dep_files)
   // Whether the tree the lint read is the whole of what this project depends
   // on. A module it cannot place is a typo only if there was nowhere left for
   // it to be: with a manifest package whose sources never turned up, the module
@@ -984,7 +994,8 @@ fn external_warnings(
     let placed = dict.has_key(index, external.module) || claimed
     case external.target {
       types.FunctionExternal(function) -> {
-        let name = types.dotted_name(QualifiedName(external.module, function))
+        let qualified = QualifiedName(external.module, function)
+        let name = types.dotted_name(qualified)
         // What answers for the name where no parsed source settles it: a module
         // something outside this package speaks for, a catalog entry for the
         // exact name, or a module the lint cannot place at all while the tree
@@ -993,10 +1004,7 @@ fn external_warnings(
         // defines.
         let unparsed_answers =
           claimed
-          || dict.has_key(
-            catalog_functions,
-            QualifiedName(external.module, function),
-          )
+          || dict.has_key(catalog_functions, qualified)
           || { unplaceable_is_unknown && !placed }
         // The catalog is a stand-in for sources graded cannot read, so it is
         // weighed only where the dependency's own source says nothing: a
@@ -1005,9 +1013,10 @@ fn external_warnings(
         // what it can prove dead, and silence is not proof.
         let resolves =
           set.contains(known_functions, name)
-          || case dict.get(dep_functions, external.module) {
-            Ok(functions) -> set.contains(functions, function)
-            Error(Nil) -> unparsed_answers
+          || case dependency_name(dependencies, qualified) {
+            DefinedByDependency -> True
+            AbsentFromDependency -> False
+            UnreadDependency -> unparsed_answers
           }
         case set.contains(stale, name), resolves {
           True, _ -> Ok(StaleFunctionExternalWarning(function: name))
@@ -1048,42 +1057,6 @@ fn dependency_sources_are_complete(package_root: String) -> Bool {
     |> set.from_list
     |> set.union(effects.packages_with_sources(packages_dir(package_root)))
   set.difference(manifest, located) |> set.is_empty
-}
-
-// The functions each dependency module named by a per-function line defines,
-// private ones included: the question is whether the name exists, and a line
-// naming a private dependency function is dead for a different reason than a
-// typo is. Parsed once per module, and only for the modules a line names, so a
-// spec with no dependency external reads no dependency source.
-fn dependency_function_names(
-  externals: List(types.ExternalAnnotation),
-  dep_files: Dict(String, String),
-) -> Dict(String, Set(String)) {
-  externals
-  |> list.filter_map(fn(external) {
-    case external.target {
-      types.FunctionExternal(_) -> Ok(external.module)
-      types.ModuleExternal -> Error(Nil)
-    }
-  })
-  |> list.fold(dict.new(), fn(acc, module) {
-    use <- bool.guard(when: dict.has_key(acc, module), return: acc)
-    case dict.get(dep_files, module) {
-      Error(Nil) -> acc
-      Ok(file) ->
-        case read_and_parse_gleam(file) {
-          Ok(parsed) ->
-            dict.insert(
-              acc,
-              module,
-              set.from_list(dict.keys(checker.function_visibility(parsed))),
-            )
-          // Unreadable or unparseable: no evidence either way, so the module
-          // goes on answering for every name it is asked about.
-          Error(_) -> acc
-        }
-    }
-  })
 }
 
 // Map of module path -> source file for every installed dependency (under
@@ -3086,6 +3059,11 @@ type DependencySources {
     // which of its own functions are foreign, since a stale line for one is
     // exactly what this set exists to refuse.
     foreign: Dict(types.QualifiedName, types.ForeignFunction),
+    // The module paths this walk parsed. What the registry cannot express: a
+    // module that parsed and defines no function keys nothing in it, exactly
+    // like one that never parsed — and the spec lint owes those two different
+    // answers, since only the first proves a name absent.
+    parsed: Set(String),
   )
 }
 
@@ -3094,7 +3072,41 @@ fn empty_dependency_sources() -> DependencySources {
     registry: signatures.empty(),
     updates: dict.new(),
     foreign: dict.new(),
+    parsed: set.new(),
   )
+}
+
+// What a dependency's own source says about one name: the three answers the
+// spec lint owes a `module.function` it did not find in this package.
+type DependencyName {
+  // The module parsed and defines the function, private ones included: the
+  // question is whether the name exists, and a line naming a private dependency
+  // function is dead for a different reason than a typo is.
+  DefinedByDependency
+  // The module parsed and defines no such function. The one answer that proves
+  // a name absent.
+  AbsentFromDependency
+  // No source graded read says anything: the module never parsed, or the walk
+  // never reached it. No evidence either way.
+  UnreadDependency
+}
+
+// Answer for `name` from the scan. The two fields are read together and only
+// here: a registry miss means nothing without the `parsed` check beside it,
+// since a module that parses and defines no function keys as little as one that
+// never parsed.
+fn dependency_name(
+  sources: DependencySources,
+  name: QualifiedName,
+) -> DependencyName {
+  use <- bool.guard(
+    when: !set.contains(sources.parsed, name.module),
+    return: UnreadDependency,
+  )
+  case signatures.defines(sources.registry, name) {
+    True -> DefinedByDependency
+    False -> AbsentFromDependency
+  }
 }
 
 // Merge two scans; `b` wins on key conflict, matching `signatures.merge`.
@@ -3106,6 +3118,7 @@ fn merge_dependency_sources(
     registry: signatures.merge(a.registry, b.registry),
     updates: dict.merge(a.updates, b.updates),
     foreign: dict.merge(a.foreign, b.foreign),
+    parsed: set.union(a.parsed, b.parsed),
   )
 }
 
@@ -3187,6 +3200,7 @@ fn source_dir_sources(
         module_path,
         package_targets,
       ),
+      parsed: set.from_list([module_path]),
     ),
   )
 }

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -658,7 +658,7 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     |> with_spec_externals(spec, stale_externals)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
-    |> with_committed_spec(spec, declared_modules, stale_externals)
+    |> with_committed_spec(spec, stale_externals)
     // Recorded before the inference pass below, so an `@external` resolves to
     // what declares it while this project's own modules are being inferred, not
     // only when they are later checked.
@@ -1552,11 +1552,7 @@ fn spec_knowledge_base(
   effects.new_knowledge_base()
   |> effects.with_package_targets(targets)
   |> with_spec_externals(spec, stale_externals)
-  |> with_committed_spec(
-    spec,
-    annotation.module_external_modules(spec),
-    stale_externals,
-  )
+  |> with_committed_spec(spec, stale_externals)
   |> with_spec_type_fields(spec)
 }
 
@@ -3617,9 +3613,12 @@ fn with_spec_type_fields(
 fn with_committed_spec(
   knowledge_base: KnowledgeBase,
   spec: GradedFile,
-  declared_modules: Set(String),
   stale_externals: Set(String),
 ) -> KnowledgeBase {
+  // Read off the spec being folded, not taken from the caller: the modules to
+  // drop are a property of that spec, and a caller passing any other set folds
+  // in the very lines this function exists to drop.
+  let declared_modules = annotation.module_external_modules(spec)
   knowledge_base
   |> effects.with_inferred(
     effects.load_spec_effects_from_file(spec)

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -636,7 +636,10 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     stale_project_externals(spec, native_functions_of(index, package_targets))
   let dep_sources = dependency_sources(package_root, package_targets)
   let registry =
-    signatures.merge(dep_sources.registry, build_project_registry(index))
+    signatures.merge(
+      dependency_registry(dep_sources),
+      build_project_registry(index),
+    )
   let type_info = build_type_index(index, package_root)
 
   // Read once and kept: the knowledge base is built from it and the spec lint
@@ -647,7 +650,7 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     effects.knowledge_base_from_catalog(
       packages_dir(package_root),
       catalog,
-      dep_sources.foreign,
+      dependency_foreign(dep_sources),
     )
     // Before anything is looked up: every foreign lookup is read on the targets
     // this build compiles, and every command reads them the same way.
@@ -2519,14 +2522,17 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
   // `index`/`package_root`.
   let dep_sources = dependency_sources(package_root, package_targets)
   let registry =
-    signatures.merge(dep_sources.registry, build_project_registry(index))
+    signatures.merge(
+      dependency_registry(dep_sources),
+      build_project_registry(index),
+    )
   let type_info = build_type_index(index, package_root)
 
   let kb_base =
     effects.load_knowledge_base(
       packages_dir(package_root),
       manifest_path(package_root),
-      dep_sources.foreign,
+      dependency_foreign(dep_sources),
     )
     |> effects.with_package_targets(cfg.targets)
     // Consumer externals are applied before path-dep inference so a module-level
@@ -3032,92 +3038,132 @@ fn manifest_path(package_root: String) -> String {
 
 // Dependency sources
 //
-// What graded derives from a dependency's own `src/`: parameter positions for
-// positional argument matching, and the update-builder signatures its public
-// builders declare. One walk parses each file once and folds the parsed module
-// into both.
+// What graded derives from a dependency's own `src/`: the names each module
+// defines, parameter positions for positional argument matching, the
+// update-builder signatures its public builders declare, and the `@external`s
+// it declares. One walk parses each file once and derives all four from that
+// parse, under the module path the file sits at.
 
-// The signature registry and update-builder map derived from one or more
-// dependency source trees. Both come from the source the consumer compiled
-// against, so a builder resolved from `updates` can never skew from a stale
-// serialized `update` line — it takes precedence over the spec-loaded map. A
-// dependency whose source can't be parsed contributes to neither field and falls
-// back to its serialized signature.
+// What one or more dependency source trees yielded, held by module path rather
+// than flattened by name. Everything a module path contributes comes from the
+// single copy of it that won the scan: a dependency that moved to a path
+// dependency without a `gleam clean` leaves a stale copy under `build/packages`
+// beside the live one, and the copy this build compiles against is the only one
+// that speaks for the path — for what it defines, what its signatures are, what
+// builders it exports and what it declares foreign alike.
 type DependencySources {
-  DependencySources(
+  DependencySources(modules: Dict(String, ScannedModule))
+}
+
+// One scanned copy of a module path: everything derived from that single parse.
+type ScannedModule {
+  ParsedModule(
+    // The functions it defines, private ones included: the question is whether
+    // the name exists, and a line naming a private dependency function is dead
+    // for a different reason than a typo is.
+    functions: Set(String),
+    // Its parameter signatures, for positional argument matching at polymorphic
+    // call sites.
     registry: SignatureRegistry,
+    // The update builders it exports. Only public builders cross a package
+    // boundary, so only those are recorded. Read from the source the consumer
+    // compiled against, so a builder resolved from here can never skew from a
+    // stale serialized `update` line — it takes precedence over the spec-loaded
+    // map.
     updates: Dict(#(String, String), types.UpdateSignature),
-    // Every `@external` the dependencies declare. Scanned here because this walk
-    // already parses each dependency module once, and because it is the only
-    // evidence a consumer has: a dependency's spec cannot be trusted to say
-    // which of its own functions are foreign, since a stale line for one is
-    // exactly what this set exists to refuse.
+    // Every `@external` it declares. Scanned here because this walk already
+    // parses each dependency module once, and because it is the only evidence a
+    // consumer has: a dependency's spec cannot be trusted to say which of its
+    // own functions are foreign, since a stale line for one is exactly what
+    // this map exists to refuse.
     foreign: Dict(types.QualifiedName, types.ForeignFunction),
-    // The module paths this walk parsed. What the registry cannot express: a
-    // module that parsed and defines no function keys nothing in it, exactly
-    // like one that never parsed — and the spec lint owes those two different
-    // answers, since only the first proves a name absent.
-    parsed: Set(String),
   )
+  // The file would not read or parse. Recorded rather than dropped so it
+  // shadows any copy of the path scanned before it, and contributes nothing in
+  // its place: the shadowed copy is not the one this build compiles against,
+  // and a dependency graded cannot read falls back to its serialized signature.
+  UnreadableModule
 }
 
 fn empty_dependency_sources() -> DependencySources {
-  DependencySources(
-    registry: signatures.empty(),
-    updates: dict.new(),
-    foreign: dict.new(),
-    parsed: set.new(),
-  )
+  DependencySources(modules: dict.new())
+}
+
+// The three name-keyed views of a scan, each folded out of the winning copies
+// once the whole walk is in hand.
+
+// Parameter signatures for every function the scanned copies define.
+fn dependency_registry(sources: DependencySources) -> SignatureRegistry {
+  use acc, _path, scanned <- dict.fold(sources.modules, signatures.empty())
+  case scanned {
+    ParsedModule(registry:, ..) -> signatures.merge(acc, registry)
+    UnreadableModule -> acc
+  }
+}
+
+// The update builders the scanned copies export.
+fn dependency_updates(
+  sources: DependencySources,
+) -> Dict(#(String, String), types.UpdateSignature) {
+  use acc, _path, scanned <- dict.fold(sources.modules, dict.new())
+  case scanned {
+    ParsedModule(updates:, ..) -> dict.merge(acc, updates)
+    UnreadableModule -> acc
+  }
+}
+
+// The `@external`s the scanned copies declare.
+fn dependency_foreign(
+  sources: DependencySources,
+) -> Dict(types.QualifiedName, types.ForeignFunction) {
+  use acc, _path, scanned <- dict.fold(sources.modules, dict.new())
+  case scanned {
+    ParsedModule(foreign:, ..) -> dict.merge(acc, foreign)
+    UnreadableModule -> acc
+  }
 }
 
 // What a dependency's own source says about one name: the three answers the
 // spec lint owes a `module.function` it did not find in this package.
 type DependencyName {
-  // The module parsed and defines the function, private ones included: the
-  // question is whether the name exists, and a line naming a private dependency
-  // function is dead for a different reason than a typo is.
+  // The module's winning copy parsed and defines the function.
   DefinedByDependency
-  // The module parsed and defines no such function. The one answer that proves
-  // a name absent.
+  // It parsed and defines no such function. The one answer that proves a name
+  // absent.
   AbsentFromDependency
-  // No source graded read says anything: the module never parsed, or the walk
-  // never reached it. No evidence either way.
+  // No source graded read says anything: the winning copy would not parse, or
+  // the walk never reached the module. No evidence either way.
   UnreadDependency
 }
 
-// Answer for `name` from the scan. The two fields are read together and only
-// here: a registry miss means nothing without the `parsed` check beside it,
-// since a module that parses and defines no function keys as little as one that
-// never parsed.
+// Answer for `name` from the scan, read off the winning copy of its module and
+// that copy alone — the answer a name is owed is what the source this build
+// compiles against says, not what any copy left on disk beside it still holds.
 fn dependency_name(
   sources: DependencySources,
   name: QualifiedName,
 ) -> DependencyName {
-  use <- bool.guard(
-    when: !set.contains(sources.parsed, name.module),
-    return: UnreadDependency,
-  )
-  case signatures.defines(sources.registry, name) {
-    True -> DefinedByDependency
-    False -> AbsentFromDependency
+  case dict.get(sources.modules, name.module) {
+    Error(Nil) | Ok(UnreadableModule) -> UnreadDependency
+    Ok(ParsedModule(functions:, ..)) ->
+      case set.contains(functions, name.function) {
+        True -> DefinedByDependency
+        False -> AbsentFromDependency
+      }
   }
 }
 
-// Merge two scans; `b` wins on key conflict, matching `signatures.merge`.
+// Merge two scans; `b`'s copy of a module path replaces `a`'s whole, so no path
+// is ever spoken for by two copies at once.
 fn merge_dependency_sources(
   a: DependencySources,
   b: DependencySources,
 ) -> DependencySources {
-  DependencySources(
-    registry: signatures.merge(a.registry, b.registry),
-    updates: dict.merge(a.updates, b.updates),
-    foreign: dict.merge(a.foreign, b.foreign),
-    parsed: set.union(a.parsed, b.parsed),
-  )
+  DependencySources(modules: dict.merge(a.modules, b.modules))
 }
 
-// Every dependency's source-derived signatures: installed packages under
-// `build/packages`, then path dependencies, which win on key conflict.
+// Every dependency's source-derived entries: installed packages under
+// `build/packages`, then path dependencies, whose copy of a module path wins.
 fn dependency_sources(
   package_root: String,
   package_targets: types.PackageTargets,
@@ -3141,7 +3187,7 @@ fn with_builders(
   package_targets: types.PackageTargets,
 ) -> KnowledgeBase {
   knowledge_base
-  |> effects.with_updates(dep_sources.updates)
+  |> effects.with_updates(dependency_updates(dep_sources))
   |> effects.with_updates(
     qualify_by_module(index, extract.update_map(
       _,
@@ -3169,34 +3215,43 @@ fn packages_dir_sources(
   }
 }
 
-// Scan one package's `src/` tree, folding each parsed module into the registry
-// and into the update-builder map. Only public builders cross a package
-// boundary, so only those land in `updates`.
+// Scan one package's `src/` tree, recording what each module derives under its
+// module path. A file that would not read or parse derives nothing, and is
+// recorded as the unreadable copy of its path.
 fn source_dir_sources(
   source_dir: String,
   package_targets: types.PackageTargets,
 ) -> DependencySources {
-  use acc, module_path, module <- signatures.fold_source_dir(
+  use acc, module_path, parsed <- signatures.fold_source_dir(
     source_dir,
     empty_dependency_sources(),
   )
-  merge_dependency_sources(
-    acc,
-    DependencySources(
-      registry: signatures.from_glance_module(module_path, module),
-      updates: extract.public_update_signatures(
-        module,
-        module_path,
-        types.declaration_targets(package_targets),
-      ),
-      foreign: checker.dependency_foreign_functions(
-        module,
-        module_path,
-        package_targets,
-      ),
-      parsed: set.from_list([module_path]),
-    ),
-  )
+  let scanned = case parsed {
+    Ok(module) ->
+      ParsedModule(
+        functions: module_function_names(module),
+        registry: signatures.from_glance_module(module_path, module),
+        updates: extract.public_update_signatures(
+          module,
+          module_path,
+          types.declaration_targets(package_targets),
+        ),
+        foreign: checker.dependency_foreign_functions(
+          module,
+          module_path,
+          package_targets,
+        ),
+      )
+    Error(Nil) -> UnreadableModule
+  }
+  DependencySources(modules: dict.insert(acc.modules, module_path, scanned))
+}
+
+// Every function a module defines, public and private alike.
+fn module_function_names(module: glance.Module) -> Set(String) {
+  list.fold(module.functions, set.new(), fn(acc, definition) {
+    set.insert(acc, definition.definition.name)
+  })
 }
 
 fn find_gleam_toml_dir(dir: String, original: String) -> String {

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -648,10 +648,7 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     // Consumer externals are applied before path-dep inference so a module-level
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.
-    |> effects.with_externals(
-      declaring_externals(spec, stale_externals),
-      types.UserExternal,
-    )
+    |> with_spec_externals(spec, stale_externals)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
     |> with_committed_spec(spec, declared_modules, stale_externals)
@@ -678,10 +675,7 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     // whose effects it settled — an `@external`'s running fallback, whose
     // callers read the summary and never the body — kept an answer the two
     // commands would then disagree about.
-    |> effects.with_type_fields(
-      annotation.extract_type_fields(spec),
-      types.CommittedSpec,
-    )
+    |> with_spec_type_fields(spec)
     |> effects.with_factories(
       qualify_by_module(index, extract.factory_map(
         _,
@@ -1566,15 +1560,17 @@ fn spec_answer(
         Ok(answer.TypeFieldAnswer(module: Some(_), ..) as found) -> Ok(found)
         Ok(answer.TypeFieldAnswer(module: None, ..))
         | Ok(answer.FunctionAnswer(..))
-        | Ok(answer.UndeclaredExternalAnswer(..))
-        | Ok(answer.UnreachedDeclarationAnswer(..))
         | Error(Nil) -> Error(Nil)
       }
   }
 }
 
-// The spec-derived layers of `load_project_context`'s knowledge base, folded in
-// the same order and by the same functions, over nothing else.
+// The spec layers of `load_project_context`'s knowledge base, folded in the same
+// order and by the same functions, over nothing else.
+//
+// The spec's `returns` lines are not among them: a returned-operator summary is
+// consumed while walking a body, and a fast-path answer is one no body was
+// walked for.
 fn spec_knowledge_base(
   spec: GradedFile,
   stale_externals: Set(String),
@@ -1582,19 +1578,13 @@ fn spec_knowledge_base(
 ) -> KnowledgeBase {
   effects.new_knowledge_base()
   |> effects.with_package_targets(targets)
-  |> effects.with_externals(
-    declaring_externals(spec, stale_externals),
-    types.UserExternal,
-  )
+  |> with_spec_externals(spec, stale_externals)
   |> with_committed_spec(
     spec,
     annotation.module_external_modules(spec),
     stale_externals,
   )
-  |> effects.with_type_fields(
-    annotation.extract_type_fields(spec),
-    types.CommittedSpec,
-  )
+  |> with_spec_type_fields(spec)
 }
 
 // Whether the queried name is one of this package's `@external`s that falls
@@ -1776,18 +1766,29 @@ fn function_effect(
   // that nothing declares it named a cause the other surfaces do not.
   use <- bool.guard(
     when: charge.declaration != effects.DeclarationCharged,
-    return: Ok(answer.UnreachedDeclarationAnswer(
+    return: Ok(answer.FunctionAnswer(
       name:,
+      module:,
       bounds: fallback_bounds,
       term: charge.term,
-      fallback:,
+      source: case fallback {
+        // The body running in the declaration's place is the whole of the
+        // term, not a half added to it, so it is named as the source and not
+        // beside one.
+        Some(_) -> answer.RunningFallbackBody
+        None -> answer.UnreachedDeclaration
+      },
+      fallback: None,
     )),
   )
   use <- bool.guard(
     when: checker.undeclared_external(knowledge_base, qualified),
-    return: Ok(answer.UndeclaredExternalAnswer(
+    return: Ok(answer.FunctionAnswer(
       name:,
+      module:,
       bounds: fallback_bounds,
+      term: charge.term,
+      source: answer.UndeclaredExternal,
       fallback:,
     )),
   )
@@ -1801,7 +1802,7 @@ fn function_effect(
         module:,
         bounds: fallback_bounds,
         term:,
-        source: types.ModuleExternalEntry(origin:),
+        source: answer.Entry(types.ModuleExternalEntry(origin:)),
         fallback:,
       ))
     effects.Known(term, types.FunctionEntry(origin:)) ->
@@ -1810,7 +1811,7 @@ fn function_effect(
         module:,
         bounds: effects.lookup_param_bounds(knowledge_base, qualified),
         term:,
-        source: types.FunctionEntry(origin:),
+        source: answer.Entry(types.FunctionEntry(origin:)),
         fallback:,
       ))
   }
@@ -2564,10 +2565,7 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
     // Consumer externals are applied before path-dep inference so a module-level
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.
-    |> effects.with_externals(
-      declaring_externals(spec, stale_externals),
-      types.UserExternal,
-    )
+    |> with_spec_externals(spec, stale_externals)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
     |> effects.with_foreign_functions(project_foreign_functions(
@@ -2577,10 +2575,7 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
 
   let base_kb =
     kb_base
-    |> effects.with_type_fields(
-      annotation.extract_type_fields(spec),
-      types.CommittedSpec,
-    )
+    |> with_spec_type_fields(spec)
     |> effects.with_factories(
       qualify_by_module(index, extract.factory_map(
         _,
@@ -3547,6 +3542,41 @@ fn infer_path_dep_module(
       )
     }
   }
+}
+
+// The spec's layers of a knowledge base
+//
+// Three folds compose them: `check`'s, `infer`'s, and the `effect` query's
+// spec-only fast path, each interleaving its own layers between them. What
+// these hold is the derivation of a layer's arguments and the origin it is
+// tagged with — the halves that could disagree between folds. Which layers a
+// fold applies is the fold's own: the fast path is held to the full context's
+// answer by a test comparing the two, not by this grouping.
+
+// The spec's `external effects` declarations, minus the stale ones.
+fn with_spec_externals(
+  knowledge_base: KnowledgeBase,
+  spec: GradedFile,
+  stale_externals: Set(String),
+) -> KnowledgeBase {
+  effects.with_externals(
+    knowledge_base,
+    declaring_externals(spec, stale_externals),
+    types.UserExternal,
+  )
+}
+
+// The spec's `type` lines, which resolve a field call on any receiver of the
+// named type.
+fn with_spec_type_fields(
+  knowledge_base: KnowledgeBase,
+  spec: GradedFile,
+) -> KnowledgeBase {
+  effects.with_type_fields(
+    knowledge_base,
+    annotation.extract_type_fields(spec),
+    types.CommittedSpec,
+  )
 }
 
 // Fold a spec file's committed `effects` lines and their parameter bounds into

--- a/src/graded/internal/answer.gleam
+++ b/src/graded/internal/answer.gleam
@@ -22,55 +22,20 @@ import graded/internal/types.{
 
 pub type EffectAnswer {
   // A qualified function: its effect term, the parameter bounds binding that
-  // term's variables, and which knowledge-base entry answered.
+  // term's variables, and what answered for it.
   FunctionAnswer(
     // The name as queried, module qualifier included.
     name: String,
     module: String,
     bounds: List(ParamBound),
     term: EffectTerm,
-    source: types.EffectSource,
+    source: AnswerSource,
     // What a Gleam fallback body running on an uncovered target contributed to
     // `term`, when the name is an `@external` that has one. `source` speaks for
     // the declaration only, so without this the union would read as what the
-    // declaration said.
-    fallback: Option(EffectTerm),
-  )
-  // A function whose implementation is foreign code — an `@external` — that
-  // nothing declares. The entries the knowledge base holds for such a name were
-  // inferred over a body the foreign implementation needn't match, so none of
-  // them answers, and the effects are the `[Unknown]` `check` and `why` charge
-  // for it.
-  //
-  // `fallback` is what its Gleam fallback body does where that body runs, when
-  // it has one. Nothing declares the external, but the fallback is ordinary code
-  // graded walked, so those effects are charged beside the `[Unknown]` — and the
-  // answer states them, as `check` and `why` do.
-  //
-  // `bounds` binds that fallback's variables. A fallback that calls a
-  // function-typed parameter states its effects over the parameter, so the
-  // bounds travel with the term the way they do for any other function; without
-  // them the line names a variable nothing introduces.
-  UndeclaredExternalAnswer(
-    name: String,
-    bounds: List(ParamBound),
-    fallback: Option(EffectTerm),
-  )
-  // A function whose implementation is foreign code, and whose declaration names
-  // only targets this build does not compile. What it declares is no part of
-  // what a caller pays, so neither its effects nor its source appear here —
-  // crediting a shipped spec with the conservative `[Unknown]` an out-of-reach
-  // declaration collapses to points the reader at the very line the answer ruled
-  // out.
-  //
-  // `term` is what the build does reach: a Gleam fallback body running in the
-  // declaration's place, or the `[Unknown]` standing for a name nothing in reach
-  // implements at all. `fallback` names that body where one runs, and tells the
-  // two apart.
-  UnreachedDeclarationAnswer(
-    name: String,
-    bounds: List(ParamBound),
-    term: EffectTerm,
+    // declaration said. `None` where the fallback is not a half added to a
+    // declaration but the whole of what was charged — `RunningFallbackBody`
+    // says so.
     fallback: Option(EffectTerm),
   )
   // A field of a custom type, declared by a `type` line. `module` is `None` for
@@ -82,6 +47,36 @@ pub type EffectAnswer {
     term: EffectTerm,
     origin: types.TypeFieldOrigin,
   )
+}
+
+// What answered for a function: the knowledge-base entry that keyed it, or —
+// for foreign code no entry may speak for — the standing that settled its term
+// instead.
+pub type AnswerSource {
+  // The entry the lookup returned, and which map it came from.
+  Entry(entry: types.EffectSource)
+  // A function whose implementation is foreign code — an `@external` — that
+  // nothing declares. The entries the knowledge base holds for such a name were
+  // inferred over a body the foreign implementation needn't match, so none of
+  // them answers, and the effects are the `[Unknown]` `check` and `why` charge
+  // for it, unioned with whatever a running Gleam fallback body does.
+  //
+  // The bounds beside it bind that fallback's variables: a fallback that calls
+  // a function-typed parameter states its effects over the parameter, and
+  // without them the line names a variable nothing introduces.
+  UndeclaredExternal
+  // A function whose implementation is foreign code, whose declaration names
+  // only targets this build does not compile, and which no Gleam body runs in
+  // the place of: nothing this build reaches implements the name at all. What
+  // the declaration says is no part of what a caller pays, so neither it nor
+  // its source is named — crediting a shipped spec with the conservative
+  // `[Unknown]` an out-of-reach declaration collapses to points the reader at
+  // the very line the answer ruled out.
+  UnreachedDeclaration
+  // The same out-of-reach declaration, with a Gleam fallback body running in
+  // its place. That body is the whole of the term, not a half added to a
+  // declaration.
+  RunningFallbackBody
 }
 
 // Rendering
@@ -109,41 +104,14 @@ pub fn render(answer: EffectAnswer, format: Format) -> String {
 
 pub fn render_graded(answer: EffectAnswer) -> String {
   case answer {
-    // A module-level external declares no per-function bounds itself, but a
+    // Whatever bounds the lookup found are rendered, whichever source answered:
+    // a module-level external declares no per-function bounds itself, but a
     // running fallback body under it states its own effects over the parameters
-    // it calls — so whatever bounds the lookup found are rendered, and the line
-    // is labelled with the module that answered.
-    FunctionAnswer(
-      name:,
-      module:,
-      bounds:,
-      term:,
-      source: types.ModuleExternalEntry(..),
-      fallback:,
-    ) ->
+    // it calls.
+    FunctionAnswer(name:, module:, bounds:, term:, source:, fallback:) ->
       effects_line(name, bounds, term)
-      <> "\n// resolved via module-level external for "
-      <> module
+      <> graded_source(module, source)
       <> graded_fallback(fallback)
-    FunctionAnswer(
-      name:,
-      bounds:,
-      term:,
-      source: types.FunctionEntry(origin:),
-      fallback:,
-      ..,
-    ) ->
-      effects_line(name, bounds, term)
-      <> graded_source(origin)
-      <> graded_fallback(fallback)
-    UndeclaredExternalAnswer(name:, bounds:, fallback:) ->
-      effects_line(name, bounds, undeclared_term(fallback))
-      <> "\n// an external with no declared effects"
-      <> graded_fallback(fallback)
-    UnreachedDeclarationAnswer(name:, bounds:, term:, fallback:) ->
-      effects_line(name, bounds, term)
-      <> "\n// "
-      <> unreached_declaration_source(fallback)
     TypeFieldAnswer(module:, type_name:, field:, term:, origin:) ->
       annotation.format_type_field(TypeFieldAnnotation(
         module:,
@@ -169,9 +137,19 @@ fn effects_line(
   ))
 }
 
-// The comment naming the source that wrote the winning entry.
-fn graded_source(origin: types.LookupOrigin) -> String {
-  "\n// resolved from " <> effects.describe_origin(origin)
+// The comment naming what answered: the source that wrote the winning entry,
+// or the standing that settled the term where no entry could.
+fn graded_source(module: String, source: AnswerSource) -> String {
+  "\n// "
+  <> case source {
+    Entry(types.ModuleExternalEntry(..)) ->
+      "resolved via module-level external for " <> module
+    Entry(types.FunctionEntry(origin:)) ->
+      "resolved from " <> effects.describe_origin(origin)
+    UndeclaredExternal -> undeclared_external_source
+    UnreachedDeclaration -> unreached_declaration_source
+    RunningFallbackBody -> running_fallback_source
+  }
 }
 
 // Only `Declared` entries reach the knowledge base today — `with_type_fields`
@@ -209,55 +187,26 @@ pub fn render_prose(answer: EffectAnswer) -> String {
         )
       ]
       |> string.join("\n")
-    // The same lines the `check`/`why` vocabulary gives it: what the effects
-    // are, that nothing declared them, the bounds its fallback states them
-    // over, and what that body added.
-    UndeclaredExternalAnswer(name:, bounds:, fallback:) ->
-      [
-        function_sentence(name, bounds, undeclared_term(fallback)),
-        "  source: an external with no declared effects",
-        ..list.append(bound_lines(bounds), prose_fallback(fallback))
-      ]
-      |> string.join("\n")
-    // No `plus its Gleam fallback body` line beside the source: the body here is
-    // not a half added to a declaration, it is the whole of what was charged.
-    UnreachedDeclarationAnswer(name:, bounds:, term:, fallback:) ->
-      [
-        function_sentence(name, bounds, term),
-        "  source: " <> unreached_declaration_source(fallback),
-        ..bound_lines(bounds)
-      ]
-      |> string.join("\n")
     TypeFieldAnswer(module:, type_name:, field:, term:, origin:) ->
       [field_sentence(module, type_name, field, term), prose_origin(origin)]
       |> string.join("\n")
   }
 }
 
+// The sentences for the sources no knowledge-base entry wrote, worded once so
+// the two formats state them identically.
+
 // The source a name answered by the Gleam body running in its declaration's
 // place names. `why` says the same of a call, stated from the calling body's
 // targets; the query answers for the package, so it names the build's.
 const running_fallback_source = "its Gleam fallback body, which is what runs on the targets this build compiles"
 
-// What answered for a name whose declaration this build reaches no part of: the
-// Gleam body running in the declaration's place, or nothing at all where there
-// is no such body.
-fn unreached_declaration_source(fallback: Option(EffectTerm)) -> String {
-  case fallback {
-    None -> "an external declared only for a target this build does not compile"
-    Some(_) -> running_fallback_source
-  }
-}
+// What answered for a name whose declaration this build reaches no part of and
+// which no Gleam body runs in the place of.
+const unreached_declaration_source = "an external declared only for a target this build does not compile"
 
-// What an undeclared external is charged: the conservative `[Unknown]`, plus
-// whatever its Gleam fallback body does where that body runs.
-fn undeclared_term(fallback: Option(EffectTerm)) -> EffectTerm {
-  case fallback {
-    None -> effect_term.unknown()
-    Some(term) ->
-      effect_term.normalize(types.TUnion([term, effect_term.unknown()]))
-  }
-}
+// What answered for foreign code nothing declares.
+const undeclared_external_source = "an external with no declared effects"
 
 // The half of the answer the declaration does not account for, named apart from
 // it so neither is credited with the other's effects.
@@ -378,20 +327,23 @@ fn ground_labels(term: EffectTerm) -> Result(Set(String), Nil) {
 fn detail_lines(
   bounds: List(ParamBound),
   module: String,
-  source: types.EffectSource,
+  source: AnswerSource,
 ) -> List(String) {
   // The bound lines follow the source lines: each states an assumption the
   // checker applies to that argument at call sites. They follow either source —
   // a module-level external declares none itself, but a running fallback body
   // under it does, and the assumption holds however the entry was reached.
   let source_lines = case source {
-    types.ModuleExternalEntry(..) -> [
+    Entry(types.ModuleExternalEntry(..)) -> [
       "  source: module-level external for `" <> module <> "`",
       "          used when no per-function entry exists",
     ]
-    types.FunctionEntry(origin:) -> [
+    Entry(types.FunctionEntry(origin:)) -> [
       "  source: " <> effects.describe_origin(origin),
     ]
+    UndeclaredExternal -> ["  source: " <> undeclared_external_source]
+    UnreachedDeclaration -> ["  source: " <> unreached_declaration_source]
+    RunningFallbackBody -> ["  source: " <> running_fallback_source]
   }
   list.append(source_lines, bound_lines(bounds))
 }

--- a/src/graded/internal/answer.gleam
+++ b/src/graded/internal/answer.gleam
@@ -30,13 +30,6 @@ pub type EffectAnswer {
     bounds: List(ParamBound),
     term: EffectTerm,
     source: AnswerSource,
-    // What a Gleam fallback body running on an uncovered target contributed to
-    // `term`, when the name is an `@external` that has one. `source` speaks for
-    // the declaration only, so without this the union would read as what the
-    // declaration said. `None` where the fallback is not a half added to a
-    // declaration but the whole of what was charged — `RunningFallbackBody`
-    // says so.
-    fallback: Option(EffectTerm),
   )
   // A field of a custom type, declared by a `type` line. `module` is `None` for
   // a bare declaration, which is keyed under no module.
@@ -52,9 +45,16 @@ pub type EffectAnswer {
 // What answered for a function: the knowledge-base entry that keyed it, or —
 // for foreign code no entry may speak for — the standing that settled its term
 // instead.
+//
+// The two that name a declaration a Gleam fallback body can be added to carry
+// that body's contribution themselves, so no answer can state a fallback half
+// beside a source that already accounts for the whole term.
 pub type AnswerSource {
-  // The entry the lookup returned, and which map it came from.
-  Entry(entry: types.EffectSource)
+  // The entry the lookup returned, and which map it came from, beside what a
+  // Gleam fallback body running on an uncovered target contributed to the term.
+  // The source speaks for the declaration only, so without that half the union
+  // would read as what the declaration said.
+  Entry(entry: types.EffectSource, fallback: Option(EffectTerm))
   // A function whose implementation is foreign code — an `@external` — that
   // nothing declares. The entries the knowledge base holds for such a name were
   // inferred over a body the foreign implementation needn't match, so none of
@@ -64,7 +64,7 @@ pub type AnswerSource {
   // The bounds beside it bind that fallback's variables: a fallback that calls
   // a function-typed parameter states its effects over the parameter, and
   // without them the line names a variable nothing introduces.
-  UndeclaredExternal
+  UndeclaredExternal(fallback: Option(EffectTerm))
   // A function whose implementation is foreign code, whose declaration names
   // only targets this build does not compile, and which no Gleam body runs in
   // the place of: nothing this build reaches implements the name at all. What
@@ -108,10 +108,10 @@ pub fn render_graded(answer: EffectAnswer) -> String {
     // a module-level external declares no per-function bounds itself, but a
     // running fallback body under it states its own effects over the parameters
     // it calls.
-    FunctionAnswer(name:, module:, bounds:, term:, source:, fallback:) ->
+    FunctionAnswer(name:, module:, bounds:, term:, source:) ->
       effects_line(name, bounds, term)
       <> graded_source(module, source)
-      <> graded_fallback(fallback)
+      <> graded_fallback(source_fallback(source))
     TypeFieldAnswer(module:, type_name:, field:, term:, origin:) ->
       annotation.format_type_field(TypeFieldAnnotation(
         module:,
@@ -142,11 +142,11 @@ fn effects_line(
 fn graded_source(module: String, source: AnswerSource) -> String {
   "\n// "
   <> case source {
-    Entry(types.ModuleExternalEntry(..)) ->
+    Entry(entry: types.ModuleExternalEntry(..), ..) ->
       "resolved via module-level external for " <> module
-    Entry(types.FunctionEntry(origin:)) ->
+    Entry(entry: types.FunctionEntry(origin:), ..) ->
       "resolved from " <> effects.describe_origin(origin)
-    UndeclaredExternal -> undeclared_external_source
+    UndeclaredExternal(..) -> undeclared_external_source
     UnreachedDeclaration -> unreached_declaration_source
     RunningFallbackBody -> running_fallback_source
   }
@@ -178,12 +178,12 @@ fn graded_origin(origin: types.TypeFieldOrigin) -> String {
 
 pub fn render_prose(answer: EffectAnswer) -> String {
   case answer {
-    FunctionAnswer(name:, module:, bounds:, term:, source:, fallback:) ->
+    FunctionAnswer(name:, module:, bounds:, term:, source:) ->
       [
         function_sentence(name, bounds, term),
         ..list.append(
           detail_lines(bounds, module, source),
-          prose_fallback(fallback),
+          prose_fallback(source_fallback(source)),
         )
       ]
       |> string.join("\n")
@@ -207,6 +207,16 @@ const unreached_declaration_source = "an external declared only for a target thi
 
 // What answered for foreign code nothing declares.
 const undeclared_external_source = "an external with no declared effects"
+
+// The fallback half of a source that carries one. The other two sources carry
+// none: a body running in an unreached declaration's place is the whole of the
+// term, not a half added to it, and there is nothing to name beside it.
+fn source_fallback(source: AnswerSource) -> Option(EffectTerm) {
+  case source {
+    Entry(fallback:, ..) | UndeclaredExternal(fallback:) -> fallback
+    UnreachedDeclaration | RunningFallbackBody -> None
+  }
+}
 
 // The half of the answer the declaration does not account for, named apart from
 // it so neither is credited with the other's effects.
@@ -334,14 +344,14 @@ fn detail_lines(
   // a module-level external declares none itself, but a running fallback body
   // under it does, and the assumption holds however the entry was reached.
   let source_lines = case source {
-    Entry(types.ModuleExternalEntry(..)) -> [
+    Entry(entry: types.ModuleExternalEntry(..), ..) -> [
       "  source: module-level external for `" <> module <> "`",
       "          used when no per-function entry exists",
     ]
-    Entry(types.FunctionEntry(origin:)) -> [
+    Entry(entry: types.FunctionEntry(origin:), ..) -> [
       "  source: " <> effects.describe_origin(origin),
     ]
-    UndeclaredExternal -> ["  source: " <> undeclared_external_source]
+    UndeclaredExternal(..) -> ["  source: " <> undeclared_external_source]
     UnreachedDeclaration -> ["  source: " <> unreached_declaration_source]
     RunningFallbackBody -> ["  source: " <> running_fallback_source]
   }

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1805,9 +1805,10 @@ pub fn load_catalog(
   let selected = resolve_catalog_files(catalog_files, installed_versions)
   let initial = CatalogAcc(dict.new(), dict.new(), dict.new(), dict.new(), [])
   let acc = list.fold(selected, initial, fold_catalog_file)
-  // Explicit `effects` annotations in the catalog take precedence over the
-  // module-level `external effects` markers. Each term carries the package that
-  // wrote it, so the winner of this merge brings its own origin.
+  // Across files, an `effects` annotation takes precedence over another
+  // package's per-function `external effects` marker; within one file the
+  // external already won, in `fold_catalog_file`. Each term carries the package
+  // that wrote it, so the winner of this merge brings its own origin.
   #(
     dict.merge(acc.ext_effects, acc.poly_effects),
     acc.module_effects,
@@ -1837,8 +1838,16 @@ fn fold_catalog_file(acc: CatalogAcc, entry: #(String, String)) -> CatalogAcc {
           // are scoped like everyone else's. Merging with the new file second
           // keeps the later file winning on a clash, as folding per-annotation
           // did.
+          // A name this file keys both ways resolves to its `external
+          // effects` line, the rule `decided_entries` applies to a dependency's
+          // own spec: the external's ground term is what the empty bounds
+          // `load_spec_params_from_file` records for the name pair with.
           let file_poly_effects =
-            with_origin(load_spec_effects_from_file(graded_file), origin)
+            load_spec_effects_from_file(graded_file)
+            |> dict.filter(fn(name, _term) {
+              !dict.has_key(function_externals, name)
+            })
+            |> with_origin(origin)
           CatalogAcc(
             ext_effects: dict.merge(acc.ext_effects, function_externals),
             module_effects: dict.merge(acc.module_effects, module_externals),

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1778,6 +1778,11 @@ type CatalogAcc {
     ext_effects: Dict(QualifiedName, #(EffectTerm, LookupOrigin)),
     module_effects: Dict(String, #(EffectTerm, LookupOrigin)),
     poly_effects: Dict(QualifiedName, #(EffectTerm, LookupOrigin)),
+    // The bounds of each tier, held apart and merged the way the terms beside
+    // them are: a name's term and its bounds must come out of one file, or a
+    // polymorphic term wins with another file's empty bounds beside it and its
+    // variable is left with nothing to bind it.
+    ext_params: Dict(QualifiedName, List(ParamBound)),
     poly_params: Dict(QualifiedName, List(ParamBound)),
     type_fields: List(#(TypeFieldAnnotation, LookupOrigin)),
   )
@@ -1803,16 +1808,19 @@ pub fn load_catalog(
     Error(_) -> []
   }
   let selected = resolve_catalog_files(catalog_files, installed_versions)
-  let initial = CatalogAcc(dict.new(), dict.new(), dict.new(), dict.new(), [])
+  let initial =
+    CatalogAcc(dict.new(), dict.new(), dict.new(), dict.new(), dict.new(), [])
   let acc = list.fold(selected, initial, fold_catalog_file)
   // Across files, an `effects` annotation takes precedence over another
   // package's per-function `external effects` marker; within one file the
   // external already won, in `fold_catalog_file`. Each term carries the package
-  // that wrote it, so the winner of this merge brings its own origin.
+  // that wrote it, so the winner of this merge brings its own origin. The
+  // bounds are merged by the same rule and in the same order, so the file whose
+  // term wins a name is the file whose bounds pair with it.
   #(
     dict.merge(acc.ext_effects, acc.poly_effects),
     acc.module_effects,
-    acc.poly_params,
+    dict.merge(acc.ext_params, acc.poly_params),
     acc.type_fields,
   )
 }
@@ -1840,8 +1848,8 @@ fn fold_catalog_file(acc: CatalogAcc, entry: #(String, String)) -> CatalogAcc {
           // did.
           // A name this file keys both ways resolves to its `external
           // effects` line, the rule `decided_entries` applies to a dependency's
-          // own spec: the external's ground term is what the empty bounds
-          // `load_spec_params_from_file` records for the name pair with.
+          // own spec: dropped from the polymorphic tier here, it keeps the
+          // ground term and the empty bounds the external tier records.
           let file_poly_effects =
             load_spec_effects_from_file(graded_file)
             |> dict.filter(fn(name, _term) {
@@ -1852,11 +1860,22 @@ fn fold_catalog_file(acc: CatalogAcc, entry: #(String, String)) -> CatalogAcc {
             ext_effects: dict.merge(acc.ext_effects, function_externals),
             module_effects: dict.merge(acc.module_effects, module_externals),
             poly_effects: dict.merge(acc.poly_effects, file_poly_effects),
+            // An external's term is ground by construction, so the bounds
+            // pairing with it are empty ones.
+            ext_params: dict.merge(
+              acc.ext_params,
+              dict.map_values(function_externals, fn(_name, _entry) { [] }),
+            ),
             poly_params: dict.merge(
               acc.poly_params,
               // A catalog entry describes a package graded has no source for,
               // so none of its externals can be stale by the visible-body rule.
-              load_spec_params_from_file(graded_file),
+              // Kept only for the names whose term this file supplies, so the
+              // two travel together through both merges.
+              load_spec_params_from_file(graded_file)
+                |> dict.filter(fn(name, _bounds) {
+                  dict.has_key(file_poly_effects, name)
+                }),
             ),
             type_fields: list.append(
               acc.type_fields,

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -84,14 +84,6 @@ pub fn merge(a: SignatureRegistry, b: SignatureRegistry) -> SignatureRegistry {
   SignatureRegistry(signatures: dict.merge(a.signatures, b.signatures))
 }
 
-// Whether the registry holds a signature for `name`: whether the module it
-// names was parsed and defines the function. Every function of a parsed module
-// is registered, empty parameter list included, so this answers existence and
-// not just "has parameters worth recording".
-pub fn defines(registry: SignatureRegistry, name: QualifiedName) -> Bool {
-  dict.has_key(registry.signatures, name)
-}
-
 // Look up a function's parameter signatures.
 pub fn lookup(
   registry: SignatureRegistry,
@@ -476,18 +468,22 @@ fn is_function_type(t: glance.Type) -> Bool {
 
 // Parse every `.gleam` file under `source_dir` with glance and fold it into
 // `initial`, in walk order. `step` receives the module path the file's location
-// denotes (`<source_dir>/gleam/list.gleam` → `gleam/list`) and the parsed
-// module. Folding rather than returning a list keeps one AST live at a time, so
-// a package's whole source never sits in memory at once.
+// denotes (`<source_dir>/gleam/list.gleam` → `gleam/list`) and the parse of it,
+// or `Error(Nil)` where the file would not read or parse. Folding rather than
+// returning a list keeps one AST live at a time, so a package's whole source
+// never sits in memory at once.
 //
-// Failures (a missing directory, parse errors from version mismatches, FFI-only
-// Erlang packages) are silently skipped — the affected files contribute nothing,
-// so calls into them fall back to label-only argument matching at polymorphic
-// call sites.
+// A file that will not read or parse (a version mismatch, an FFI-only Erlang
+// package) is handed to `step` rather than skipped: it derives nothing, but it
+// still names a module path, and a caller recording which copy of a path it
+// read needs the copies it could not read too. A caller with nothing to record
+// for them drops them, and calls into them fall back to label-only argument
+// matching at polymorphic call sites. A missing directory yields `initial`,
+// with no step at all.
 pub fn fold_source_dir(
   source_dir: String,
   initial: acc,
-  step: fn(acc, String, Module) -> acc,
+  step: fn(acc, String, Result(Module, Nil)) -> acc,
 ) -> acc {
   case simplifile.get_files(source_dir) {
     Error(_) -> initial
@@ -502,15 +498,7 @@ pub fn fold_source_dir(
           ))
           result.replace_error(glance.module(source), Nil)
         }
-        case parsed {
-          Ok(module) ->
-            step(
-              acc,
-              config.module_path_for_source(gleam_path, source_dir),
-              module,
-            )
-          Error(Nil) -> acc
-        }
+        step(acc, config.module_path_for_source(gleam_path, source_dir), parsed)
       })
   }
 }

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -84,6 +84,14 @@ pub fn merge(a: SignatureRegistry, b: SignatureRegistry) -> SignatureRegistry {
   SignatureRegistry(signatures: dict.merge(a.signatures, b.signatures))
 }
 
+// Whether the registry holds a signature for `name`: whether the module it
+// names was parsed and defines the function. Every function of a parsed module
+// is registered, empty parameter list included, so this answers existence and
+// not just "has parameters worth recording".
+pub fn defines(registry: SignatureRegistry, name: QualifiedName) -> Bool {
+  dict.has_key(registry.signatures, name)
+}
+
 // Look up a function's parameter signatures.
 pub fn lookup(
   registry: SignatureRegistry,

--- a/test/answer_test.gleam
+++ b/test/answer_test.gleam
@@ -27,7 +27,7 @@ fn function(
     module: "app",
     bounds:,
     term:,
-    source: FunctionEntry(origin: CommittedSpec),
+    source: answer.Entry(FunctionEntry(origin: CommittedSpec)),
     fallback: None,
   )
 }
@@ -141,9 +141,9 @@ pub fn a_module_level_external_states_its_precedence_test() {
     module: "fake_clock",
     bounds: [],
     term: labels(["Time"]),
-    source: ModuleExternalEntry(origin: ModuleExternalOrigin(
-      source: UserExternal,
-    )),
+    source: answer.Entry(
+      ModuleExternalEntry(origin: ModuleExternalOrigin(source: UserExternal)),
+    ),
     fallback: None,
   )
   |> prose
@@ -163,7 +163,7 @@ fn from(origin: types.LookupOrigin) -> answer.EffectAnswer {
     module: "app",
     bounds: [],
     term: labels(["Stdout"]),
-    source: FunctionEntry(origin:),
+    source: answer.Entry(FunctionEntry(origin:)),
     fallback: None,
   )
 }
@@ -188,7 +188,7 @@ pub fn a_source_line_precedes_the_bounds_test() {
     module: "app",
     bounds: [ParamBound("f", labels(["Stdout"]))],
     term: labels(["Stdout"]),
-    source: FunctionEntry(origin: Catalog("gleam_stdlib")),
+    source: answer.Entry(FunctionEntry(origin: Catalog("gleam_stdlib"))),
     fallback: None,
   )
   |> prose

--- a/test/answer_test.gleam
+++ b/test/answer_test.gleam
@@ -27,8 +27,7 @@ fn function(
     module: "app",
     bounds:,
     term:,
-    source: answer.Entry(FunctionEntry(origin: CommittedSpec)),
-    fallback: None,
+    source: answer.Entry(FunctionEntry(origin: CommittedSpec), None),
   )
 }
 
@@ -143,14 +142,33 @@ pub fn a_module_level_external_states_its_precedence_test() {
     term: labels(["Time"]),
     source: answer.Entry(
       ModuleExternalEntry(origin: ModuleExternalOrigin(source: UserExternal)),
+      None,
     ),
-    fallback: None,
   )
   |> prose
   |> should.equal(
     "fake_clock.now has effects [Time]
   source: module-level external for `fake_clock`
           used when no per-function entry exists",
+  )
+}
+
+pub fn a_fallback_body_is_stated_beside_the_source_it_adds_to_test() {
+  // A running fallback body is a half added to what the source names, so it is
+  // carried by that source and stated after it. The sources that account for
+  // the whole term carry none, which is why no answer can state both.
+  answer.FunctionAnswer(
+    name: "app.now",
+    module: "app",
+    bounds: [],
+    term: labels(["Time", "Stdout"]),
+    source: answer.UndeclaredExternal(Some(labels(["Stdout"]))),
+  )
+  |> prose
+  |> should.equal(
+    "app.now has effects [Stdout, Time]
+  source: an external with no declared effects
+  plus its Gleam fallback body, which runs on the targets its `@external` declares no implementation for: [Stdout]",
   )
 }
 
@@ -163,8 +181,7 @@ fn from(origin: types.LookupOrigin) -> answer.EffectAnswer {
     module: "app",
     bounds: [],
     term: labels(["Stdout"]),
-    source: answer.Entry(FunctionEntry(origin:)),
-    fallback: None,
+    source: answer.Entry(FunctionEntry(origin:), None),
   )
 }
 
@@ -188,8 +205,7 @@ pub fn a_source_line_precedes_the_bounds_test() {
     module: "app",
     bounds: [ParamBound("f", labels(["Stdout"]))],
     term: labels(["Stdout"]),
-    source: answer.Entry(FunctionEntry(origin: Catalog("gleam_stdlib"))),
-    fallback: None,
+    source: answer.Entry(FunctionEntry(origin: Catalog("gleam_stdlib")), None),
   )
   |> prose
   |> should.equal(

--- a/test/effect_cli_test.gleam
+++ b/test/effect_cli_test.gleam
@@ -497,6 +497,33 @@ pub fn prose_states_module_external_precedence_test() {
   )
 }
 
+// Both formats' answers for a dependency `@external` declared only for a target
+// this build does not compile. `body` is what the declaration sits over — `""`
+// for a bodiless one, a Gleam block for one the build runs in its place.
+fn out_of_reach_outputs(name: String, body: String) -> #(String, String) {
+  let project =
+    write_fixture("build/" <> name, [
+      #("gleam.toml", "name = \"" <> name <> "\"\ntarget = \"erlang\"\n"),
+      #(name <> ".graded", ""),
+      #(
+        "build/packages/dep/dep.graded",
+        "external effects dep/ffi.run : [Time]\n",
+      ),
+      #(
+        "build/packages/dep/src/dep/ffi.gleam",
+        "@external(javascript, \"dep_ffi\", \"run\")\npub fn run() -> Nil"
+          <> body
+          <> "\n",
+      ),
+    ])
+  let assert Ok(prose_output) =
+    graded.run_effect_formatted(project, "dep/ffi.run", answer.Prose)
+  let assert Ok(graded_output) =
+    graded.run_effect_formatted(project, "dep/ffi.run", answer.Graded)
+  cleanup(project)
+  #(prose_output, graded_output)
+}
+
 pub fn prose_names_an_out_of_reach_declaration_test() {
   // The dependency ships a declaration for JavaScript, this package names
   // Erlang, and `run` has no Gleam body to run in its place — so the charge is
@@ -504,37 +531,79 @@ pub fn prose_names_an_out_of_reach_declaration_test() {
   // declaration's source beside it credited dep's shipped `[Time]` line with a
   // set that line states no part of, sending the reader to a declaration the
   // answer had just ruled out.
+  out_of_reach_outputs("graded_effect_out_of_reach", "")
+  |> should.equal(#(
+    "dep/ffi.run has effects that could not be determined: [Unknown]
+  source: an external declared only for a target this build does not compile",
+    "effects dep/ffi.run : [Unknown]
+// an external declared only for a target this build does not compile",
+  ))
+}
+
+pub fn prose_names_the_body_running_in_a_declarations_place_test() {
+  // The same out-of-reach declaration, except `run` has a Gleam body to run in
+  // its place. That body is the whole of what the build reaches, so it is named
+  // as the source rather than beside one — no `plus its Gleam fallback body`
+  // line, which would read as a half added to a declaration that pays for none
+  // of it.
+  out_of_reach_outputs("graded_effect_fallback_in_reach", " {\n  Nil\n}")
+  |> should.equal(#(
+    "dep/ffi.run has effects that could not be determined: [Unknown]
+  source: its Gleam fallback body, which is what runs on the targets this build compiles",
+    "effects dep/ffi.run : [Unknown]
+// its Gleam fallback body, which is what runs on the targets this build compiles",
+  ))
+}
+
+pub fn an_undeclared_external_states_its_running_fallback_test() {
+  // Nothing declares `raw.op`, and its Gleam body runs on the target its
+  // `@external` leaves uncovered. The answer is the `[Unknown]` an undeclared
+  // external carries unioned with what that body does, and the body is named
+  // apart from that half so neither is credited with the other's effects.
   let project =
-    write_fixture("build/graded_effect_out_of_reach", [
+    write_fixture("build/graded_effect_undeclared_fallback", [
       #(
         "gleam.toml",
-        "name = \"graded_effect_out_of_reach\"\ntarget = \"erlang\"\n",
-      ),
-      #("graded_effect_out_of_reach.graded", ""),
-      #(
-        "build/packages/dep/dep.graded",
-        "external effects dep/ffi.run : [Time]\n",
+        support.dual_target_toml("graded_effect_undeclared_fallback"),
       ),
       #(
-        "build/packages/dep/src/dep/ffi.gleam",
-        "@external(javascript, \"dep_ffi\", \"run\")
-pub fn run() -> Nil
+        "graded_effect_undeclared_fallback.graded",
+        "external effects ffi.disk : [Disk]\n",
+      ),
+      #(
+        "ffi.gleam",
+        "@external(erlang, \"d\", \"w\")
+@external(javascript, \"d\", \"w\")
+pub fn disk() -> Nil
+",
+      ),
+      #(
+        "raw.gleam",
+        "import ffi
+
+@external(javascript, \"e\", \"o\")
+pub fn op() -> Nil {
+  ffi.disk()
+}
 ",
       ),
     ])
   let assert Ok(prose_output) =
-    graded.run_effect_formatted(project, "dep/ffi.run", answer.Prose)
+    graded.run_effect_formatted(project, "raw.op", answer.Prose)
   prose_output
   |> should.equal(
-    "dep/ffi.run has effects that could not be determined: [Unknown]
-  source: an external declared only for a target this build does not compile",
+    "raw.op has effects [Disk, Unknown]; part of them could not be determined
+  source: an external with no declared effects
+  plus its Gleam fallback body, which runs on the targets its `@external` declares no implementation for: [Disk]",
   )
   let assert Ok(graded_output) =
-    graded.run_effect_formatted(project, "dep/ffi.run", answer.Graded)
+    graded.run_effect_formatted(project, "raw.op", answer.Graded)
   graded_output
+  |> should_parse
   |> should.equal(
-    "effects dep/ffi.run : [Unknown]
-// an external declared only for a target this build does not compile",
+    "effects raw.op : [Disk, Unknown]
+// an external with no declared effects
+// unioned with its Gleam fallback body, which runs on the targets its `@external` declares no implementation for: [Disk]",
   )
   cleanup(project)
 }

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -728,6 +728,40 @@ pub fn a_catalog_effects_line_beats_another_packages_external_test() {
   Nil
 }
 
+pub fn a_catalog_external_beats_its_own_files_effects_line_test() {
+  // One catalog file keys the same function both ways. The `external effects`
+  // line decides the term, pairing with the empty bounds the file's own reader
+  // records for a declared name — the `effects` line's polymorphic term would
+  // leave `cb` free with nothing left to bind it.
+  let root = "build/eff_catalog_same_file_clash"
+  let catalog = root <> "/catalog"
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) = simplifile.create_directory_all(catalog)
+  let assert Ok(Nil) =
+    simplifile.write(
+      catalog <> "/a_pkg@1.0.0.graded",
+      "effects shared/mod.run(cb: [cb]) : [cb]\nexternal effects shared/mod.run : [Disk]\n",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/manifest.toml",
+      "packages = [\n  { name = \"a_pkg\", version = \"1.0.0\" },\n]\n",
+    )
+
+  let #(all_effects, _module_effects, params, _type_fields) =
+    effects.load_catalog(catalog, root <> "/manifest.toml")
+  dict.get(all_effects, QualifiedName("shared/mod", "run"))
+  |> result.map(fn(entry) { #(effect_term.to_effect_set(entry.0), entry.1) })
+  |> should.equal(
+    Ok(#(Specific(set.from_list(["Disk"])), types.Catalog("a_pkg"))),
+  )
+  dict.get(params, QualifiedName("shared/mod", "run"))
+  |> should.equal(Ok([]))
+
+  let _ = simplifile.delete(root)
+  Nil
+}
+
 // Dependency-declared externals
 //
 // A dependency's own `external effects` lines are part of what it ships: the

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -696,36 +696,25 @@ pub fn a_catalog_effects_line_beats_another_packages_external_test() {
   // Two catalog files key the same function: one with an `effects` line, one
   // with an `external effects` line. The `effects` line decides the term, so it
   // must decide the origin too — the external's package never claims it.
-  let root = "build/eff_catalog_clash"
-  let catalog = root <> "/catalog"
-  let _ = simplifile.delete(root)
-  let assert Ok(Nil) = simplifile.create_directory_all(catalog)
-  let assert Ok(Nil) =
-    simplifile.write(
-      catalog <> "/a_pkg@1.0.0.graded",
-      "effects shared/mod.run : [Http]\n",
-    )
-  let assert Ok(Nil) =
-    simplifile.write(
-      catalog <> "/b_pkg@1.0.0.graded",
-      "external effects shared/mod.run : [Disk]\n",
-    )
-  let assert Ok(Nil) =
-    simplifile.write(
-      root <> "/manifest.toml",
-      "packages = [\n  { name = \"a_pkg\", version = \"1.0.0\" },\n  { name = \"b_pkg\", version = \"1.0.0\" },\n]\n",
-    )
+  let root =
+    write_fixture("build/eff_catalog_clash", [
+      #("catalog/a_pkg@1.0.0.graded", "effects shared/mod.run : [Http]\n"),
+      #(
+        "catalog/b_pkg@1.0.0.graded",
+        "external effects shared/mod.run : [Disk]\n",
+      ),
+      #("manifest.toml", two_package_manifest),
+    ])
 
   let #(all_effects, _module_effects, _params, _type_fields) =
-    effects.load_catalog(catalog, root <> "/manifest.toml")
+    effects.load_catalog(root <> "/catalog", root <> "/manifest.toml")
   dict.get(all_effects, QualifiedName("shared/mod", "run"))
   |> result.map(fn(entry) { #(effect_term.to_effect_set(entry.0), entry.1) })
   |> should.equal(
     Ok(#(Specific(set.from_list(["Http"])), types.Catalog("a_pkg"))),
   )
 
-  let _ = simplifile.delete(root)
-  Nil
+  cleanup(root)
 }
 
 pub fn a_catalog_external_beats_its_own_files_effects_line_test() {
@@ -733,23 +722,20 @@ pub fn a_catalog_external_beats_its_own_files_effects_line_test() {
   // line decides the term, pairing with the empty bounds the file's own reader
   // records for a declared name — the `effects` line's polymorphic term would
   // leave `cb` free with nothing left to bind it.
-  let root = "build/eff_catalog_same_file_clash"
-  let catalog = root <> "/catalog"
-  let _ = simplifile.delete(root)
-  let assert Ok(Nil) = simplifile.create_directory_all(catalog)
-  let assert Ok(Nil) =
-    simplifile.write(
-      catalog <> "/a_pkg@1.0.0.graded",
-      "effects shared/mod.run(cb: [cb]) : [cb]\nexternal effects shared/mod.run : [Disk]\n",
-    )
-  let assert Ok(Nil) =
-    simplifile.write(
-      root <> "/manifest.toml",
-      "packages = [\n  { name = \"a_pkg\", version = \"1.0.0\" },\n]\n",
-    )
+  let root =
+    write_fixture("build/eff_catalog_same_file_clash", [
+      #(
+        "catalog/a_pkg@1.0.0.graded",
+        "effects shared/mod.run(cb: [cb]) : [cb]\nexternal effects shared/mod.run : [Disk]\n",
+      ),
+      #(
+        "manifest.toml",
+        "packages = [\n  { name = \"a_pkg\", version = \"1.0.0\" },\n]\n",
+      ),
+    ])
 
   let #(all_effects, _module_effects, params, _type_fields) =
-    effects.load_catalog(catalog, root <> "/manifest.toml")
+    effects.load_catalog(root <> "/catalog", root <> "/manifest.toml")
   dict.get(all_effects, QualifiedName("shared/mod", "run"))
   |> result.map(fn(entry) { #(effect_term.to_effect_set(entry.0), entry.1) })
   |> should.equal(
@@ -758,8 +744,75 @@ pub fn a_catalog_external_beats_its_own_files_effects_line_test() {
   dict.get(params, QualifiedName("shared/mod", "run"))
   |> should.equal(Ok([]))
 
-  let _ = simplifile.delete(root)
-  Nil
+  cleanup(root)
+}
+
+// The manifest both cross-file clash fixtures install: each of the two catalog
+// files is selected only if its package is installed.
+const two_package_manifest = "packages = [
+  { name = \"a_pkg\", version = \"1.0.0\" },
+  { name = \"b_pkg\", version = \"1.0.0\" },
+]
+"
+
+// What `load_catalog` settles on for `shared/mod.run` when two catalog files key
+// it: `poly_package`'s polymorphic `effects` line and `ext_package`'s
+// `external effects` line.
+fn catalog_clash_entry(
+  root: String,
+  poly_package: String,
+  ext_package: String,
+) -> #(
+  Result(#(types.EffectTerm, types.LookupOrigin), Nil),
+  Result(List(ParamBound), Nil),
+) {
+  let root =
+    write_fixture(root, [
+      #(
+        "catalog/" <> poly_package <> "@1.0.0.graded",
+        "effects shared/mod.run(cb: [cb]) : [cb]\n",
+      ),
+      #(
+        "catalog/" <> ext_package <> "@1.0.0.graded",
+        "external effects shared/mod.run : [Disk]\n",
+      ),
+      #("manifest.toml", two_package_manifest),
+    ])
+  let #(all_effects, _module_effects, params, _type_fields) =
+    effects.load_catalog(root <> "/catalog", root <> "/manifest.toml")
+  cleanup(root)
+  #(
+    dict.get(all_effects, QualifiedName("shared/mod", "run")),
+    dict.get(params, QualifiedName("shared/mod", "run")),
+  )
+}
+
+pub fn a_catalog_effects_lines_bounds_travel_with_its_term_test() {
+  // The `effects` line decides the term across files, so the file that wrote it
+  // must decide the bounds too: the external's file records empty bounds for
+  // the name, and pairing those with this term leaves `cb` with nothing to bind
+  // it.
+  catalog_clash_entry("build/eff_catalog_bounds_clash", "a_pkg", "b_pkg")
+  |> should.equal(#(
+    Ok(#(types.TVar("cb"), types.Catalog("a_pkg"))),
+    Ok([ParamBound("cb", types.TVar("cb"))]),
+  ))
+}
+
+pub fn a_catalog_clash_resolves_the_same_either_way_round_test() {
+  // The same clash with the two files swapped. Which file the fold reaches last
+  // is the catalog directory's own order, so the pair pins both: in one of the
+  // two the losing file is folded last, and its empty bounds must not outlive
+  // its term there either.
+  catalog_clash_entry(
+    "build/eff_catalog_bounds_clash_swapped",
+    "b_pkg",
+    "a_pkg",
+  )
+  |> should.equal(#(
+    Ok(#(types.TVar("cb"), types.Catalog("b_pkg"))),
+    Ok([ParamBound("cb", types.TVar("cb"))]),
+  ))
 }
 
 // Dependency-declared externals

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -7153,6 +7153,101 @@ pub fn an_external_on_an_unreadable_dependency_is_not_flagged_test() {
   support.cleanup(root)
 }
 
+pub fn a_stale_duplicate_dependency_copy_does_not_answer_for_a_name_test() {
+  // Two copies of `dep/mod` are on disk: the path dependency the project
+  // declares, and a hex copy left under `build/packages` by a `gleam clean`
+  // that never ran. The path dependency is what this build compiles against and
+  // it defines no `writes`, so the line is dead — the stale copy still defining
+  // the name is no evidence about the source in use.
+  let root = "build/external_lint_stale_dep_copy"
+  support.write_fixture(root, [
+    #(
+      "proj/gleam.toml",
+      "name = \"proj\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n",
+    ),
+    #("proj/proj.graded", "external effects dep/mod.writes : [Disk]\n"),
+    #(
+      "proj/build/packages/dep/src/dep/mod.gleam",
+      "pub fn writes() -> Nil {\n  Nil\n}\n",
+    ),
+    #("proj/src/m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
+    #("dep/gleam.toml", "name = \"dep\"\n"),
+    #("dep/src/dep/mod.gleam", "pub fn reads() -> Nil {\n  Nil\n}\n"),
+  ])
+
+  let assert Ok(results) = graded.run(root <> "/proj")
+  results
+  |> list.flat_map(fn(r) { r.warnings })
+  |> should.equal([
+    types.UnmatchedFunctionExternalWarning(function: "dep/mod.writes"),
+  ])
+  support.cleanup(root)
+}
+
+pub fn a_stale_copy_does_not_stand_in_for_an_unreadable_one_test() {
+  // The mirror case: the copy this build compiles against will not parse, and
+  // the stale one under `build/packages` does. A module graded cannot read
+  // proves nothing about the names in it, and a copy it is not compiling
+  // against cannot prove it either — so the line naming a function only the
+  // unreadable copy defines is left alone.
+  let root = "build/external_lint_stale_copy_unreadable"
+  support.write_fixture(root, [
+    #(
+      "proj/gleam.toml",
+      "name = \"proj\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n",
+    ),
+    #("proj/proj.graded", "external effects dep/mod.writes : [Disk]\n"),
+    #(
+      "proj/build/packages/dep/src/dep/mod.gleam",
+      "pub fn reads() -> Nil {\n  Nil\n}\n",
+    ),
+    #("proj/src/m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
+    #("dep/gleam.toml", "name = \"dep\"\n"),
+    #("dep/src/dep/mod.gleam", "pub fn ( not gleam\n"),
+  ])
+
+  let assert Ok(results) = graded.run(root <> "/proj")
+  results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
+  support.cleanup(root)
+}
+
+pub fn a_stale_duplicate_dependency_copy_declares_nothing_foreign_test() {
+  // Every map the dependency scan derives is read off the copy this build
+  // compiles against, not just the names it defines. A stale copy under
+  // `build/packages` declaring a function `@external` cannot refuse the effects
+  // the live copy's shipped spec states for it, since that copy runs Gleam.
+  let root = "build/stale_dep_copy_foreign"
+  support.write_fixture(root, [
+    #(
+      "proj/gleam.toml",
+      "name = \"proj\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n",
+    ),
+    #("proj/proj.graded", "check app.go : [Disk]\n"),
+    #(
+      "proj/src/app.gleam",
+      "import dep/mod
+
+pub fn go() -> Nil {
+  mod.writes()
+}
+",
+    ),
+    #(
+      "proj/build/packages/dep/src/dep/mod.gleam",
+      "@external(erlang, \"dep_ffi\", \"writes\")
+pub fn writes() -> Nil
+",
+    ),
+    #("dep/gleam.toml", "name = \"dep\"\n"),
+    #("dep/dep.graded", "effects dep/mod.writes : [Disk]\n"),
+    #("dep/src/dep/mod.gleam", "pub fn writes() -> Nil {\n  Nil\n}\n"),
+  ])
+
+  let assert Ok(results) = graded.run(root <> "/proj")
+  results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
+  support.cleanup(root)
+}
+
 pub fn an_external_on_a_function_less_dependency_module_is_flagged_test() {
   // A dependency module that parses and defines no function at all — a
   // type-only module — proves the name absent just as a module full of other

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -7153,6 +7153,32 @@ pub fn an_external_on_an_unreadable_dependency_is_not_flagged_test() {
   support.cleanup(root)
 }
 
+pub fn an_external_on_a_function_less_dependency_module_is_flagged_test() {
+  // A dependency module that parses and defines no function at all — a
+  // type-only module — proves the name absent just as a module full of other
+  // functions does. Reading "defines nothing" as "said nothing" is how a module
+  // graded read would come to answer for every name in it, which is the answer
+  // reserved for one it could not read.
+  let root = "build/external_lint_type_only_dep"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #("proj.graded", "external effects types_only/mod.whatever : [Disk]\n"),
+    #(
+      "build/packages/types_only/src/types_only/mod.gleam",
+      "pub type Handle {\n  Handle(id: Int)\n}\n",
+    ),
+    #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
+  ])
+
+  let assert Ok(results) = graded.run(root)
+  results
+  |> list.flat_map(fn(r) { r.warnings })
+  |> should.equal([
+    types.UnmatchedFunctionExternalWarning(function: "types_only/mod.whatever"),
+  ])
+  support.cleanup(root)
+}
+
 // Reference warnings and foreign code
 //
 // The "passed as a value" warning quotes an effect, so it reads that effect

--- a/test/signatures_test.gleam
+++ b/test/signatures_test.gleam
@@ -226,11 +226,15 @@ pub fn make() -> foo.Resolver { todo }
 fn registry_from_source_dir(
   source_dir: String,
 ) -> signatures.SignatureRegistry {
-  use acc, module_path, module <- signatures.fold_source_dir(
+  use acc, module_path, parsed <- signatures.fold_source_dir(
     source_dir,
     signatures.empty(),
   )
-  signatures.merge(acc, signatures.from_glance_module(module_path, module))
+  case parsed {
+    Ok(module) ->
+      signatures.merge(acc, signatures.from_glance_module(module_path, module))
+    Error(Nil) -> acc
+  }
 }
 
 pub fn parse_source_dir_walks_dep_sources_test() {


### PR DESCRIPTION
Four small cleanups sized for a patch release: one latent fix, one settled
decision written down, two internal-shape changes. Nothing here adds a command,
an annotation kind, or a resolution-order change.

## Let a catalog file's external win over its own `effects` line

Within one catalog file, a function keyed by both an `effects` line and a
per-function `external effects` line resolved to the `effects` line's term,
while the same file's bounds reader recorded the external's empty bounds for
the name. A polymorphic term (`effects pkg.run(cb: [cb]) : [cb]`) would then
carry a free variable nothing could bind.

The clash is now resolved per file, in `fold_catalog_file`, the rule a
dependency's and a path dependency's own spec already follow: the declaration
decides the term, pairing with the empty bounds recorded beside it. The
cross-package rule is untouched — an `effects` line from one catalog file still
beats another package's external, which
`a_catalog_effects_line_beats_another_packages_external_test` pins.

Latent today: no bundled catalog file keys a name both ways, so nothing shipped
changes. New test asserts the term *and* the bounds, one tier up from the
path-dep test it cribs.

## Document what a reference passed as a value warns about

REFERENCE.md covered the dead-field-bound warning but not the one for a function
reference passed as a value. New "References passed as values" section: what the
warning says, that the set it quotes is what a *call* to that name resolves to
(never a stale line), that a mixed set quotes both halves, that a wholly
`[Unknown]` or pure reference stays silent, and that warnings never fail a
check. Documentation only — the silence is deliberate and unchanged.

## Fold one answer shape and one set of spec layers

`graded effect`'s answer carried three function variants differing only in how
the term was settled and which sentence named its source. Two re-derived what
the other was handed, and one re-derived its term inside the renderer. They
collapse into `FunctionAnswer` over an `AnswerSource` that says what answered —
an entry, an undeclared external, an out-of-reach declaration, or the body
running in its place — so both renderers read one shape and each sentence is
worded once. The undeclared term now comes from `declared_charge`, which had
already computed it.

The `effect` fast path, the full project fold and `infer`'s fold each derived
the spec's externals and `type` layers by hand. Each layer's arguments and
origin tag now come from one function all three compose.

Output is unchanged. Two renderings the refactor touched and nothing pinned —
an out-of-reach declaration with a body running in its place, and an undeclared
external whose fallback runs — are now covered.

## Read the lint's dependency names off the scan that already parsed them

The spec lint re-read and re-parsed every dependency module a per-function
`external effects` line named, though the dependency scan `check` runs anyway
had already parsed all of them into the signature registry.

`DependencySources` now records which module paths that scan parsed, and one
query answers the lint's three states together: the module defines the name, the
module defines no such name, or graded never read the module. The set is what
the registry cannot say — a module that parses and defines no function keys
nothing in it, exactly like one that never parsed, and only the first proves a
name absent.

A type-only dependency module is now covered: it still flags the name, rather
than answering for every name the way an unreadable module does.

## Checks

`gleam format --check`, `gleam build --warnings-as-errors`, `gleam test` (999
passing), `gleam run -m glinter`, and `graded check` on this repo's own spec,
which reports exactly what it reported at v0.12.0.

The changelog carries one `Fixed` entry, for the catalog fix. The version bump
and release commit are the maintainer's, after merge.
