### PR TITLE
Declare what an FFI producer returns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Fourteen modules, no circular dependencies. Only `src/graded.gleam` is the publi
 
 ## .graded Annotation Syntax
 
-The spec file uses **module-qualified** names (`myapp/router.handle_request`); cache files under `build/.graded/` use bare names because each is scoped to one module by location. Four annotation kinds: `effects` (inferred cache), `check` (enforced invariant), `type` (function-typed fields on custom types), `external effects` (third-party functions not in the catalog). Parameter bounds (`effects myapp.apply(f: [Stdout]) : [Stdout]`) carry higher-order budgets.
+The spec file uses **module-qualified** names (`myapp/router.handle_request`); cache files under `build/.graded/` use bare names because each is scoped to one module by location. Five annotation kinds: `effects` (inferred cache), `check` (enforced invariant), `type` (function-typed fields on custom types), `external effects` (third-party functions not in the catalog), `external returns` (the closure an FFI producer hands back). Parameter bounds (`effects myapp.apply(f: [Stdout]) : [Stdout]`) carry higher-order budgets.
 
 See [docs/REFERENCE.md](docs/REFERENCE.md) for the full grammar, every annotation kind, the effect-set syntax, and worked examples.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `external returns <module>.<function> : <operator>` declares the closure an
+  FFI producer hands back, so calling it resolves instead of costing
+  `[Unknown]`. The line is hand-written and preserved by `graded infer`, and it
+  answers where the declaration stands alone — a call refuses it where the
+  declaration is out of the build's reach or a Gleam fallback body runs beside
+  it, and says which. Dependencies and path dependencies can ship the line for
+  their own producers.
+
 ## [0.12.1] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Two cases need no packing:
 
 ## Reference
 
-The `.graded` spec language and graded's analysis model are documented in full in **[the Reference](https://hexdocs.pm/graded/reference.html)** — the annotation kinds (`effects`, `check`, `type`, `external effects`, `returns`), effect-set syntax, effect resolution order, higher-order and second-order effect polymorphism, type field effects, the effect-label conventions, and the bundled catalog of common packages.
+The `.graded` spec language and graded's analysis model are documented in full in **[the Reference](https://hexdocs.pm/graded/reference.html)** — the annotation kinds (`effects`, `check`, `type`, `external effects`, `external returns`, `returns`), effect-set syntax, effect resolution order, higher-order and second-order effect polymorphism, type field effects, the effect-label conventions, and the bundled catalog of common packages.
 
 ## Commands
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -357,19 +357,13 @@ pub fn build_client() -> Client
 resolves is one it can see built, or annotate the *field* the returned function
 lands in with a `type` line.
 
-The closure a producer hands back is the one such channel `external returns`
-declares:
-
-```
-external returns my_ffi.make_client : [Net]
-```
-
-Two limits hold even with the line written. It must be **ground**: an operator
-with free effect variables — a foreign decorator whose returned closure runs an
-argument it was handed — is ignored, so wrap that producer in Gleam. And the
-declaration is refused where a Gleam fallback body also runs, because the two
-halves can hand back different closures and there is no union of operators to
-take; the call reports which of the two refusals applies.
+The closure a producer hands back is the one such channel with a declaring form:
+`external returns my_ffi.make_client : [Net]`. It is refused where a Gleam
+fallback body runs beside the declaration — the two can hand back different
+closures and there is no union of operators to take — and the operator must be
+ground, so a foreign decorator's still needs the Gleam wrapper. The call names
+whichever refusal applied; the rules are in
+[External declarations](./REFERENCE.md#external-declarations-and-ffi).
 
 ### Which targets an `@external` is built for
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -343,20 +343,33 @@ For common third-party packages, the [bundled catalog](./REFERENCE.md#effect-cat
 already supplies these declarations, so you only need `external effects` for your
 own FFI and for packages the catalog doesn't cover.
 
-An `external effects` line covers the *call*, and there is no form that covers
-the **value** foreign code returns. A closure an FFI producer hands back, the
-record it builds, and the fields either wires stay `[Unknown]` at every use —
-declared or not, fallback body or not — because nothing states what the foreign
-implementation returns:
+An `external effects` line covers the *call*. The record an FFI producer builds
+and the fields either it or an update builder of it wires stay `[Unknown]` at
+every use — declared or not, fallback body or not — because nothing states what
+the foreign implementation returns:
 
 ```gleam
-@external(erlang, "my_ffi", "make_client")
-pub fn make_client() -> fn(Request) -> Response
+@external(erlang, "my_ffi", "build_client")
+pub fn build_client() -> Client
 ```
 
 **How to avoid it** — wrap the producer in ordinary Gleam, so the value graded
 resolves is one it can see built, or annotate the *field* the returned function
 lands in with a `type` line.
+
+The closure a producer hands back is the one such channel `external returns`
+declares:
+
+```
+external returns my_ffi.make_client : [Net]
+```
+
+Two limits hold even with the line written. It must be **ground**: an operator
+with free effect variables — a foreign decorator whose returned closure runs an
+argument it was handed — is ignored, so wrap that producer in Gleam. And the
+declaration is refused where a Gleam fallback body also runs, because the two
+halves can hand back different closures and there is no union of operators to
+take; the call reports which of the two refusals applies.
 
 ### Which targets an `@external` is built for
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -138,8 +138,9 @@ order and takes the first hit:
 
 Returned-operator summaries follow the same order on their own channel: an
 `external returns` declaration outranks an inferred `returns` line for the same
-name, and this package's spec outranks a dependency's. The catalog carries no
-returns lines of either kind.
+name — across two packages' specs as well as within one — and this package's spec
+outranks a dependency's, which outranks a path dependency's. The catalog carries
+no returns lines of either kind.
 
 ## Effect set syntax
 
@@ -590,7 +591,11 @@ package declares `@external` is refused, while its `external effects` line, its
 `external returns` line, a module-level external, and the catalog entry underneath
 keep answering. A dependency's `external returns` line is kept even over one of
 its own Gleam-bodied functions — weighing a spec against the source beside it is
-that package's job at its own `infer` time. Where a
+that package's job at its own `infer` time. What a spec may state a returned-
+operator summary *about* is narrower: the modules that package ships, plus the
+names a scan of dependency source records as `@external`. A `returns` or
+`external returns` line for anyone else's code — your own modules included — is
+dropped, so no dependency can overrule what your own body says it hands back. Where a
 dependency's external carries a fallback body that runs on some target, its
 declaration is widened by `[Unknown]` — the union graded performs against a
 walked fallback in the defining package has no second operand one package away.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -577,13 +577,15 @@ it stands alone; two readings refuse it, and the call says which:
   the body covers the rest. Effects union the two halves; there is no union of
   operators, and the closure the body hands back needn't be the foreign one.
 
-Three lines are dropped rather than trusted, each flagged by the spec lint: an
+Four lines are dropped rather than trusted, each flagged by the spec lint: an
 operator with free effect variables (a foreign decorator returning a closure that
 runs its own argument — wrap the producer in Gleam instead), a name with no
-function part (`external returns mymodule : [...]` names no function), and a name
-that is one of *this package's own* ordinary Gleam functions, whose body every
-caller can already see. `graded infer` replaces the last with the inferred
-`returns` line.
+function part (`external returns mymodule : [...]` names no function), a name of
+more than two parts (`external returns myapp.Handler.run : [...]` is the `type`
+line's field shape, not this one's), and a name that is one of *this package's
+own* ordinary Gleam functions, whose body every caller can already see. `graded
+infer` deletes the last; where the function returns an operator, the inferred
+`returns` line takes its place.
 
 A dependency is held to the same rules, against the dependency's *own* source
 under `build/packages`: a shipped `effects` or `returns` line for a function that

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -25,7 +25,7 @@ graded keeps two kinds of `.graded` file:
 
 ## Annotation kinds
 
-Five kinds of line appear in a spec file.
+Six kinds of line appear in a spec file.
 
 ### `effects` — inferred effects
 
@@ -94,13 +94,26 @@ across module and package boundaries, not just within the defining module. Like
 written for an `@external`, and one naming an `@external` is ignored — see
 [External declarations](#external-declarations-and-ffi).
 
+### `external returns` — what a foreign producer hands back
+
+```
+external returns myapp/ffi.make_client : [Net]
+```
+
+Declares the operator an `@external` producer returns, so a call of the closure
+it hands back resolves instead of degrading to `[Unknown]`. Hand-written like
+`external effects` and never regenerated: `graded infer` preserves the line and
+writes none of its own. The operator uses the same grammar as `returns` and must
+be **ground** — one with free effect variables is ignored and flagged. See
+[External declarations](#external-declarations-and-ffi).
+
 ## Effect resolution order
 
 When graded needs a function's effects, it consults these sources in priority
 order and takes the first hit:
 
-1. **Your spec file** — `check`, `external effects`, `type`, and `returns`
-   declarations in `<package_name>.graded`.
+1. **Your spec file** — `check`, `external effects`, `external returns`, `type`,
+   and `returns` declarations in `<package_name>.graded`.
 2. **Cross-module project effects** — effects inferred from sibling modules in the
    same project, propagated in topological order. A fresh checkout resolves
    transitive call chains with no prior `graded infer`; committed `effects` lines
@@ -122,6 +135,11 @@ order and takes the first hit:
 5. **Bundled catalog** — the versioned catalog files shipped with graded (see
    [Effect catalog](#effect-catalog)).
 6. **Conservative default** — anything still unresolved gets `[Unknown]`.
+
+Returned-operator summaries follow the same order on their own channel: an
+`external returns` declaration outranks an inferred `returns` line for the same
+name, and this package's spec outranks a dependency's. The catalog carries no
+returns lines of either kind.
 
 ## Effect set syntax
 
@@ -522,34 +540,57 @@ a helper handed an undeclared external contributes `[Unknown]` rather than the
 `[]` its bodyless declaration reads as.
 
 What it does *not* answer for is the value the external hands back. A declaration
-states what calling the function costs; nothing in it describes the closure an
-FFI producer returns, the record it builds, or the fields either wires. So an
-`@external` is opaque on every one of those channels — its `returns` summary, its
-return provenance, and its factory and update-builder signatures are all refused,
-whether or not it is declared and whether or not a Gleam fallback body beside it
-runs:
+states what calling the function costs; nothing in it describes the closure an FFI
+producer returns, the record it builds, or the fields either wires. So an
+`@external`'s return provenance and its factory and update-builder signatures are
+refused whether or not it is declared and whether or not a Gleam fallback body
+beside it runs, and an inferred `returns` line for one is refused too: `graded
+infer` writes none for an `@external`, and removes one a function that has since
+become `@external` left behind.
+
+The closure it hands back is the one channel with a declaring form of its own:
 
 ```gleam
 @external(erlang, "my_ffi", "make_logger")
-pub fn make_logger() -> fn(String) -> Nil {
-  fn(_) { Nil }        // never runs on Erlang; describes nothing
-}
+@external(javascript, "my_ffi", "make_logger")
+pub fn make_logger() -> fn(String) -> Nil
 
 pub fn caller() -> Nil {
   let log = make_logger()
-  log("hi")            // [Unknown] — no declaring form describes this closure
+  log("hi")            // [Stdout] — from the `external returns` line
 }
 ```
 
-`graded infer` writes no `returns` line for an `@external`, and removes one a
-function that has since become `@external` left behind. There is no annotation
-that declares an FFI producer's return today; a call of the returned closure
-stays `[Unknown]`.
+```
+external effects myapp/ffi.make_logger : []
+external returns myapp/ffi.make_logger : [Stdout]
+```
 
-A dependency is held to the same rule, against the dependency's *own* source
+Without that line the call is `[Unknown]`. With it, the declaration answers where
+it stands alone; two readings refuse it, and the call says which:
+
+- **out of reach** — the declaration names only targets this build does not
+  compile, so nothing it describes is what runs. The same reading that drops the
+  external's own declared effects;
+- **a Gleam fallback body also runs** — the declaration covers some targets and
+  the body covers the rest. Effects union the two halves; there is no union of
+  operators, and the closure the body hands back needn't be the foreign one.
+
+Three lines are dropped rather than trusted, each flagged by the spec lint: an
+operator with free effect variables (a foreign decorator returning a closure that
+runs its own argument — wrap the producer in Gleam instead), a name with no
+function part (`external returns mymodule : [...]` names no function), and a name
+that is one of *this package's own* ordinary Gleam functions, whose body every
+caller can already see. `graded infer` replaces the last with the inferred
+`returns` line.
+
+A dependency is held to the same rules, against the dependency's *own* source
 under `build/packages`: a shipped `effects` or `returns` line for a function that
-package declares `@external` is refused, while its `external effects` line, a
-module-level external, and the catalog entry underneath keep answering. Where a
+package declares `@external` is refused, while its `external effects` line, its
+`external returns` line, a module-level external, and the catalog entry underneath
+keep answering. A dependency's `external returns` line is kept even over one of
+its own Gleam-bodied functions — weighing a spec against the source beside it is
+that package's job at its own `infer` time. Where a
 dependency's external carries a fallback body that runs on some target, its
 declaration is widened by `[Unknown]` — the union graded performs against a
 walked fallback in the defining package has no second operand one package away.

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -1553,9 +1553,11 @@ fn spec_answer(
 // The spec layers of `load_project_context`'s knowledge base, folded in the same
 // order and by the same functions, over nothing else.
 //
-// The spec's `returns` lines are not among them: a returned-operator summary is
-// consumed while walking a body, and a fast-path answer is one no body was
-// walked for.
+// Neither the spec's `returns` lines nor its `external returns` declarations are
+// among them: a returned-operator summary is consumed while walking a body, and
+// a fast-path answer is one no body was walked for. That holds for the declared
+// ones as much as the inferred — the declaration answers a call of the value,
+// which this path never reaches.
 fn spec_knowledge_base(
   spec: GradedFile,
   stale_externals: Set(String),
@@ -2558,6 +2560,13 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
   let base_kb =
     kb_base
     |> with_spec_type_fields(spec)
+    // Declared returns are state no inference pass re-derives. Without them the
+    // walk of a caller's body writes `[Unknown]` where `check` scores the same
+    // body from the declaration, and the two commands disagree about it.
+    |> effects.with_declared_returned_operators(
+      effects.load_spec_external_returns_from_file(spec),
+      types.UserExternal,
+    )
     |> effects.with_factories(
       qualify_by_module(index, extract.factory_map(
         _,

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -57,10 +57,10 @@ import graded/internal/types.{
   type TypeFieldAnnotation, type Violation, type Warning, AnnotationLine,
   CheckResult, DotlessExternalReturnsWarning, EffectAnnotation, GradedFile,
   PolymorphicExternalReturnsWarning, QualifiedName, StaleExternalReturnsWarning,
-  StaleFunctionExternalWarning, UnmatchedCheckWarning,
-  UnmatchedExternalReturnsWarning, UnmatchedFieldBoundWarning,
+  StaleFunctionExternalWarning, TypeShapedExternalReturnsWarning,
+  UnmatchedCheckWarning, UnmatchedExternalReturnsWarning,
   UnmatchedFunctionExternalWarning, UnmatchedModuleExternalWarning,
-  UnmatchedParamBoundWarning, UnmatchedTypeFieldWarning, UntrackedEffectWarning,
+  UnmatchedTypeFieldWarning,
 }
 import simplifile
 
@@ -1129,8 +1129,10 @@ fn external_warnings(
 // one can be dead. Two are the existence branches above, read through the same
 // evidence; two are this form's own, and both are lines the loader drops:
 //
-//   - a name with no `.`: the declaration is per-function, and nothing keys a
-//     whole module's returned value;
+//   - a name the function grammar rejects: one with no `.`, where the
+//     declaration is read as naming a whole module and nothing keys a module's
+//     returned value, and one with more than one, which reaches for the `type`
+//     line's field shape;
 //   - a polymorphic operator, whose free variables nothing sanitized.
 //
 // One warning per line, so a line that is dead twice over is reported by the
@@ -1142,7 +1144,11 @@ fn external_returns_warnings(
 ) -> List(Warning) {
   list.filter_map(declared, fn(returns) {
     case annotation.split_function_name(returns.function) {
-      Error(Nil) -> Ok(DotlessExternalReturnsWarning(name: returns.function))
+      Error(Nil) ->
+        case string.contains(returns.function, ".") {
+          True -> Ok(TypeShapedExternalReturnsWarning(name: returns.function))
+          False -> Ok(DotlessExternalReturnsWarning(name: returns.function))
+        }
       Ok(#(module, function)) ->
         case
           set.contains(stale, returns.function),
@@ -3942,110 +3948,7 @@ fn print_warnings(check_result: CheckResult) -> Nil {
 }
 
 fn print_warning(file: String, warning: Warning) -> Nil {
-  case warning {
-    UntrackedEffectWarning(function:, reference:, effects: effs, ..) ->
-      io.println(
-        file
-        <> ": warning: "
-        <> function
-        <> " passes "
-        <> reference.module
-        <> "."
-        <> reference.function
-        <> " as a value — its effects "
-        <> effects.format_effect_set(effs)
-        <> " won't be tracked",
-      )
-    UnmatchedFieldBoundWarning(function:, field_path:, receiver_is_param:) -> {
-      let cause = case receiver_is_param {
-        True -> " matches no field call in its body — check the path"
-        // A non-parameter receiver can be traced to a construction site, so the
-        // call may exist but resolve through value provenance, shadowing the bound.
-        False ->
-          " matches no field call in its body — check the path, or the receiver is traced to a construction site and resolved through value provenance (field bounds apply only to untraceable receivers)"
-      }
-      io.println(
-        file
-        <> ": warning: field bound "
-        <> field_path
-        <> " on "
-        <> function
-        <> cause,
-      )
-    }
-    UnmatchedParamBoundWarning(function:, param:) ->
-      io.println(
-        file
-        <> ": warning: parameter bound "
-        <> param
-        <> " on "
-        <> function
-        <> " names no parameter of the function — check the name",
-      )
-    UnmatchedCheckWarning(function:) ->
-      io.println(
-        file
-        <> ": warning: check "
-        <> function
-        <> " names no function in any project module — check the module qualifier; the check never runs",
-      )
-    UnmatchedTypeFieldWarning(name:) ->
-      io.println(
-        file
-        <> ": warning: type "
-        <> name
-        <> " names no field of any project type — check the module qualifier; the field resolves to [Unknown]",
-      )
-    StaleFunctionExternalWarning(function:) ->
-      io.println(
-        file
-        <> ": warning: external effects "
-        <> function
-        <> " names a function of this package with a Gleam body — the line declares no foreign code and is ignored; the body is walked instead. There is no replacement: fix the source, or widen the check budget",
-      )
-    UnmatchedFunctionExternalWarning(function:) ->
-      io.println(
-        file
-        <> ": warning: external effects "
-        <> function
-        <> " names no dependency, catalog, or project function — check the module qualifier; the declaration covers nothing",
-      )
-    UnmatchedModuleExternalWarning(module:) ->
-      io.println(
-        file
-        <> ": warning: external effects "
-        <> module
-        <> " names no dependency or project module — check the module path; the declaration covers nothing",
-      )
-    StaleExternalReturnsWarning(function:) ->
-      io.println(
-        file
-        <> ": warning: external returns "
-        <> function
-        <> " names a function of this package with a Gleam body — every caller resolves what it returns from that body, so the line declares nothing and is ignored. `graded infer` replaces it with the inferred `returns` line",
-      )
-    UnmatchedExternalReturnsWarning(function:) ->
-      io.println(
-        file
-        <> ": warning: external returns "
-        <> function
-        <> " names no dependency, catalog, or project function — check the module qualifier; the declaration covers nothing",
-      )
-    PolymorphicExternalReturnsWarning(function:) ->
-      io.println(
-        file
-        <> ": warning: external returns "
-        <> function
-        <> " declares an operator with effect variables — only a ground operator is loaded, so the line is ignored; write the effects the returned function performs, or wrap the producer in Gleam",
-      )
-    DotlessExternalReturnsWarning(name:) ->
-      io.println(
-        file
-        <> ": warning: external returns "
-        <> name
-        <> " names a module, not a function — a returns declaration is per-function; the line resolves nothing",
-      )
-  }
+  io.println(checker.format_warning(file, warning))
 }
 
 @external(erlang, "erlang", "halt")

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -671,6 +671,15 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     ))
     // What this package defines, for the query that answers from its public API.
     |> effects.with_project_functions(project_function_visibility(index))
+    // Declared returns first: an `external returns` line is a declaration, not
+    // inference, so it must outrank both a committed `returns` line for the same
+    // name — a spec written before the function became `@external` still carries
+    // one until the next `infer` — and the fresh pass below. Both merges here
+    // gap-fill, so folding earlier is what makes it win.
+    |> effects.with_declared_returned_operators(
+      effects.load_spec_external_returns_from_file(spec),
+      types.UserExternal,
+    )
     // Committed project returns are Foreign (Fix E): serialized, unsanitized. The
     // fresh in-memory pass below re-infers project returns and, being Fresh, wins
     // over these for the same key.

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -46,6 +46,7 @@ import graded/internal/checker
 import graded/internal/cli
 import graded/internal/config
 import graded/internal/diff
+import graded/internal/effect_term
 import graded/internal/effects.{type KnowledgeBase}
 import graded/internal/extract
 import graded/internal/signatures.{type SignatureRegistry}
@@ -766,25 +767,11 @@ fn stale_project_externals(
   spec: GradedFile,
   native_of: fn(String) -> Result(Set(String), Nil),
 ) -> Set(String) {
-  annotation.extract_externals(spec)
-  |> list.filter_map(fn(external) {
-    use function <- result.try(case external.target {
-      types.FunctionExternal(function) -> Ok(function)
-      types.ModuleExternal -> Error(Nil)
-    })
-    use native <- result.try(native_of(external.module))
-    case set.contains(native, function) {
-      True -> Ok(types.dotted_name(QualifiedName(external.module, function)))
-      False -> Error(Nil)
-    }
-  })
-  |> set.from_list()
+  declaring_nothing(annotation.external_function_names(spec), native_of)
 }
 
 // The `external returns` lines that declare nothing: the same rule one channel
-// over, so the two read alike — the named function is one of this package's own
-// ordinary Gleam-bodied functions, whose returned value every caller can see for
-// itself.
+// over, over the same predicate, so the two cannot drift apart.
 //
 // Derived apart from `stale_project_externals` and threaded apart from it. That
 // set drives the effects channel's two suppressions — committed `effects` lines
@@ -795,18 +782,26 @@ fn stale_project_external_returns(
   spec: GradedFile,
   native_of: fn(String) -> Result(Set(String), Nil),
 ) -> Set(String) {
-  annotation.extract_external_returns(spec)
-  |> list.filter_map(fn(declared) {
-    use #(module, function) <- result.try(annotation.split_function_name(
-      declared.function,
-    ))
-    use native <- result.try(native_of(module))
-    case set.contains(native, function) {
-      True -> Ok(declared.function)
-      False -> Error(Nil)
+  declaring_nothing(annotation.external_returns_names(spec), native_of)
+}
+
+// Which of `names` this package defines with a Gleam body — the rule both
+// declaring forms are held to, written once. A name whose module offers no
+// source to consult is kept out: absence is not evidence, so the line stands.
+fn declaring_nothing(
+  names: Set(String),
+  native_of: fn(String) -> Result(Set(String), Nil),
+) -> Set(String) {
+  set.filter(names, fn(name) {
+    case annotation.split_function_name(name) {
+      Error(Nil) -> False
+      Ok(#(module, function)) ->
+        case native_of(module) {
+          Ok(native) -> set.contains(native, function)
+          Error(Nil) -> False
+        }
     }
   })
-  |> set.from_list()
 }
 
 // A module's Gleam-bodied function names as the project index holds them, in
@@ -940,26 +935,34 @@ fn validate_spec_annotations(
   }
   let dep_modules = set.from_list(dict.keys(dep_files))
 
-  // The two declaring forms weigh a name by one rule, over one precomputation.
-  let evidence =
-    spec_name_evidence(
-      index,
-      known_functions,
-      package_root,
-      dep_files,
-      catalog,
-      dependencies,
-    )
-
-  let external_warnings =
-    external_warnings(externals, evidence, stale_externals)
-
-  let external_returns_warnings =
-    external_returns_warnings(
-      declared_returns,
-      evidence,
-      stale_external_returns,
-    )
+  // The two declaring forms weigh a name by one rule, over one precomputation —
+  // which reads the whole dependency tree, so it is built only where a
+  // declaring line asks a question of it.
+  let #(external_warnings, external_returns_warnings) = case
+    externals,
+    declared_returns
+  {
+    [], [] -> #([], [])
+    _, _ -> {
+      let evidence =
+        spec_name_evidence(
+          index,
+          known_functions,
+          package_root,
+          dep_files,
+          catalog,
+          dependencies,
+        )
+      #(
+        external_warnings(externals, evidence, stale_externals),
+        external_returns_warnings(
+          declared_returns,
+          evidence,
+          stale_external_returns,
+        ),
+      )
+    }
+  }
 
   // Resolving `type` lines also needs per-module type info; build it only when
   // there are `type` lines to check.
@@ -1133,7 +1136,7 @@ fn external_returns_warnings(
         case
           set.contains(stale, returns.function),
           evidence.defines(QualifiedName(module, function)),
-          effects.is_ground_operator(returns.operator)
+          effect_term.is_ground(returns.operator)
         {
           True, _, _ ->
             Ok(StaleExternalReturnsWarning(function: returns.function))

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -632,8 +632,9 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
   // run, this package and its dependencies alike: a dependency is compiled for
   // the consumer's target, not its own.
   let package_targets = cfg.targets
-  let stale_externals =
-    stale_project_externals(spec, native_functions_of(index, package_targets))
+  let native_of = native_functions_of(index, package_targets)
+  let stale_externals = stale_project_externals(spec, native_of)
+  let stale_external_returns = stale_project_external_returns(spec, native_of)
   let dep_sources = dependency_sources(package_root, package_targets)
   let registry =
     signatures.merge(
@@ -676,10 +677,7 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     // name — a spec written before the function became `@external` still carries
     // one until the next `infer` — and the fresh pass below. Both merges here
     // gap-fill, so folding earlier is what makes it win.
-    |> effects.with_declared_returned_operators(
-      effects.load_spec_external_returns_from_file(spec),
-      types.UserExternal,
-    )
+    |> with_spec_declared_returns(spec, stale_external_returns)
     // Committed project returns are Foreign (Fix E): serialized, unsanitized. The
     // fresh in-memory pass below re-infers project returns and, being Fresh, wins
     // over these for the same key.
@@ -769,6 +767,34 @@ fn stale_project_externals(
     use native <- result.try(native_of(external.module))
     case set.contains(native, function) {
       True -> Ok(types.dotted_name(QualifiedName(external.module, function)))
+      False -> Error(Nil)
+    }
+  })
+  |> set.from_list()
+}
+
+// The `external returns` lines that declare nothing: the same rule one channel
+// over, so the two read alike — the named function is one of this package's own
+// ordinary Gleam-bodied functions, whose returned value every caller can see for
+// itself.
+//
+// Derived apart from `stale_project_externals` and threaded apart from it. That
+// set drives the effects channel's two suppressions — committed `effects` lines
+// with their bounds, and the inferred lines `infer` writes — and a returns name
+// reaching either would delete a function's effect lines because its *value* was
+// declared.
+fn stale_project_external_returns(
+  spec: GradedFile,
+  native_of: fn(String) -> Result(Set(String), Nil),
+) -> Set(String) {
+  annotation.extract_external_returns(spec)
+  |> list.filter_map(fn(declared) {
+    use #(module, function) <- result.try(annotation.split_function_name(
+      declared.function,
+    ))
+    use native <- result.try(native_of(module))
+    case set.contains(native, function) {
+      True -> Ok(declared.function)
       False -> Error(Nil)
     }
   })
@@ -2524,8 +2550,9 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
   // As in `project_context`: one target set for the package and every
   // dependency it is built with.
   let package_targets = cfg.targets
-  let stale_externals =
-    stale_project_externals(spec, native_functions_of(index, package_targets))
+  let native_of = native_functions_of(index, package_targets)
+  let stale_externals = stale_project_externals(spec, native_of)
+  let stale_external_returns = stale_project_external_returns(spec, native_of)
 
   // Build a signature registry covering every project module so the checker can
   // do positional argument matching for cross-module polymorphic calls. Hoisted
@@ -2563,10 +2590,7 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
     // Declared returns are state no inference pass re-derives. Without them the
     // walk of a caller's body writes `[Unknown]` where `check` scores the same
     // body from the declaration, and the two commands disagree about it.
-    |> effects.with_declared_returned_operators(
-      effects.load_spec_external_returns_from_file(spec),
-      types.UserExternal,
-    )
+    |> with_spec_declared_returns(spec, stale_external_returns)
     |> effects.with_factories(
       qualify_by_module(index, extract.factory_map(
         _,
@@ -2626,6 +2650,7 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
       public_annotations,
       public_returns,
       stale_externals,
+      stale_external_returns,
     ),
     cache_files: list.reverse(cache_files),
   ))
@@ -3643,6 +3668,23 @@ fn with_spec_externals(
   effects.with_externals(
     knowledge_base,
     declaring_externals(spec, stale_externals),
+    types.UserExternal,
+  )
+}
+
+// The spec's `external returns` declarations, minus the stale ones. A stale line
+// is ignored at load as well as warned about and rewritten: trusted between
+// `infer` runs it would be a per-function override of what the walk can see for
+// itself.
+fn with_spec_declared_returns(
+  knowledge_base: KnowledgeBase,
+  spec: GradedFile,
+  stale_external_returns: Set(String),
+) -> KnowledgeBase {
+  effects.with_declared_returned_operators(
+    knowledge_base,
+    effects.load_spec_external_returns_from_file(spec)
+      |> drop_stale_names(stale_external_returns),
     types.UserExternal,
   )
 }

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -54,11 +54,12 @@ import graded/internal/typeinfo
 import graded/internal/types.{
   type CheckResult, type EffectAnnotation, type GradedFile, type QualifiedName,
   type TypeFieldAnnotation, type Violation, type Warning, AnnotationLine,
-  CheckResult, EffectAnnotation, GradedFile, QualifiedName,
+  CheckResult, DotlessExternalReturnsWarning, EffectAnnotation, GradedFile,
+  PolymorphicExternalReturnsWarning, QualifiedName, StaleExternalReturnsWarning,
   StaleFunctionExternalWarning, UnmatchedCheckWarning,
-  UnmatchedFieldBoundWarning, UnmatchedFunctionExternalWarning,
-  UnmatchedModuleExternalWarning, UnmatchedParamBoundWarning,
-  UnmatchedTypeFieldWarning, UntrackedEffectWarning,
+  UnmatchedExternalReturnsWarning, UnmatchedFieldBoundWarning,
+  UnmatchedFunctionExternalWarning, UnmatchedModuleExternalWarning,
+  UnmatchedParamBoundWarning, UnmatchedTypeFieldWarning, UntrackedEffectWarning,
 }
 import simplifile
 
@@ -469,6 +470,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
     registry:,
     type_info:,
     stale_externals:,
+    stale_external_returns:,
     knowledge_base:,
     catalog:,
     dependencies:,
@@ -526,6 +528,7 @@ pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
       index,
       package_root,
       stale_externals,
+      stale_external_returns,
       catalog,
       dependencies,
     )
@@ -555,6 +558,10 @@ type ProjectContext {
     // here: the knowledge base is assembled without them, and the spec lint
     // reports them, so the two can't disagree about which lines are live.
     stale_externals: Set(String),
+    // The same about the `external returns` lines, on the value channel. Two
+    // sets rather than one: each suppresses only its own channel's lines, and
+    // each is reported by its own warning.
+    stale_external_returns: Set(String),
     knowledge_base: KnowledgeBase,
     // The bundled catalog this context was assembled against. Held rather than
     // re-read by the spec lint, which weighs the same entries the knowledge
@@ -719,6 +726,7 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     registry:,
     type_info:,
     stale_externals:,
+    stale_external_returns:,
     knowledge_base:,
     catalog:,
     dependencies: dep_sources,
@@ -909,6 +917,7 @@ fn validate_spec_annotations(
   index: Dict(String, #(String, glance.Module)),
   package_root: String,
   stale_externals: Set(String),
+  stale_external_returns: Set(String),
   catalog: effects.BundledCatalog,
   dependencies: DependencySources,
 ) -> List(Warning) {
@@ -920,26 +929,36 @@ fn validate_spec_annotations(
     |> list.map(fn(ann) { UnmatchedCheckWarning(function: ann.function) })
 
   let externals = annotation.extract_externals(spec)
+  let declared_returns = annotation.extract_external_returns(spec)
   let type_fields = annotation.extract_type_fields(spec)
-  // Both lints tell a dependency module from a typo, and the scan behind that
-  // is the expensive part: walked once here and shared, and not at all for a
-  // spec holding neither kind of line.
-  let dep_files = case externals, type_fields {
-    [], [] -> dict.new()
-    _, _ -> dependency_module_files(package_root)
+  // Every lint here tells a dependency module from a typo, and the scan behind
+  // that is the expensive part: walked once here and shared, and not at all for
+  // a spec holding none of these line kinds.
+  let dep_files = case externals, declared_returns, type_fields {
+    [], [], [] -> dict.new()
+    _, _, _ -> dependency_module_files(package_root)
   }
   let dep_modules = set.from_list(dict.keys(dep_files))
 
-  let external_warnings =
-    external_warnings(
-      externals,
+  // The two declaring forms weigh a name by one rule, over one precomputation.
+  let evidence =
+    spec_name_evidence(
       index,
       known_functions,
       package_root,
-      stale_externals,
       dep_files,
       catalog,
       dependencies,
+    )
+
+  let external_warnings =
+    external_warnings(externals, evidence, stale_externals)
+
+  let external_returns_warnings =
+    external_returns_warnings(
+      declared_returns,
+      evidence,
+      stale_external_returns,
     )
 
   // Resolving `type` lines also needs per-module type info; build it only when
@@ -960,21 +979,28 @@ fn validate_spec_annotations(
     }
   }
 
-  list.flatten([check_warnings, external_warnings, type_field_warnings])
+  list.flatten([
+    check_warnings,
+    external_warnings,
+    external_returns_warnings,
+    type_field_warnings,
+  ])
 }
 
-// One walk of the spec's `external effects` lines, yielding the three ways such
-// a line can be dead. Both tiers are covered, since a typo is as likely in the
-// module name as in the function name:
-//
-//   - a per-function line naming one of *this package's* Gleam-bodied functions:
-//     valid syntax, nothing foreign to declare, so it is ignored and the body
-//     walked (see `stale_project_externals`);
-//   - a per-function line whose `module.function` resolves nowhere at all —
-//     dependency, catalog, or project index;
-//   - a module-level line whose module is neither a dependency nor a project
-//     module.
-//
+// What both declaring forms' lints weigh a name against, precomputed once over
+// the catalog and the dependency scan and then asked per name. One rule, so an
+// `external effects` line and an `external returns` line naming the same
+// function are called dead together or not at all.
+type SpecNameEvidence {
+  SpecNameEvidence(
+    // Whether anything graded can read defines the name.
+    defines: fn(QualifiedName) -> Bool,
+    // Whether the name's module was placed at all — or the dependency tree is
+    // too incomplete for its absence to prove anything.
+    module_placed: fn(String) -> Bool,
+  )
+}
+
 // A dependency is weighed by the function, not by the module: graded holds that
 // dependency's source, so `external effects dep/io.typo` over a `dep/io` that
 // defines only `writes` is as dead as one naming no module at all, and the
@@ -982,18 +1008,15 @@ fn validate_spec_annotations(
 // function to weigh and is settled by the module alone.
 //
 // Existence only. A name that resolves but that graded cannot introspect is
-// exactly what the line is for, and is never flagged.
-fn external_warnings(
-  externals: List(types.ExternalAnnotation),
+// exactly what a declaring line is for, and is never flagged.
+fn spec_name_evidence(
   index: Dict(String, #(String, glance.Module)),
   known_functions: Set(String),
   package_root: String,
-  stale: Set(String),
   dep_files: Dict(String, String),
   catalog: effects.BundledCatalog,
   dependencies: DependencySources,
-) -> List(Warning) {
-  use <- bool.guard(when: externals == [], return: [])
+) -> SpecNameEvidence {
   // The catalog the knowledge base was assembled from, selected against *this*
   // project's manifest — so a line naming a catalogued function of a package
   // this project depends on resolves exactly as `check` resolves it.
@@ -1016,56 +1039,109 @@ fn external_warnings(
   // it to be: with a manifest package whose sources never turned up, the module
   // may be that package's, and no reading of what is on disk disproves it.
   let unplaceable_is_unknown = !dependency_sources_are_complete(package_root)
+  // Whether something *outside* this package's own parsed source speaks for the
+  // module: a dependency source the lint could read, or a catalog entry.
+  let claimed = fn(module) {
+    dict.has_key(dep_files, module)
+    || dict.has_key(catalog_modules, module)
+    || set.contains(catalog_function_modules, module)
+  }
+  // And whether anything at all does. Nothing here is what "unplaceable" means.
+  let placed = fn(module) { dict.has_key(index, module) || claimed(module) }
+  let defines = fn(qualified: QualifiedName) {
+    // What answers for the name where no parsed source settles it: a module
+    // something outside this package speaks for, a catalog entry for the exact
+    // name, or a module the lint cannot place at all while the tree is missing
+    // a package that could be holding it. A project module is *not* among them
+    // — it was parsed, and `known_functions` is what it defines.
+    let unparsed_answers =
+      claimed(qualified.module)
+      || dict.has_key(catalog_functions, qualified)
+      || { unplaceable_is_unknown && !placed(qualified.module) }
+    // The catalog is a stand-in for sources graded cannot read, so it is
+    // weighed only where the dependency's own source says nothing: a parsed
+    // module defines what it defines, and a name it provably lacks is a typo
+    // whatever the catalog keys for the module. The lint flags what it can
+    // prove dead, and silence is not proof.
+    set.contains(known_functions, types.dotted_name(qualified))
+    || case dependency_name(dependencies, qualified) {
+      DefinedByDependency -> True
+      AbsentFromDependency -> False
+      UnreadDependency -> unparsed_answers
+    }
+  }
+  SpecNameEvidence(defines:, module_placed: fn(module) {
+    placed(module) || unplaceable_is_unknown
+  })
+}
+
+// One walk of the spec's `external effects` lines, yielding the three ways such
+// a line can be dead. Both tiers are covered, since a typo is as likely in the
+// module name as in the function name:
+//
+//   - a per-function line naming one of *this package's* Gleam-bodied functions:
+//     valid syntax, nothing foreign to declare, so it is ignored and the body
+//     walked (see `stale_project_externals`);
+//   - a per-function line whose `module.function` resolves nowhere at all —
+//     dependency, catalog, or project index;
+//   - a module-level line whose module is neither a dependency nor a project
+//     module.
+fn external_warnings(
+  externals: List(types.ExternalAnnotation),
+  evidence: SpecNameEvidence,
+  stale: Set(String),
+) -> List(Warning) {
   list.filter_map(externals, fn(external) {
-    // Whether something *outside* this package's own parsed source speaks for
-    // the module: a dependency source the lint could read, or a catalog entry —
-    // keyed by a module-level line, or by the per-function lines that are the
-    // usual form. The stdlib catalog holds `gleam/io.println` and no `gleam/io`
-    // line, and reading the module tier alone calls a real module a typo
-    // wherever that dependency's own source is not installed to say otherwise.
-    let claimed =
-      dict.has_key(dep_files, external.module)
-      || dict.has_key(catalog_modules, external.module)
-      || set.contains(catalog_function_modules, external.module)
-    // And whether anything at all does. Nothing here is what "unplaceable"
-    // means.
-    let placed = dict.has_key(index, external.module) || claimed
     case external.target {
       types.FunctionExternal(function) -> {
         let qualified = QualifiedName(external.module, function)
         let name = types.dotted_name(qualified)
-        // What answers for the name where no parsed source settles it: a module
-        // something outside this package speaks for, a catalog entry for the
-        // exact name, or a module the lint cannot place at all while the tree
-        // is missing a package that could be holding it. A project module is
-        // *not* among them — it was parsed, and `known_functions` is what it
-        // defines.
-        let unparsed_answers =
-          claimed
-          || dict.has_key(catalog_functions, qualified)
-          || { unplaceable_is_unknown && !placed }
-        // The catalog is a stand-in for sources graded cannot read, so it is
-        // weighed only where the dependency's own source says nothing: a
-        // parsed module defines what it defines, and a name it provably lacks
-        // is a typo whatever the catalog keys for the module. The lint flags
-        // what it can prove dead, and silence is not proof.
-        let resolves =
-          set.contains(known_functions, name)
-          || case dependency_name(dependencies, qualified) {
-            DefinedByDependency -> True
-            AbsentFromDependency -> False
-            UnreadDependency -> unparsed_answers
-          }
-        case set.contains(stale, name), resolves {
+        case set.contains(stale, name), evidence.defines(qualified) {
           True, _ -> Ok(StaleFunctionExternalWarning(function: name))
           False, False -> Ok(UnmatchedFunctionExternalWarning(function: name))
           False, True -> Error(Nil)
         }
       }
       types.ModuleExternal ->
-        case placed || unplaceable_is_unknown {
+        case evidence.module_placed(external.module) {
           True -> Error(Nil)
           False -> Ok(UnmatchedModuleExternalWarning(module: external.module))
+        }
+    }
+  })
+}
+
+// The same walk over the spec's `external returns` lines, yielding the four ways
+// one can be dead. Two are the existence branches above, read through the same
+// evidence; two are this form's own, and both are lines the loader drops:
+//
+//   - a name with no `.`: the declaration is per-function, and nothing keys a
+//     whole module's returned value;
+//   - a polymorphic operator, whose free variables nothing sanitized.
+//
+// One warning per line, so a line that is dead twice over is reported by the
+// first rule that catches it.
+fn external_returns_warnings(
+  declared: List(types.ReturnsAnnotation),
+  evidence: SpecNameEvidence,
+  stale: Set(String),
+) -> List(Warning) {
+  list.filter_map(declared, fn(returns) {
+    case annotation.split_function_name(returns.function) {
+      Error(Nil) -> Ok(DotlessExternalReturnsWarning(name: returns.function))
+      Ok(#(module, function)) ->
+        case
+          set.contains(stale, returns.function),
+          evidence.defines(QualifiedName(module, function)),
+          effects.is_ground_operator(returns.operator)
+        {
+          True, _, _ ->
+            Ok(StaleExternalReturnsWarning(function: returns.function))
+          False, False, _ ->
+            Ok(UnmatchedExternalReturnsWarning(function: returns.function))
+          False, True, False ->
+            Ok(PolymorphicExternalReturnsWarning(function: returns.function))
+          False, True, True -> Error(Nil)
         }
     }
   })
@@ -3924,6 +4000,34 @@ fn print_warning(file: String, warning: Warning) -> Nil {
         <> ": warning: external effects "
         <> module
         <> " names no dependency or project module — check the module path; the declaration covers nothing",
+      )
+    StaleExternalReturnsWarning(function:) ->
+      io.println(
+        file
+        <> ": warning: external returns "
+        <> function
+        <> " names a function of this package with a Gleam body — every caller resolves what it returns from that body, so the line declares nothing and is ignored. `graded infer` replaces it with the inferred `returns` line",
+      )
+    UnmatchedExternalReturnsWarning(function:) ->
+      io.println(
+        file
+        <> ": warning: external returns "
+        <> function
+        <> " names no dependency, catalog, or project function — check the module qualifier; the declaration covers nothing",
+      )
+    PolymorphicExternalReturnsWarning(function:) ->
+      io.println(
+        file
+        <> ": warning: external returns "
+        <> function
+        <> " declares an operator with effect variables — only a ground operator is loaded, so the line is ignored; write the effects the returned function performs, or wrap the producer in Gleam",
+      )
+    DotlessExternalReturnsWarning(name:) ->
+      io.println(
+        file
+        <> ": warning: external returns "
+        <> name
+        <> " names a module, not a function — a returns declaration is per-function; the line resolves nothing",
       )
   }
 }

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -668,6 +668,11 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.
     |> with_spec_externals(spec, stale_externals)
+    // Applied before path-dep inference for the same reason the externals above
+    // are, one channel over: a spec-less path dependency's bodies are summarized
+    // during that pass, and a consumer line declaring what one of its producers
+    // hands back has to be in reach while they are, not only afterwards.
+    |> with_spec_declared_returns(spec, stale_external_returns)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
     |> with_committed_spec(spec, stale_externals)
@@ -680,15 +685,21 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     ))
     // What this package defines, for the query that answers from its public API.
     |> effects.with_project_functions(project_function_visibility(index))
-    // Declared returns first: an `external returns` line is a declaration, not
-    // inference, so it must outrank both a committed `returns` line for the same
-    // name — a spec written before the function became `@external` still carries
-    // one until the next `infer` — and the fresh pass below. Both merges here
-    // gap-fill, so folding earlier is what makes it win.
-    |> with_spec_declared_returns(spec, stale_external_returns)
     // Committed project returns are Foreign (Fix E): serialized, unsanitized. The
     // fresh in-memory pass below re-infers project returns and, being Fresh, wins
     // over these for the same key.
+    //
+    // The `external returns` declarations folded above outrank both, by two
+    // different mechanisms, and the difference matters to anyone editing either.
+    // Against this committed load the **ordering is load-bearing**: the merge
+    // gap-fills, so a spec written before the function became `@external`, still
+    // carrying its inferred `returns` line until the next `infer`, loses only
+    // because the declaration is already there. Against the fresh pass below the
+    // ordering decides nothing — that merge lets the incoming summary win — and
+    // the declaration survives on `merge_returns`'s explicit
+    // declared-beats-inferred rule instead. That rule reads as redundant from
+    // here, since fresh inference keys no foreign name; it is what holds if any
+    // link of that three-file invariant chain ever gives.
     |> effects.with_foreign_returned_operators(
       effects.load_spec_returns_from_file(spec),
       types.CommittedSpec,
@@ -2656,6 +2667,12 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.
     |> with_spec_externals(spec, stale_externals)
+    // Declared returns are state no inference pass re-derives. Without them the
+    // walk of a caller's body writes `[Unknown]` where `check` scores the same
+    // body from the declaration, and the two commands disagree about it — so
+    // they are folded here, at the point `check` folds them, ahead of the
+    // path-dep pass whose own inference reads them too.
+    |> with_spec_declared_returns(spec, stale_external_returns)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
     |> effects.with_foreign_functions(project_foreign_functions(
@@ -2666,10 +2683,6 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
   let base_kb =
     kb_base
     |> with_spec_type_fields(spec)
-    // Declared returns are state no inference pass re-derives. Without them the
-    // walk of a caller's body writes `[Unknown]` where `check` scores the same
-    // body from the declaration, and the two commands disagree about it.
-    |> with_spec_declared_returns(spec, stale_external_returns)
     |> effects.with_factories(
       qualify_by_module(index, extract.factory_map(
         _,

--- a/src/graded/internal/annotation.gleam
+++ b/src/graded/internal/annotation.gleam
@@ -11,9 +11,10 @@ import graded/internal/types.{
   type ExternalAnnotation, type GradedFile, type GradedLine, type ParamBound,
   type ReturnsAnnotation, type TypeFieldAnnotation, AnnotationLine, BlankLine,
   Check, CommentLine, EffectAnnotation, Effects, ExternalAnnotation,
-  ExternalLine, FunctionExternal, GradedFile, ModuleExternal, ParamBound,
-  Polymorphic, ReturnsAnnotation, ReturnsLine, Specific, TAbs, TApp, TLabels,
-  TTop, TUnion, TVar, TypeFieldAnnotation, TypeFieldLine, Wildcard,
+  ExternalLine, ExternalReturnsLine, FunctionExternal, GradedFile,
+  ModuleExternal, ParamBound, Polymorphic, ReturnsAnnotation, ReturnsLine,
+  Specific, TAbs, TApp, TLabels, TTop, TUnion, TVar, TypeFieldAnnotation,
+  TypeFieldLine, Wildcard,
 }
 
 // Parsing
@@ -67,6 +68,11 @@ fn parse_structured_line(
         Ok(ext) -> Ok(ExternalLine(ext))
         Error(Nil) -> Error(InvalidLine(line_number, line))
       }
+    "external returns " <> rest ->
+      case parse_returns_line(rest) {
+        Ok(returns) -> Ok(ExternalReturnsLine(returns))
+        Error(Nil) -> Error(InvalidLine(line_number, line))
+      }
     "returns " <> rest ->
       case parse_returns_line(rest) {
         Ok(returns) -> Ok(ReturnsLine(returns))
@@ -76,8 +82,10 @@ fn parse_structured_line(
   }
 }
 
-// Parse a `returns mod.fn : fn(cb) -> [body]` line. The operator reuses the
-// same `fn(..) -> [..]` syntax as an operator parameter bound.
+// Parse the name and operator of a `returns mod.fn : fn(cb) -> [body]` line,
+// shared with `external returns`. The operator reuses the same
+// `fn(..) -> [..]` syntax as an operator parameter bound. Ground-ness and
+// dotted-ness of the name are load-time checks, not grammar.
 fn parse_returns_line(rest: String) -> Result(ReturnsAnnotation, Nil) {
   use #(name, operator) <- result.try(parse_name_colon_effects(rest))
   Ok(ReturnsAnnotation(function: name, operator:))
@@ -385,17 +393,28 @@ pub fn extract_annotations(file: GradedFile) -> List(EffectAnnotation) {
       TypeFieldLine(_) -> Error(Nil)
       ExternalLine(_) -> Error(Nil)
       ReturnsLine(_) -> Error(Nil)
+      ExternalReturnsLine(_) -> Error(Nil)
       CommentLine(_) -> Error(Nil)
       BlankLine -> Error(Nil)
     }
   })
 }
 
-// Extract all `returns` annotations from a parsed file.
+// Extract all inferred `returns` annotations from a parsed file.
 pub fn extract_returns(file: GradedFile) -> List(ReturnsAnnotation) {
   list.filter_map(file.lines, fn(line) {
     case line {
       ReturnsLine(returns) -> Ok(returns)
+      _ -> Error(Nil)
+    }
+  })
+}
+
+// Extract all declared `external returns` annotations from a parsed file.
+pub fn extract_external_returns(file: GradedFile) -> List(ReturnsAnnotation) {
+  list.filter_map(file.lines, fn(line) {
+    case line {
+      ExternalReturnsLine(returns) -> Ok(returns)
       _ -> Error(Nil)
     }
   })
@@ -609,6 +628,7 @@ pub fn merge_inferred(
         TypeFieldLine(_) -> Error(Nil)
         ExternalLine(_) -> Error(Nil)
         ReturnsLine(_) -> Error(Nil)
+        ExternalReturnsLine(_) -> Error(Nil)
         CommentLine(_) -> Error(Nil)
         BlankLine -> Error(Nil)
       }
@@ -620,6 +640,7 @@ pub fn merge_inferred(
         AnnotationLine(_) -> Error(Nil)
         TypeFieldLine(_) -> Error(Nil)
         ExternalLine(_) -> Error(Nil)
+        ExternalReturnsLine(_) -> Error(Nil)
         CommentLine(_) -> Error(Nil)
         BlankLine -> Error(Nil)
       }
@@ -708,6 +729,7 @@ pub fn format_file(file: GradedFile) -> String {
       TypeFieldLine(tf) -> format_type_field(tf)
       ExternalLine(ext) -> format_external(ext)
       ReturnsLine(returns) -> format_returns(returns)
+      ExternalReturnsLine(returns) -> format_external_returns(returns)
       CommentLine(text) -> text
       BlankLine -> ""
     }
@@ -760,6 +782,13 @@ pub fn format_sorted(file: GradedFile) -> String {
     })
     |> list.map(format_external)
 
+  let external_returns_lines =
+    extract_external_returns(file)
+    |> list.sort(fn(left, right) {
+      string.compare(left.function, right.function)
+    })
+    |> list.map(format_external_returns)
+
   let returns_lines =
     extract_returns(file)
     |> list.sort(fn(left, right) {
@@ -770,6 +799,7 @@ pub fn format_sorted(file: GradedFile) -> String {
   let sections = [
     comments,
     external_lines,
+    external_returns_lines,
     type_field_lines,
     check_lines,
     effects_lines,
@@ -803,9 +833,15 @@ pub fn format_annotation(annotation: EffectAnnotation) -> String {
   <> effects_string
 }
 
-// Render a ReturnsAnnotation back to its .graded line format.
+// Render a ReturnsAnnotation back to its inferred `returns` line format.
 pub fn format_returns(returns: ReturnsAnnotation) -> String {
   "returns " <> returns.function <> " : " <> format_operator(returns.operator)
+}
+
+// Render a ReturnsAnnotation back to its declared `external returns` line
+// format.
+pub fn format_external_returns(returns: ReturnsAnnotation) -> String {
+  "external " <> format_returns(returns)
 }
 
 // Format an operator term — a `TAbs` as `fn(cb) -> [body]`, anything else as a

--- a/src/graded/internal/annotation.gleam
+++ b/src/graded/internal/annotation.gleam
@@ -468,6 +468,16 @@ pub fn external_function_names(file: GradedFile) -> set.Set(String) {
   |> set.from_list()
 }
 
+// The `<module>.<function>` names a file declares with an
+// `external returns <module>.<function> : [...]` line. Read by `merge_inferred`,
+// which writes no inferred `returns` line for a name a declaration already
+// answers for.
+pub fn external_returns_names(file: GradedFile) -> set.Set(String) {
+  extract_external_returns(file)
+  |> list.map(fn(declared) { declared.function })
+  |> set.from_list()
+}
+
 // The modules a file declares with a module-level `external effects
 // <module> : [...]` line (no `.`). Per-function externals (`<module>.<fn>`)
 // don't count — they target one function, not the whole module. These are the
@@ -576,14 +586,22 @@ pub fn split_type_field_name(
 // Merge inferred effects and returned-operator signatures into an existing
 // GradedFile, preserving structure.
 //
-// - `check` / `type` / `external` lines, comments, blanks: kept in place
+// - `check` / `type` / `external` / `external returns` lines, comments, blanks:
+//   kept in place
 // - Existing `effects` and `returns` lines: updated in-place; removed if stale
 // - New functions not yet in file: `effects` / `returns` lines appended at end
+//
+// The two stale sets are separate channels and stay separate: an
+// `external effects` line that declares nothing suppresses this package's
+// `effects` lines for the name, and an `external returns` one that declares
+// nothing suppresses its `returns` line. Threading either set into the other's
+// filters deletes lines about a channel nobody declared anything on.
 pub fn merge_inferred(
   file: GradedFile,
   inferred: List(EffectAnnotation),
   inferred_returns: List(ReturnsAnnotation),
   stale_externals: set.Set(String),
+  stale_external_returns: set.Set(String),
 ) -> GradedFile {
   // A function the author declared with `external effects mod.fn : [...]` is
   // authoritative — that line is their opt-in to a precise FFI effect. Drop any
@@ -606,6 +624,22 @@ pub fn merge_inferred(
     list.filter(inferred, fn(annotation) {
       !set.contains(external_functions, annotation.function)
       && !in_external_module(annotation.function, external_modules)
+    })
+
+  // A function whose return an `external returns` line declares needs no
+  // inferred `returns` line: the declaration answers for it, and a second line
+  // for the same name would sit in the file looking like a second opinion.
+  // Except where that line is stale — it names one of this package's own
+  // ordinary functions — in which case the line is dropped below and the
+  // inferred one written in its place.
+  //
+  // Defensive for the healthy case rather than load-bearing: inference produces
+  // no returns entry for an `@external` in the first place.
+  let declared_returns =
+    set.difference(external_returns_names(file), stale_external_returns)
+  let inferred_returns =
+    list.filter(inferred_returns, fn(returns) {
+      !set.contains(declared_returns, returns.function)
     })
 
   let inferred_map =
@@ -664,6 +698,11 @@ pub fn merge_inferred(
                 False -> Ok(line)
               }
             Error(Nil) -> Ok(line)
+          }
+        ExternalReturnsLine(r) ->
+          case set.contains(stale_external_returns, r.function) {
+            True -> Error(Nil)
+            False -> Ok(line)
           }
         _ -> Ok(line)
       }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -23,10 +23,15 @@ import graded/internal/types.{
   type CallExplanation, type EffectAnnotation, type EffectTerm, type LocalCall,
   type LookupOrigin, type ParamBound, type QualifiedName, type ResolvedCall,
   type UnknownReason, type Violation, type Warning, CallExplanation,
-  EffectAnnotation, Effects, FieldNotAnnotated, NoKnownEffects, ParamBound,
-  QualifiedName, ReceiverTypeUnresolved, RefusedDeclaredReturn, TUnion, TVar,
-  TypeLine, UnbuiltExternal, UndeclaredExternal, UnmatchedFieldBoundWarning,
-  UnmatchedParamBoundWarning, UnresolvedFieldValue, UntraceableArgument,
+  DotlessExternalReturnsWarning, EffectAnnotation, Effects, FieldNotAnnotated,
+  NoKnownEffects, ParamBound, PolymorphicExternalReturnsWarning, QualifiedName,
+  ReceiverTypeUnresolved, RefusedDeclaredReturn, StaleExternalReturnsWarning,
+  StaleFunctionExternalWarning, TUnion, TVar, TypeLine,
+  TypeShapedExternalReturnsWarning, UnbuiltExternal, UndeclaredExternal,
+  UnmatchedCheckWarning, UnmatchedExternalReturnsWarning,
+  UnmatchedFieldBoundWarning, UnmatchedFunctionExternalWarning,
+  UnmatchedModuleExternalWarning, UnmatchedParamBoundWarning,
+  UnmatchedTypeFieldWarning, UnresolvedFieldValue, UntraceableArgument,
   UntraceableProducer, UntraceableReceiver, UntrackedEffectWarning, Violation,
 }
 
@@ -1505,6 +1510,95 @@ pub fn call_kind(call: QualifiedName) -> CallKind {
       )
       DirectCall(module:, function: call.function)
     }
+  }
+}
+
+// Render a warning as the line `graded check` reports.
+pub fn format_warning(file: String, warning: Warning) -> String {
+  case warning {
+    UntrackedEffectWarning(function:, reference:, effects: effs, ..) ->
+      file
+      <> ": warning: "
+      <> function
+      <> " passes "
+      <> reference.module
+      <> "."
+      <> reference.function
+      <> " as a value — its effects "
+      <> effects.format_effect_set(effs)
+      <> " won't be tracked"
+    UnmatchedFieldBoundWarning(function:, field_path:, receiver_is_param:) -> {
+      let cause = case receiver_is_param {
+        True -> " matches no field call in its body — check the path"
+        // A non-parameter receiver can be traced to a construction site, so the
+        // call may exist but resolve through value provenance, shadowing the bound.
+        False ->
+          " matches no field call in its body — check the path, or the receiver is traced to a construction site and resolved through value provenance (field bounds apply only to untraceable receivers)"
+      }
+      file
+      <> ": warning: field bound "
+      <> field_path
+      <> " on "
+      <> function
+      <> cause
+    }
+    UnmatchedParamBoundWarning(function:, param:) ->
+      file
+      <> ": warning: parameter bound "
+      <> param
+      <> " on "
+      <> function
+      <> " names no parameter of the function — check the name"
+    UnmatchedCheckWarning(function:) ->
+      file
+      <> ": warning: check "
+      <> function
+      <> " names no function in any project module — check the module qualifier; the check never runs"
+    UnmatchedTypeFieldWarning(name:) ->
+      file
+      <> ": warning: type "
+      <> name
+      <> " names no field of any project type — check the module qualifier; the field resolves to [Unknown]"
+    StaleFunctionExternalWarning(function:) ->
+      file
+      <> ": warning: external effects "
+      <> function
+      <> " names a function of this package with a Gleam body — the line declares no foreign code and is ignored; the body is walked instead. There is no replacement: fix the source, or widen the check budget"
+    UnmatchedFunctionExternalWarning(function:) ->
+      file
+      <> ": warning: external effects "
+      <> function
+      <> " names no dependency, catalog, or project function — check the module qualifier; the declaration covers nothing"
+    UnmatchedModuleExternalWarning(module:) ->
+      file
+      <> ": warning: external effects "
+      <> module
+      <> " names no dependency or project module — check the module path; the declaration covers nothing"
+    StaleExternalReturnsWarning(function:) ->
+      file
+      <> ": warning: external returns "
+      <> function
+      <> " names a function of this package with a Gleam body — every caller resolves what it returns from that body, so the line declares nothing and is ignored. `graded infer` removes it; where the function returns an operator, the inferred `returns` line takes its place"
+    UnmatchedExternalReturnsWarning(function:) ->
+      file
+      <> ": warning: external returns "
+      <> function
+      <> " names no dependency, catalog, or project function — check the module qualifier; the declaration covers nothing"
+    PolymorphicExternalReturnsWarning(function:) ->
+      file
+      <> ": warning: external returns "
+      <> function
+      <> " declares an operator with effect variables — only a ground operator is loaded, so the line is ignored; write the effects the returned function performs, or wrap the producer in Gleam"
+    DotlessExternalReturnsWarning(name:) ->
+      file
+      <> ": warning: external returns "
+      <> name
+      <> " names a module, not a function — a returns declaration is per-function; the line resolves nothing"
+    TypeShapedExternalReturnsWarning(name:) ->
+      file
+      <> ": warning: external returns "
+      <> name
+      <> " names a type field, not a function — a returns declaration is per-function; write a `type` line to give a field's effects, and the line resolves nothing as written"
   }
 }
 

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -24,10 +24,10 @@ import graded/internal/types.{
   type LookupOrigin, type ParamBound, type QualifiedName, type ResolvedCall,
   type UnknownReason, type Violation, type Warning, CallExplanation,
   EffectAnnotation, Effects, FieldNotAnnotated, NoKnownEffects, ParamBound,
-  QualifiedName, ReceiverTypeUnresolved, TUnion, TVar, TypeLine, UnbuiltExternal,
-  UndeclaredExternal, UnmatchedFieldBoundWarning, UnmatchedParamBoundWarning,
-  UnresolvedFieldValue, UntraceableArgument, UntraceableProducer,
-  UntraceableReceiver, UntrackedEffectWarning, Violation,
+  QualifiedName, ReceiverTypeUnresolved, RefusedDeclaredReturn, TUnion, TVar,
+  TypeLine, UnbuiltExternal, UndeclaredExternal, UnmatchedFieldBoundWarning,
+  UnmatchedParamBoundWarning, UnresolvedFieldValue, UntraceableArgument,
+  UntraceableProducer, UntraceableReceiver, UntrackedEffectWarning, Violation,
 }
 
 // Entry points
@@ -1601,7 +1601,8 @@ fn reason_clause(kind: CallKind, reason: UnknownReason) -> String {
         | ReceiverTypeUnresolved
         | UntraceableReceiver
         | UnresolvedFieldValue
-        | UntraceableProducer -> ""
+        | UntraceableProducer
+        | RefusedDeclaredReturn -> ""
       }
     FieldAccessCall(..) ->
       case reason {
@@ -1621,7 +1622,7 @@ fn reason_clause(kind: CallKind, reason: UnknownReason) -> String {
         // compiles, so the field call says what a direct call to that name says.
         UnbuiltExternal ->
           ", wired to an external declared only for a target this build does not compile,"
-        NoKnownEffects | UntraceableProducer -> ""
+        NoKnownEffects | UntraceableProducer | RefusedDeclaredReturn -> ""
       }
     // An undeclared external is the one reason worth stating: nothing said what
     // the foreign code does, which is why the effects stayed unresolved.
@@ -1635,14 +1636,21 @@ fn reason_clause(kind: CallKind, reason: UnknownReason) -> String {
         | UntraceableReceiver
         | UnresolvedFieldValue
         | UntraceableProducer
+        | RefusedDeclaredReturn
         | UntraceableArgument -> ""
       }
     ReturnedOperatorCall(..) ->
       case reason {
         UntraceableProducer -> ", whose producer could not be resolved,"
+        // The producer is the same `@external` a direct call reports out of
+        // reach, read one channel over: what it declares about the value is no
+        // more built than what it declares about the call.
+        UnbuiltExternal ->
+          ", an external declared only for a target this build does not compile,"
+        RefusedDeclaredReturn ->
+          ", whose declared return is refused where its Gleam fallback body also runs,"
         NoKnownEffects
         | UndeclaredExternal
-        | UnbuiltExternal
         | FieldNotAnnotated(..)
         | ReceiverTypeUnresolved
         | UntraceableReceiver
@@ -3155,7 +3163,13 @@ fn collect_effects(
       // holds it.
       let #(reason, origin) = case resolved_op {
         Ok(#(_, origin)) -> #(None, origin)
-        Error(Nil) -> #(Some(UntraceableProducer), None)
+        Error(Nil) -> #(
+          Some(unresolved_producer_reason(
+            knowledge_base,
+            producer_key(op.callee, context),
+          )),
+          None,
+        )
       }
       let #(effect, memo) = case resolved_op {
         Ok(#(operator, _)) -> {
@@ -4922,6 +4936,35 @@ fn build_lift_operator_arg(
   }
 }
 
+// A producer's knowledge-base key. A same-module callee carries no module of its
+// own, so the module being walked qualifies it — the resolution path and the
+// diagnostic that explains its failure ask about one name this way.
+fn producer_key(
+  callee: QualifiedName,
+  context: ImportContext,
+) -> QualifiedName {
+  case callee.module {
+    "" -> QualifiedName(module: context.module_path, function: callee.function)
+    _ -> callee
+  }
+}
+
+// Why a producer left its applied operator unknown. A declared return that a
+// gate refused is named rather than folded into the generic reason: one gate is
+// the same reading a direct call reports for that `@external`, and the other is
+// this channel's own refusal, which no other surface has words for.
+fn unresolved_producer_reason(
+  knowledge_base: KnowledgeBase,
+  producer: QualifiedName,
+) -> UnknownReason {
+  case effects.declared_return_standing(knowledge_base, producer) {
+    effects.DeclaredReturnUnbuilt -> UnbuiltExternal
+    effects.DeclaredReturnFallbackRuns -> RefusedDeclaredReturn
+    effects.DeclaredReturnAnswers | effects.NoDeclaredReturn ->
+      UntraceableProducer
+  }
+}
+
 // The knowledge base's summary for `name`, in the shape the trust match reads:
 // the operator, how it was produced, and the source that wrote it.
 fn knowledge_base_operator(
@@ -5004,13 +5047,7 @@ fn resolve_returned_operator(
         // `Declared` summary — no same-module `Fresh` or `Foreign` one leaks
         // through it.
         _, ForeignDefinition -> #(
-          knowledge_base_operator(
-            knowledge_base,
-            QualifiedName(
-              module: context.module_path,
-              function: callee.function,
-            ),
-          ),
+          knowledge_base_operator(knowledge_base, producer_key(callee, context)),
           memo,
         )
         _, NoLocalDefinition -> #(Error(Nil), memo)

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2362,22 +2362,6 @@ fn local_definition(
   }
 }
 
-// The same-module definition of `function`, or `Error(Nil)` when this module
-// defines no such function or defines it `@external`. The value channels resolve
-// through this rather than the raw function map: a fallback body describes
-// neither what the foreign implementation returns nor how, so a same-module
-// consumer of one is charged `[Unknown]` exactly as a cross-module consumer is.
-fn local_native_definition(
-  function_map: dict.Dict(String, Definition(Function)),
-  function: String,
-  package_targets: types.PackageTargets,
-) -> Result(Definition(Function), Nil) {
-  case local_definition(function_map, function, package_targets) {
-    NativeDefinition(definition) -> Ok(definition)
-    ForeignDefinition | NoLocalDefinition -> Error(Nil)
-  }
-}
-
 // A collected call whose kind states the whole story: the sentinel names what
 // happened, so there is nothing to add.
 fn plain_call(call: ResolvedCall, term: EffectTerm) -> CollectedCall {
@@ -4554,16 +4538,16 @@ fn callee_provenance(
 ) -> Result(types.ReturnProvenance, Nil) {
   case callee.module {
     "" ->
+      // A fallback body describes neither what the foreign implementation
+      // returns nor how, so a same-module consumer of one is charged `[Unknown]`
+      // exactly as a cross-module consumer is: this channel reads no
+      // declaration, so a foreign definition and no definition end alike here.
       case
-        local_native_definition(
-          function_map,
-          callee.function,
-          context.package_targets,
-        )
+        local_definition(function_map, callee.function, context.package_targets)
       {
-        Ok(definition) ->
+        NativeDefinition(definition) ->
           Ok(extract.return_provenance(definition.definition, context))
-        Error(Nil) -> Error(Nil)
+        ForeignDefinition | NoLocalDefinition -> Error(Nil)
       }
     _ -> effects.lookup_provenance(knowledge_base, callee)
   }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2234,6 +2234,32 @@ type CollectedCall {
   CollectedCall(call: ResolvedCall, resolution: Resolution)
 }
 
+// What the module under analysis defines for `function`, as the value channels
+// read it: a Gleam body they may walk, an `@external` only a declaration speaks
+// for, or no definition at all. The three are held apart because a declared
+// return answers for the middle case and for neither of the others — collapsing
+// them is how a plain miss would start consulting the knowledge base.
+type LocalDefinition {
+  NativeDefinition(definition: Definition(Function))
+  ForeignDefinition
+  NoLocalDefinition
+}
+
+fn local_definition(
+  function_map: dict.Dict(String, Definition(Function)),
+  function: String,
+  package_targets: types.PackageTargets,
+) -> LocalDefinition {
+  case dict.get(function_map, function) {
+    Error(Nil) -> NoLocalDefinition
+    Ok(definition) ->
+      case foreign_definition(definition, package_targets) {
+        True -> ForeignDefinition
+        False -> NativeDefinition(definition)
+      }
+  }
+}
+
 // The same-module definition of `function`, or `Error(Nil)` when this module
 // defines no such function or defines it `@external`. The value channels resolve
 // through this rather than the raw function map: a fallback body describes
@@ -2244,10 +2270,9 @@ fn local_native_definition(
   function: String,
   package_targets: types.PackageTargets,
 ) -> Result(Definition(Function), Nil) {
-  use definition <- result.try(dict.get(function_map, function))
-  case foreign_definition(definition, package_targets) {
-    True -> Error(Nil)
-    False -> Ok(definition)
+  case local_definition(function_map, function, package_targets) {
+    NativeDefinition(definition) -> Ok(definition)
+    ForeignDefinition | NoLocalDefinition -> Error(Nil)
   }
 }
 
@@ -4897,6 +4922,21 @@ fn build_lift_operator_arg(
   }
 }
 
+// The knowledge base's summary for `name`, in the shape the trust match reads:
+// the operator, how it was produced, and the source that wrote it.
+fn knowledge_base_operator(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> Result(
+  #(EffectTerm, effects.SummaryOrigin, option.Option(LookupOrigin)),
+  Nil,
+) {
+  effects.lookup_returned_operator(knowledge_base, name)
+  |> result.map(fn(found) {
+    #(found.operator, found.summary, Some(found.source))
+  })
+}
+
 // Resolve the operator a producer returns. A qualified callee is looked up in
 // the KB (computed at the producer's inference time, available downstream by
 // topological order); a same-module callee (`""` module) is computed on-demand
@@ -4925,13 +4965,9 @@ fn resolve_returned_operator(
     "" ->
       case
         set.contains(visited, callee.function),
-        local_native_definition(
-          function_map,
-          callee.function,
-          context.package_targets,
-        )
+        local_definition(function_map, callee.function, context.package_targets)
       {
-        False, Ok(definition) -> {
+        False, NativeDefinition(definition) -> {
           let #(result, memo) =
             compute_returned_operator(
               definition.definition,
@@ -4952,20 +4988,34 @@ fn resolve_returned_operator(
         // recursive function-reference handling in `build_lift_operator_arg`.
         // Arity comes from the producer's return type; if it isn't a function
         // type, stay conservative.
-        True, Ok(definition) -> #(
+        True, NativeDefinition(definition) -> #(
           neutral_returned_operator(definition.definition, cache.fn_alias_types)
             |> result.map(fn(op) { #(op, effects.Fresh, None) }),
           memo,
         )
-        _, _ -> #(Error(Nil), memo)
+        // A same-module `@external`: there is no body to compute a summary
+        // from, so the only thing that can say what it hands back is a
+        // declaration. Extraction keys a bare reference with no module, so the
+        // name is qualified with the module being walked before the base is
+        // asked.
+        //
+        // The branch is reached for foreign definitions alone, and a foreign
+        // name is value-opaque, so the gated lookup can answer here only with a
+        // `Declared` summary — no same-module `Fresh` or `Foreign` one leaks
+        // through it.
+        _, ForeignDefinition -> #(
+          knowledge_base_operator(
+            knowledge_base,
+            QualifiedName(
+              module: context.module_path,
+              function: callee.function,
+            ),
+          ),
+          memo,
+        )
+        _, NoLocalDefinition -> #(Error(Nil), memo)
       }
-    _ -> #(
-      effects.lookup_returned_operator(knowledge_base, callee)
-        |> result.map(fn(found) {
-          #(found.operator, found.summary, Some(found.source))
-        }),
-      memo,
-    )
+    _ -> #(knowledge_base_operator(knowledge_base, callee), memo)
   }
   case lookup {
     Error(Nil) -> #(Error(Nil), memo)
@@ -5007,6 +5057,11 @@ fn resolve_returned_operator(
         // for synthesis. Resolve conservatively to [Unknown] (the `Error` here
         // reaches every consumer's [Unknown] fallback).
         False, effects.Foreign -> #(Error(Nil), memo)
+        // Polymorphic + Declared: the loader drops a polymorphic declaration, so
+        // nothing reaches here. A loader that stopped doing so must degrade to
+        // [Unknown] rather than substitute over free variables nothing
+        // sanitized.
+        False, effects.Declared -> #(Error(Nil), memo)
       }
   }
 }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -1864,7 +1864,7 @@ fn callback_binder_sentinel(start: Int, name: String) -> String {
 
 // True iff a term still carries unresolved (free) effect variables.
 fn has_vars(term: EffectTerm) -> Bool {
-  !set.is_empty(effect_term.free_vars(term))
+  !effect_term.is_ground(term)
 }
 
 // Union the effect terms of a list of collected calls, normalizing once.
@@ -4392,16 +4392,8 @@ fn reorder_args_by_signature(
   context: ImportContext,
   registry: SignatureRegistry,
 ) -> Result(List(types.CallArgument), Nil) {
-  let key = case callee.module {
-    "" ->
-      types.QualifiedName(
-        module: context.module_path,
-        function: callee.function,
-      )
-    _ -> callee
-  }
   use params <- result.try(option.to_result(
-    signatures.lookup(registry, key),
+    signatures.lookup(registry, producer_key(callee, context)),
     Nil,
   ))
   let sorted =
@@ -5057,7 +5049,7 @@ fn resolve_returned_operator(
   case lookup {
     Error(Nil) -> #(Error(Nil), memo)
     Ok(#(operator, summary, source)) ->
-      case set.is_empty(effect_term.free_vars(operator)), summary {
+      case effect_term.is_ground(operator), summary {
         // Ground operator (no free vars): trusted regardless of origin. A Fresh
         // one is sanitized by this run (callback binders can't have captured a
         // residual). A Foreign one — a serialized summary, including this
@@ -5094,10 +5086,10 @@ fn resolve_returned_operator(
         // for synthesis. Resolve conservatively to [Unknown] (the `Error` here
         // reaches every consumer's [Unknown] fallback).
         False, effects.Foreign -> #(Error(Nil), memo)
-        // Polymorphic + Declared: the loader drops a polymorphic declaration, so
-        // nothing reaches here. A loader that stopped doing so must degrade to
-        // [Unknown] rather than substitute over free variables nothing
-        // sanitized.
+        // Polymorphic + Declared: a declaration is tagged only after the
+        // non-ground operators are dropped, so nothing reaches here. An edit
+        // that changed that must degrade to [Unknown] rather than substitute
+        // over free variables nothing sanitized.
         False, effects.Declared -> #(Error(Nil), memo)
       }
   }
@@ -5332,7 +5324,7 @@ fn compute_returned_operator_result(
         False -> Ok(operator)
       }
     types.TApp(_, _) ->
-      case set.is_empty(effect_term.free_vars(operator)) {
+      case effect_term.is_ground(operator) {
         True -> Error(Nil)
         False -> Ok(operator)
       }

--- a/src/graded/internal/effect_term.gleam
+++ b/src/graded/internal/effect_term.gleam
@@ -106,6 +106,13 @@ pub fn free_vars(term: EffectTerm) -> Set(String) {
   }
 }
 
+// Whether a term binds every effect variable it mentions. A ground term means
+// the same thing wherever it is read, which is what lets one be trusted without
+// the substitution a free variable would otherwise need.
+pub fn is_ground(term: EffectTerm) -> Bool {
+  set.is_empty(free_vars(term))
+}
+
 // Capture-avoiding substitution
 //
 // Replace effect variables with terms without letting a binder capture an

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1207,11 +1207,63 @@ pub fn with_declared_returned_operators(
   source: LookupOrigin,
 ) -> KnowledgeBase {
   let merged =
-    dict.merge(
+    merge_returns(
       knowledge_base.returned_operators,
       declared_returns(declared, source),
     )
   KnowledgeBase(..knowledge_base, returned_operators: merged)
+}
+
+// Merge declared summaries that only *fill gaps*: whatever an earlier fold
+// already wrote for a name stands, declaration or not.
+//
+// The path-dependency fold merges this way. Its tier sits below the installed
+// dependencies', so a path dep declaring `external returns dep/ffi.make` for a
+// name an installed dependency's own spec already declares must not displace it
+// — the inversion of the documented order that `over_catalog` keeps the effects
+// channel out of. Within the one spec being folded, this still leaves the
+// declaration standing over that file's inferred `returns` line: the
+// declarations fold first, and the inferred merge beside them gap-fills too.
+fn gap_filling_declared_returns(
+  knowledge_base: KnowledgeBase,
+  declared: Dict(QualifiedName, EffectTerm),
+  source: LookupOrigin,
+) -> KnowledgeBase {
+  let merged =
+    dict.merge(
+      declared_returns(declared, source),
+      knowledge_base.returned_operators,
+    )
+  KnowledgeBase(..knowledge_base, returned_operators: merged)
+}
+
+// The one precedence rule this channel merges by: an incoming entry wins its
+// key, **except** that nothing inferred replaces a declaration.
+//
+// Tier order on the channel is fold order — the folds run outermost-first, so
+// a consumer's line, folded last, is the one that answers. Declared-beats-
+// inferred cannot ride on that ordering alone, because it must hold *within* a
+// tier as well: installed dependencies are folded in directory order, and a
+// stray `returns` line in the second package naming the first package's module
+// would otherwise bury the `external returns` line its author shipped.
+fn merge_returns(
+  existing: Dict(QualifiedName, ReturnedOperator),
+  incoming: Dict(QualifiedName, ReturnedOperator),
+) -> Dict(QualifiedName, ReturnedOperator) {
+  let winning =
+    dict.filter(incoming, fn(name, entry) {
+      case entry.summary {
+        Declared -> True
+        Fresh | Foreign ->
+          case dict.get(existing, name) {
+            Ok(ReturnedOperator(summary: Declared, ..)) -> False
+            Ok(ReturnedOperator(summary: Fresh, ..))
+            | Ok(ReturnedOperator(summary: Foreign, ..))
+            | Error(Nil) -> True
+          }
+      }
+    })
+  dict.merge(existing, winning)
 }
 
 // Tag declared summaries, dropping every operator that is not ground — the one
@@ -1237,35 +1289,23 @@ fn declared_returns(
 // replaces a committed Foreign one for the same key. Used for the pre-pass /
 // main-loop fresh deltas.
 //
-// A **Declared** entry is the exception: inference describes a body, and the
-// line describes what the foreign implementation hands back, so the line stands.
-// Fresh inference keys no foreign name in the first place and a declaration over
-// an ordinary own function is dropped at load, so this guard is insurance
-// against drift in a chain of invariants that spans three files.
+// A **Declared** entry is the exception `merge_returns` states: inference
+// describes a body, and the line describes what the foreign implementation hands
+// back, so the line stands. Fresh inference keys no foreign name in the first
+// place and a declaration over an ordinary own function is dropped at load, so
+// here the rule is insurance against drift in a chain of invariants that spans
+// three files rather than the thing holding the roof up.
 pub fn with_fresh_returned_operators(
   knowledge_base: KnowledgeBase,
   inferred: Dict(QualifiedName, EffectTerm),
   source: LookupOrigin,
 ) -> KnowledgeBase {
-  let fresh =
-    dict.filter(tag_returns(inferred, Fresh, source), fn(name, _summary) {
-      !is_declared_return(knowledge_base, name)
-    })
-  let merged = dict.merge(knowledge_base.returned_operators, fresh)
+  let merged =
+    merge_returns(
+      knowledge_base.returned_operators,
+      tag_returns(inferred, Fresh, source),
+    )
   KnowledgeBase(..knowledge_base, returned_operators: merged)
-}
-
-// Whether the base already holds a declared summary for `name`.
-fn is_declared_return(
-  knowledge_base: KnowledgeBase,
-  name: QualifiedName,
-) -> Bool {
-  case dict.get(knowledge_base.returned_operators, name) {
-    Ok(ReturnedOperator(summary: Declared, ..)) -> True
-    Ok(ReturnedOperator(summary: Fresh, ..))
-    | Ok(ReturnedOperator(summary: Foreign, ..))
-    | Error(Nil) -> False
-  }
 }
 
 // Attach the package-wide factory map (keyed by `#(module, function)`), so a
@@ -1582,6 +1622,12 @@ pub fn load_spec_params_from_file(
 //
 // The two returns maps are held apart because only one of them is a
 // declaration, and the sanitizing below weighs them by exactly that.
+//
+// `modules` is the package's own module paths, read off the `src/` tree beside
+// the spec: what the sanitizing below measures a line's *subject* against, so a
+// spec cannot state a returned-operator summary about code it does not ship.
+// Empty where that tree could not be read, which the filter reads as "nothing to
+// arbitrate with" rather than as "the package owns nothing".
 pub type DepSpec {
   DepSpec(
     effects: Dict(QualifiedName, EffectTerm),
@@ -1590,6 +1636,7 @@ pub type DepSpec {
     declared_returns: Dict(QualifiedName, EffectTerm),
     type_fields: List(TypeFieldAnnotation),
     externals: List(ExternalAnnotation),
+    modules: Set(String),
   )
 }
 
@@ -1603,7 +1650,8 @@ pub type DepSpec {
 // lines the dep author wrote for its FFI.
 pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
   case read_spec_file(config.spec_file_for(dep_root, package_name)) {
-    Error(_) -> DepSpec(dict.new(), dict.new(), dict.new(), dict.new(), [], [])
+    Error(_) ->
+      DepSpec(dict.new(), dict.new(), dict.new(), dict.new(), [], [], set.new())
     Ok(file) ->
       // Loaded through the same two readers a package uses for its *own* spec,
       // so a dependency's `check` budgets and externally-declared functions are
@@ -1620,8 +1668,16 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
         declared_returns: load_spec_external_returns_from_file(file),
         type_fields: annotation.extract_type_fields(file),
         externals: annotation.extract_externals(file),
+        modules: package_modules(dep_root),
       )
   }
+}
+
+// The module paths a package ships, read off its `src/` tree.
+fn package_modules(dep_root: String) -> Set(String) {
+  source_dir_module_files(filepath.join(dep_root, "src"))
+  |> dict.keys
+  |> set.from_list
 }
 
 // A dependency spec minus the entries no dependency spec may state about its
@@ -1637,11 +1693,20 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
 // `external returns` line, a module-level external, or the catalog entry
 // underneath.
 //
-// `declared_returns` is therefore never filtered here, over a foreign name or an
-// ordinary one. The line is the dep author's declaration of what their producer
-// hands back, and arbitrating it against their own source is their `infer`'s
-// job, not their consumer's — the same reading that keeps their
-// `external effects` line for a Gleam-bodied function of their own.
+// `declared_returns` is therefore not weighed against the dep's own foreign
+// scan. The line is the dep author's declaration of what their producer hands
+// back, and arbitrating it against their own source is their `infer`'s job, not
+// their consumer's — the same reading that keeps their `external effects` line
+// for a Gleam-bodied function of their own.
+//
+// Both returns maps are weighed against a second question, which the effects
+// channel has no analogue of: whose code the line is *about*. A spec may state a
+// returned-operator summary for a module it ships or for a name the foreign scan
+// records, and for nothing else. Without that, a dependency shipping
+// `external returns app.helper` — an ordinary Gleam function of the *consumer* —
+// lands a declaration in the tier above the consumer's own body-derived summary,
+// and the consumer's source stops being what its own callers are charged for.
+// A package whose `src/` tree could not be read arbitrates nothing here.
 //
 // A term and its bounds are dropped together. `load_knowledge_base` merges terms
 // and bounds in two independent passes, so a term dropped without its bounds
@@ -1662,6 +1727,11 @@ fn sanitize_dep_spec(
   let inferred_over_foreign = fn(name) {
     dict.has_key(foreign, name) && !set.contains(declared, name)
   }
+  let about_other_code = fn(name: QualifiedName) {
+    !set.is_empty(dep.modules)
+    && !set.contains(dep.modules, name.module)
+    && !dict.has_key(foreign, name)
+  }
   DepSpec(
     ..dep,
     effects: dict.filter(dep.effects, fn(name, _term) {
@@ -1671,7 +1741,10 @@ fn sanitize_dep_spec(
       !inferred_over_foreign(name)
     }),
     returns: dict.filter(dep.returns, fn(name, _operator) {
-      !dict.has_key(foreign, name)
+      !dict.has_key(foreign, name) && !about_other_code(name)
+    }),
+    declared_returns: dict.filter(dep.declared_returns, fn(name, _operator) {
+      !about_other_code(name)
     }),
   )
 }
@@ -1708,10 +1781,12 @@ fn decided_entries(dep: DepSpec, origin: LookupOrigin) -> ExternalTiers {
 // function-keyed entries outrank it — the per-function-beats-module-level rule.
 //
 // The spec's `external returns` declarations fold ahead of its inferred
-// `returns` lines, so a name both key resolves to the declaration. Nothing pairs
-// bounds with a summary on this channel — the ground-only rule means a declared
-// operator binds no parameter — so there is no term-and-bounds pairing to keep
-// intact here.
+// `returns` lines, so a name both key resolves to the declaration. Both merges
+// gap-fill: this tier reads below the installed dependencies', so a name an
+// installed dep's spec already answered keeps that answer, declaration or not.
+// Nothing pairs bounds with a summary on this channel — the ground-only rule
+// means a declared operator binds no parameter — so there is no term-and-bounds
+// pairing to keep intact here.
 pub fn with_path_dep_spec(
   knowledge_base: KnowledgeBase,
   dep: DepSpec,
@@ -1737,7 +1812,7 @@ pub fn with_path_dep_spec(
       over_catalog(knowledge_base.module_effects, module_externals),
     ),
   )
-  |> with_declared_returned_operators(dep.declared_returns, origin)
+  |> gap_filling_declared_returns(dep.declared_returns, origin)
   |> with_foreign_returned_operators(dep.returns, origin)
   |> with_type_fields(dep.type_fields, origin)
 }
@@ -1874,11 +1949,13 @@ fn load_dependencies(
       Dependencies(
         effects: dict.merge(acc.effects, decided),
         params: dict.merge(acc.params, dep.params),
-        returns: dict.merge(
+        returns: merge_returns(
           acc.returns,
           // Within one spec a declared summary answers for a name its own
-          // `returns` line also keys: the second argument wins.
-          dict.merge(
+          // `returns` line also keys: the incoming argument wins. Across the
+          // specs, the same rule keeps one package's stray `returns` line from
+          // burying another's declaration for the same name.
+          merge_returns(
             tag_returns(dep.returns, Foreign, origin),
             declared_returns(dep.declared_returns, origin),
           ),

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1165,6 +1165,12 @@ fn with_origin(
 
 // Pair every summary in a bare `name -> operator` map with how it was produced
 // and the source that wrote it, giving the shape `returned_operators` holds.
+//
+// Guard: never reach here with `Foreign` for a map of `external returns` lines.
+// A declaration is written for a value-opaque name, and a Foreign-tagged summary
+// over one is refused at lookup — a new tier folding declarations this way (the
+// deferred catalog tier is the one waiting to) silently no-ops instead of
+// answering. `declared_returns` is the entry point for those.
 fn tag_returns(
   returns: Dict(QualifiedName, EffectTerm),
   summary: SummaryOrigin,
@@ -1178,6 +1184,13 @@ fn tag_returns(
 // Merge **Foreign** returned-operator summaries (from a serialized `.graded`)
 // into a knowledge base — existing entries take priority (gap-fill). Used for
 // dependency and committed-project returns.
+//
+// Guard: this takes a spec's inferred `returns` lines and nothing else. Folding
+// `external returns` lines through it tags them `Foreign`, and a Foreign summary
+// over the value-opaque name a declaration is written for is refused at lookup,
+// so the tier folding them would silently answer nothing — the failure a
+// deferred catalog tier is one edit away from. Declarations go through
+// `with_declared_returned_operators`.
 pub fn with_foreign_returned_operators(
   knowledge_base: KnowledgeBase,
   inferred: Dict(QualifiedName, EffectTerm),
@@ -1363,7 +1376,7 @@ pub fn lookup_returned_operator(
   use found <- result.try(dict.get(knowledge_base.returned_operators, name))
   case found.summary {
     Declared ->
-      case declared_return_standing(knowledge_base, name) {
+      case charged_standing(knowledge_base, name) {
         DeclaredReturnAnswers -> Ok(found)
         DeclaredReturnUnbuilt | DeclaredReturnFallbackRuns | NoDeclaredReturn ->
           Error(Nil)
@@ -1413,15 +1426,25 @@ pub fn declared_return_standing(
     Error(Nil) -> NoDeclaredReturn
     Ok(ReturnedOperator(summary: Fresh, ..))
     | Ok(ReturnedOperator(summary: Foreign, ..)) -> NoDeclaredReturn
-    Ok(ReturnedOperator(summary: Declared, ..)) -> {
-      let charge = declared_charge(knowledge_base, name)
-      case charge.declaration, charge.fallback {
-        DeclarationCharged, None -> DeclaredReturnAnswers
-        DeclarationCharged, Some(_) -> DeclaredReturnFallbackRuns
-        FallbackAnswersInstead, _ | NothingImplementsName, _ ->
-          DeclaredReturnUnbuilt
-      }
-    }
+    Ok(ReturnedOperator(summary: Declared, ..)) ->
+      charged_standing(knowledge_base, name)
+  }
+}
+
+// The standing of a declaration already known to key `name` — the charge match
+// alone, without the triage that established there is one to weigh. The lookup
+// reads it having just fetched the entry; the wrapper above adds the fetch for a
+// caller holding only the name.
+fn charged_standing(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> DeclaredReturnStanding {
+  let charge = declared_charge(knowledge_base, name)
+  case charge.declaration, charge.fallback {
+    DeclarationCharged, None -> DeclaredReturnAnswers
+    DeclarationCharged, Some(_) -> DeclaredReturnFallbackRuns
+    FallbackAnswersInstead, _ | NothingImplementsName, _ ->
+      DeclaredReturnUnbuilt
   }
 }
 

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1137,7 +1137,8 @@ pub type SummaryOrigin {
   // hands back, declared rather than inferred. It answers for a name every
   // other summary is refused for — that is the whole point of the line — so
   // it is held to `declared_return_standing` instead of to `is_value_opaque`.
-  // Ground by the loader's invariant, which is what makes trusting it sound.
+  // Ground by construction — `declared_returns` is the only place the tag is
+  // stamped and it drops anything else — which is what makes trusting it sound.
   Declared
 }
 
@@ -1208,9 +1209,27 @@ pub fn with_declared_returned_operators(
   let merged =
     dict.merge(
       knowledge_base.returned_operators,
-      tag_returns(declared, Declared, source),
+      declared_returns(declared, source),
     )
   KnowledgeBase(..knowledge_base, returned_operators: merged)
+}
+
+// Tag declared summaries, dropping every operator that is not ground — the one
+// place `Declared` is stamped, so the tag means ground by construction rather
+// than by the loaders that happen to feed it.
+//
+// A polymorphic operator carries free variables nothing sanitized, which is the
+// substitution a serialized summary is already refused for. Dropping it here is
+// what makes the checker's polymorphic-`Declared` case unreachable, and a new
+// source of declarations — a catalog tier, a cache — inherits the rule instead
+// of having to restate it. The drop is silent: nothing in this module holds a
+// warning channel, and the project's own lines are reported by the spec lint.
+fn declared_returns(
+  declared: Dict(QualifiedName, EffectTerm),
+  source: LookupOrigin,
+) -> Dict(QualifiedName, ReturnedOperator) {
+  dict.filter(declared, fn(_name, operator) { effect_term.is_ground(operator) })
+  |> tag_returns(Declared, source)
 }
 
 // Merge **Fresh** returned-operator summaries (produced by this run's inference)
@@ -1791,31 +1810,15 @@ pub fn load_spec_returns_from_file(
   fold_spec_returns(annotation.extract_returns(file))
 }
 
-// The same map from a parsed spec's declared `external returns` lines — the one
-// choke point that keeps every declared summary in the base ground.
-//
-// A polymorphic operator carries free variables nothing sanitized, which is the
-// substitution the checker refuses for a serialized summary; it is dropped here
-// rather than loaded and refused later, so `Declared` means ground everywhere
-// downstream. A dotless name splits to nothing and `fold_spec_returns` drops it
-// with the rest — a returns declaration is per-function, and a name that
-// resolves nowhere would otherwise sit in the file looking effective.
-//
-// Both drops are silent in every tier: nothing here holds a warning channel, a
-// consumer can act on neither a dependency's line nor the catalog's, and the
-// project's own are reported by the spec lint.
+// The same map from a parsed spec's declared `external returns` lines. A dotless
+// name splits to nothing and `fold_spec_returns` drops it silently — a returns
+// declaration is per-function, and a name that resolves nowhere would otherwise
+// sit in the file looking effective. The ground-only rule is applied where the
+// summaries are tagged, in `declared_returns`.
 pub fn load_spec_external_returns_from_file(
   file: types.GradedFile,
 ) -> Dict(QualifiedName, EffectTerm) {
-  annotation.extract_external_returns(file)
-  |> list.filter(fn(declared) { is_ground_operator(declared.operator) })
-  |> fold_spec_returns()
-}
-
-// Whether an operator binds no free effect variable — the ground-only rule the
-// declared tier is cut to.
-pub fn is_ground_operator(operator: EffectTerm) -> Bool {
-  set.is_empty(effect_term.free_vars(operator))
+  fold_spec_returns(annotation.extract_external_returns(file))
 }
 
 fn fold_spec_returns(
@@ -1877,7 +1880,7 @@ fn load_dependencies(
           // `returns` line also keys: the second argument wins.
           dict.merge(
             tag_returns(dep.returns, Foreign, origin),
-            tag_returns(dep.declared_returns, Declared, origin),
+            declared_returns(dep.declared_returns, origin),
           ),
         ),
         type_fields: list.append(

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -891,9 +891,12 @@ pub fn project_visibility(
 //
 // The effects channel can afford a narrower rule, because it unions a
 // declaration with a fallback body that runs. The value channels have no such
-// counterpart — nothing declares the operator an FFI factory returns, or the
-// provenance of the record it builds — so every `@external` is opaque to them,
-// declared or not, fallback or not.
+// counterpart — nothing declares the provenance of the record an FFI factory
+// builds — so every `@external` is opaque to them, declared or not, fallback or
+// not. The one exception is the returned operator, which an `external returns`
+// line declares: that channel weighs a declaration through
+// `declared_return_standing` and asks this only about the summaries it does
+// not cover.
 pub fn is_value_opaque(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
@@ -1129,6 +1132,12 @@ pub type SummaryOrigin {
   // Loaded from a serialized `.graded` (dependency or committed project spec),
   // unsanitized; a polymorphic Foreign summary is not trusted for synthesis.
   Foreign
+  // Written by hand as an `external returns` line: what a foreign producer
+  // hands back, declared rather than inferred. It answers for a name every
+  // other summary is refused for — that is the whole point of the line — so
+  // it is held to `declared_return_standing` instead of to `is_value_opaque`.
+  // Ground by the loader's invariant, which is what makes trusting it sound.
+  Declared
 }
 
 // A function's returned-operator summary as the knowledge base holds it: the
@@ -1180,21 +1189,57 @@ pub fn with_foreign_returned_operators(
   KnowledgeBase(..knowledge_base, returned_operators: merged)
 }
 
+// Merge **Declared** returned-operator summaries (`external returns` lines) into
+// a knowledge base — existing entries take priority (gap-fill), as the foreign
+// merge does, so a fold that runs earlier outranks one that runs later. Used for
+// the project spec and for every dependency tier's declarations.
+pub fn with_declared_returned_operators(
+  knowledge_base: KnowledgeBase,
+  declared: Dict(QualifiedName, EffectTerm),
+  source: LookupOrigin,
+) -> KnowledgeBase {
+  let merged =
+    dict.merge(
+      tag_returns(declared, Declared, source),
+      knowledge_base.returned_operators,
+    )
+  KnowledgeBase(..knowledge_base, returned_operators: merged)
+}
+
 // Merge **Fresh** returned-operator summaries (produced by this run's inference)
 // into a knowledge base — new entries take priority, so a re-inferred summary
 // replaces a committed Foreign one for the same key. Used for the pre-pass /
 // main-loop fresh deltas.
+//
+// A **Declared** entry is the exception: inference describes a body, and the
+// line describes what the foreign implementation hands back, so the line stands.
+// Fresh inference keys no foreign name in the first place and a declaration over
+// an ordinary own function is dropped at load, so this guard is insurance
+// against drift in a chain of invariants that spans three files.
 pub fn with_fresh_returned_operators(
   knowledge_base: KnowledgeBase,
   inferred: Dict(QualifiedName, EffectTerm),
   source: LookupOrigin,
 ) -> KnowledgeBase {
-  let merged =
-    dict.merge(
-      knowledge_base.returned_operators,
-      tag_returns(inferred, Fresh, source),
-    )
+  let fresh =
+    dict.filter(tag_returns(inferred, Fresh, source), fn(name, _summary) {
+      !is_declared_return(knowledge_base, name)
+    })
+  let merged = dict.merge(knowledge_base.returned_operators, fresh)
   KnowledgeBase(..knowledge_base, returned_operators: merged)
+}
+
+// Whether the base already holds a declared summary for `name`.
+fn is_declared_return(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> Bool {
+  case dict.get(knowledge_base.returned_operators, name) {
+    Ok(ReturnedOperator(summary: Declared, ..)) -> True
+    Ok(ReturnedOperator(summary: Fresh, ..))
+    | Ok(ReturnedOperator(summary: Foreign, ..))
+    | Error(Nil) -> False
+  }
 }
 
 // Attach the package-wide factory map (keyed by `#(module, function)`), so a
@@ -1241,15 +1286,77 @@ pub fn updates(
 // Look up the operator a function returns, if known, with how it was produced
 // (Fix E) and the source that wrote it. `Error(Nil)` when the callee doesn't
 // return a (tracked) operator.
+//
+// A summary inferred over a body answers only for a name no `@external`
+// declares, as it always has; a **declared** one answers exactly where it
+// stands, which is what an `external returns` line is written to do.
 pub fn lookup_returned_operator(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
 ) -> Result(ReturnedOperator, Nil) {
-  use <- bool.guard(
-    when: is_value_opaque(knowledge_base, name),
-    return: Error(Nil),
-  )
-  dict.get(knowledge_base.returned_operators, name)
+  use found <- result.try(dict.get(knowledge_base.returned_operators, name))
+  case found.summary {
+    Declared ->
+      case declared_return_standing(knowledge_base, name) {
+        DeclaredReturnAnswers -> Ok(found)
+        DeclaredReturnUnbuilt | DeclaredReturnFallbackRuns | NoDeclaredReturn ->
+          Error(Nil)
+      }
+    Fresh | Foreign ->
+      case is_value_opaque(knowledge_base, name) {
+        True -> Error(Nil)
+        False -> Ok(found)
+      }
+  }
+}
+
+// Where a declared return stands for one name — read both by the lookup that
+// trusts it and by the diagnostic that reports its refusal, so a call and its
+// explanation cannot disagree about which gate answered.
+pub type DeclaredReturnStanding {
+  // In reach, and no Gleam fallback body runs beside it: the declaration is the
+  // whole story about what the producer hands back.
+  DeclaredReturnAnswers
+  // Out of reach: the declaration names targets this build does not compile, so
+  // nothing it describes is what runs.
+  DeclaredReturnUnbuilt
+  // In reach, but a Gleam fallback body runs on some target too, and the
+  // closure that body hands back needn't be the foreign one.
+  DeclaredReturnFallbackRuns
+  // No `external returns` line keys the name at all.
+  NoDeclaredReturn
+}
+
+// How a declared return for `name` stands against what this build compiles.
+//
+// The effects channel copes with a declaration and a running fallback body by
+// unioning them; there is no union of operators, so this channel answers only
+// where the declaration is alone. Standing and fallback are two fields of the
+// one `ForeignCharge`, read through `declared_charge` because the returns
+// channel holds no declared *effects* term of its own to pass down.
+//
+// The permissive default underneath is load-bearing: a name no foreign scan
+// recorded, a walk carrying no targets, and an `@external` whose declared
+// targets cannot be read all reach `DeclarationAndFallback` with no fallback
+// term, which answers. Nothing there contradicts the line.
+pub fn declared_return_standing(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> DeclaredReturnStanding {
+  case dict.get(knowledge_base.returned_operators, name) {
+    Error(Nil) -> NoDeclaredReturn
+    Ok(ReturnedOperator(summary: Fresh, ..))
+    | Ok(ReturnedOperator(summary: Foreign, ..)) -> NoDeclaredReturn
+    Ok(ReturnedOperator(summary: Declared, ..)) -> {
+      let charge = declared_charge(knowledge_base, name)
+      case charge.declaration, charge.fallback {
+        DeclarationCharged, None -> DeclaredReturnAnswers
+        DeclarationCharged, Some(_) -> DeclaredReturnFallbackRuns
+        FallbackAnswersInstead, _ | NothingImplementsName, _ ->
+          DeclaredReturnUnbuilt
+      }
+    }
+  }
 }
 
 // Merge inferred return-value provenance into a knowledge base, so a downstream
@@ -1656,6 +1763,33 @@ pub fn load_spec_returns_from_file(
   file: types.GradedFile,
 ) -> Dict(QualifiedName, EffectTerm) {
   fold_spec_returns(annotation.extract_returns(file))
+}
+
+// The same map from a parsed spec's declared `external returns` lines — the one
+// choke point that keeps every declared summary in the base ground.
+//
+// A polymorphic operator carries free variables nothing sanitized, which is the
+// substitution the checker refuses for a serialized summary; it is dropped here
+// rather than loaded and refused later, so `Declared` means ground everywhere
+// downstream. A dotless name splits to nothing and `fold_spec_returns` drops it
+// with the rest — a returns declaration is per-function, and a name that
+// resolves nowhere would otherwise sit in the file looking effective.
+//
+// Both drops are silent in every tier: nothing here holds a warning channel, a
+// consumer can act on neither a dependency's line nor the catalog's, and the
+// project's own are reported by the spec lint.
+pub fn load_spec_external_returns_from_file(
+  file: types.GradedFile,
+) -> Dict(QualifiedName, EffectTerm) {
+  annotation.extract_external_returns(file)
+  |> list.filter(fn(declared) { is_ground_operator(declared.operator) })
+  |> fold_spec_returns()
+}
+
+// Whether an operator binds no free effect variable — the ground-only rule the
+// declared tier is cut to.
+pub fn is_ground_operator(operator: EffectTerm) -> Bool {
+  set.is_empty(effect_term.free_vars(operator))
 }
 
 fn fold_spec_returns(

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -203,8 +203,9 @@ pub fn knowledge_base_from_catalog(
     all_effects: dict.merge(cat_effects, deps.effects),
     param_bounds: dict.merge(cat_params, deps.params),
     type_fields: dict.new(),
-    // Every dependency summary is Foreign (loaded from a serialized dep spec),
-    // tagged by `load_dependencies` with the package whose spec held it.
+    // Every dependency summary is tagged by `load_dependencies` with the package
+    // whose spec held it: Declared for an `external returns` line, Foreign for
+    // an inferred `returns` one, which is a serialized dep spec either way.
     returned_operators: deps.returns,
     factories: dict.new(),
     // Update builders are derived from dependency source at run time, not loaded
@@ -1190,9 +1191,15 @@ pub fn with_foreign_returned_operators(
 }
 
 // Merge **Declared** returned-operator summaries (`external returns` lines) into
-// a knowledge base — existing entries take priority (gap-fill), as the foreign
-// merge does, so a fold that runs earlier outranks one that runs later. Used for
-// the project spec and for every dependency tier's declarations.
+// a knowledge base — the incoming entries win, since a declaration outranks a
+// summary inferred over a body and the two merges beside it both gap-fill.
+//
+// Tier order on this channel is fold order, and the folds run outermost-first:
+// a dependency's declarations land while its spec is read, a path dependency's
+// when its spec is folded, and the consumer's own last, so a consumer line for
+// a dependency's producer is the one that answers. Within one spec, folding the
+// declarations ahead of that file's inferred `returns` lines leaves the
+// declaration standing.
 pub fn with_declared_returned_operators(
   knowledge_base: KnowledgeBase,
   declared: Dict(QualifiedName, EffectTerm),
@@ -1200,8 +1207,8 @@ pub fn with_declared_returned_operators(
 ) -> KnowledgeBase {
   let merged =
     dict.merge(
-      tag_returns(declared, Declared, source),
       knowledge_base.returned_operators,
+      tag_returns(declared, Declared, source),
     )
   KnowledgeBase(..knowledge_base, returned_operators: merged)
 }
@@ -1548,16 +1555,20 @@ pub fn load_spec_params_from_file(
   })
 }
 
-// Everything one dependency's spec file declares. The three `QualifiedName`-keyed
+// Everything one dependency's spec file declares. The four `QualifiedName`-keyed
 // maps hold the terms, bounds and returned-operator summaries; `type_fields` and
 // `externals` stay lists, since where each lands in the knowledge base is the
 // merging caller's decision (`with_type_fields`'s insert order against the
 // project spec; `split_externals`'s two tiers).
+//
+// The two returns maps are held apart because only one of them is a
+// declaration, and the sanitizing below weighs them by exactly that.
 pub type DepSpec {
   DepSpec(
     effects: Dict(QualifiedName, EffectTerm),
     params: Dict(QualifiedName, List(ParamBound)),
     returns: Dict(QualifiedName, EffectTerm),
+    declared_returns: Dict(QualifiedName, EffectTerm),
     type_fields: List(TypeFieldAnnotation),
     externals: List(ExternalAnnotation),
   )
@@ -1573,7 +1584,7 @@ pub type DepSpec {
 // lines the dep author wrote for its FFI.
 pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
   case read_spec_file(config.spec_file_for(dep_root, package_name)) {
-    Error(_) -> DepSpec(dict.new(), dict.new(), dict.new(), [], [])
+    Error(_) -> DepSpec(dict.new(), dict.new(), dict.new(), dict.new(), [], [])
     Ok(file) ->
       // Loaded through the same two readers a package uses for its *own* spec,
       // so a dependency's `check` budgets and externally-declared functions are
@@ -1587,6 +1598,7 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
         // own body is the documented case for the line.
         params: load_spec_params_from_file(file),
         returns: load_spec_returns_from_file(file),
+        declared_returns: load_spec_external_returns_from_file(file),
         type_fields: annotation.extract_type_fields(file),
         externals: annotation.extract_externals(file),
       )
@@ -1602,8 +1614,15 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
 // from believing about its own `@external` — and a `returns` line for it
 // describes a value only that implementation produces, so it is dropped whether
 // or not a declaration also covers the name. What survives for a declared name
-// is the declaration: the dep's own `external effects` line, a module-level
-// external, or the catalog entry underneath.
+// is the declaration: the dep's own `external effects` line, an
+// `external returns` line, a module-level external, or the catalog entry
+// underneath.
+//
+// `declared_returns` is therefore never filtered here, over a foreign name or an
+// ordinary one. The line is the dep author's declaration of what their producer
+// hands back, and arbitrating it against their own source is their `infer`'s
+// job, not their consumer's — the same reading that keeps their
+// `external effects` line for a Gleam-bodied function of their own.
 //
 // A term and its bounds are dropped together. `load_knowledge_base` merges terms
 // and bounds in two independent passes, so a term dropped without its bounds
@@ -1668,6 +1687,12 @@ fn decided_entries(dep: DepSpec, origin: LookupOrigin) -> ExternalTiers {
 // A consumer's *module-level* external stays in the `module_effects` fallback
 // tier, which `lookup` consults only after `all_effects` misses, so these
 // function-keyed entries outrank it — the per-function-beats-module-level rule.
+//
+// The spec's `external returns` declarations fold ahead of its inferred
+// `returns` lines, so a name both key resolves to the declaration. Nothing pairs
+// bounds with a summary on this channel — the ground-only rule means a declared
+// operator binds no parameter — so there is no term-and-bounds pairing to keep
+// intact here.
 pub fn with_path_dep_spec(
   knowledge_base: KnowledgeBase,
   dep: DepSpec,
@@ -1693,6 +1718,7 @@ pub fn with_path_dep_spec(
       over_catalog(knowledge_base.module_effects, module_externals),
     ),
   )
+  |> with_declared_returned_operators(dep.declared_returns, origin)
   |> with_foreign_returned_operators(dep.returns, origin)
   |> with_type_fields(dep.type_fields, origin)
 }
@@ -1847,7 +1873,12 @@ fn load_dependencies(
         params: dict.merge(acc.params, dep.params),
         returns: dict.merge(
           acc.returns,
-          tag_returns(dep.returns, Foreign, origin),
+          // Within one spec a declared summary answers for a name its own
+          // `returns` line also keys: the second argument wins.
+          dict.merge(
+            tag_returns(dep.returns, Foreign, origin),
+            tag_returns(dep.declared_returns, Declared, origin),
+          ),
         ),
         type_fields: list.append(
           acc.type_fields,

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -824,6 +824,10 @@ pub type Warning {
   // is per-function by nature — nothing keys a whole module's returned value —
   // so the line resolves nothing at all.
   DotlessExternalReturnsWarning(name: String)
+  // An `external returns <module>.<Type>.<field>` line: a name of more than two
+  // parts, which is the `type` line's shape, not this one's. A returns
+  // declaration keys a function, so the line resolves nothing.
+  TypeShapedExternalReturnsWarning(name: String)
 }
 
 // Result of checking one file.

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -461,6 +461,10 @@ pub type GradedLine {
   TypeFieldLine(type_field: TypeFieldAnnotation)
   ExternalLine(external: ExternalAnnotation)
   ReturnsLine(returns: ReturnsAnnotation)
+  // `external returns mod.fn : [Net]` — the operator a foreign producer hands
+  // back, written by hand. The payload matches `ReturnsLine`; the separate
+  // variant is what tells a declaration from an inferred line, at parse time.
+  ExternalReturnsLine(returns: ReturnsAnnotation)
   CommentLine(text: String)
   BlankLine
 }

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -325,7 +325,9 @@ pub type UnknownReason {
   UndeclaredExternal
   // A call to an `@external` whose declaration names only targets this build
   // does not compile, and which has no Gleam body to run in their place. Nothing
-  // in reach implements the name, so what it declares is no part of the charge.
+  // in reach implements the name, so what it declares is no part of the charge —
+  // which is why the value channel reuses it for a declared return the same
+  // reading puts out of reach.
   UnbuiltExternal
   // A field call whose receiver girard could not type and no syntactic
   // parameter annotation names.
@@ -345,6 +347,11 @@ pub type UnknownReason {
   // A direct application of a returned operator whose producer could not be
   // resolved.
   UntraceableProducer
+  // A direct application of a returned operator whose producer's declared
+  // return is in reach beside a Gleam fallback body that also runs. The two can
+  // hand back different closures and there is no union of operators, so the
+  // declaration answers nothing.
+  RefusedDeclaredReturn
   // A call whose own effect resolved, and whose effect variable call-site
   // substitution then bound to `[Unknown]` — an argument this call site passed
   // that nothing resolves.
@@ -354,7 +361,8 @@ pub type UnknownReason {
 // Where a resolved effect came from: which source wrote the winning
 // knowledge-base entry, or — for a field call — which rule decided it.
 pub type LookupOrigin {
-  // A per-function `external effects` line in this project's spec.
+  // A per-function declaring line in this project's spec: an
+  // `external effects` one, or an `external returns` one.
   UserExternal
   // A committed `effects` line in this project's spec.
   CommittedSpec
@@ -797,6 +805,25 @@ pub type Warning {
   // installed dependency, a path dependency, nor a project module. Same
   // reasoning one tier up: the declaration governs no module at all.
   UnmatchedModuleExternalWarning(module: String)
+  // An `external returns <module>.<function>` line naming one of this package's
+  // own ordinary Gleam functions. The same rule as
+  // `StaleFunctionExternalWarning` one channel over: the body is visible, so
+  // every caller resolves what it hands back for itself and the line declares
+  // nothing. It is ignored and the body walked instead.
+  StaleExternalReturnsWarning(function: String)
+  // An `external returns <module>.<function>` line whose name resolves nowhere
+  // — no dependency, no catalog entry, no project module. The declaration then
+  // covers nothing, so it is a typo rather than a signature.
+  UnmatchedExternalReturnsWarning(function: String)
+  // An `external returns` line whose operator is polymorphic (`fn(cb) -> [cb]`).
+  // Its free variables are unsanitized, so substituting through it would pass a
+  // budget nothing backs: only a ground operator is loaded, and this line is
+  // ignored.
+  PolymorphicExternalReturnsWarning(function: String)
+  // An `external returns <module>` line with no function part. The declaration
+  // is per-function by nature — nothing keys a whole module's returned value —
+  // so the line resolves nothing at all.
+  DotlessExternalReturnsWarning(name: String)
 }
 
 // Result of checking one file.

--- a/test/annotation_test.gleam
+++ b/test/annotation_test.gleam
@@ -817,6 +817,46 @@ pub fn returns_line_multi_callback_round_trip_test() {
   annotation.format_file(file) |> should.equal(line)
 }
 
+// External returns annotations
+//
+// `external returns module.fn : [Net]` lines declaring the operator a foreign
+// producer hands back. Same operator grammar as `returns`, a distinct line
+// kind.
+
+pub fn external_returns_line_round_trip_test() {
+  let line = "external returns app/ffi.make_client : [Net]"
+  let assert Ok(file) = annotation.parse_file(line)
+  let assert [declared] = annotation.extract_external_returns(file)
+  declared.function |> should.equal("app/ffi.make_client")
+  declared.operator |> should.equal(TLabels(set.from_list(["Net"])))
+  annotation.extract_external_returns(file) |> list.length |> should.equal(1)
+  annotation.extract_returns(file) |> should.equal([])
+  annotation.format_file(file) |> should.equal(line)
+}
+
+pub fn external_returns_line_operator_round_trip_test() {
+  let line = "external returns m.wrap : fn(cb) -> [cb]"
+  let assert Ok(file) = annotation.parse_file(line)
+  let assert [declared] = annotation.extract_external_returns(file)
+  declared.operator |> should.equal(TAbs("cb", TVar("cb")))
+  annotation.format_file(file) |> should.equal(line)
+}
+
+pub fn external_returns_line_is_not_an_effects_annotation_test() {
+  let assert Ok(annotations) =
+    annotation.parse("external returns m.make : [Net]")
+  annotations |> should.equal([])
+}
+
+pub fn external_returns_malformed_line_test() {
+  let input =
+    "effects m.a : []
+external returns m.make
+"
+  annotation.parse_file(input)
+  |> should.equal(Error(annotation.InvalidLine(2, "external returns m.make")))
+}
+
 // Helpers
 //
 // Shared term-building shorthand used by tests across sections.

--- a/test/annotation_test.gleam
+++ b/test/annotation_test.gleam
@@ -8,9 +8,10 @@ import graded/internal/annotation
 import graded/internal/effect_term
 import graded/internal/types.{
   type EffectTerm, AnnotationLine, BlankLine, Check, CommentLine,
-  EffectAnnotation, Effects, ExternalAnnotation, ExternalLine, FunctionExternal,
-  ParamBound, Polymorphic, Specific, TAbs, TApp, TLabels, TUnion, TVar,
-  TypeFieldAnnotation, TypeFieldLine, Wildcard,
+  EffectAnnotation, Effects, ExternalAnnotation, ExternalLine,
+  ExternalReturnsLine, FunctionExternal, ParamBound, Polymorphic, ReturnsLine,
+  Specific, TAbs, TApp, TLabels, TUnion, TVar, TypeFieldAnnotation,
+  TypeFieldLine, Wildcard,
 }
 import qcheck
 
@@ -573,7 +574,8 @@ pub fn merge_inferred_invariants_test() {
       fn(f, i) { #(f, i) },
     ),
   )
-  let merged = annotation.merge_inferred(file, inferred, [], set.new())
+  let merged =
+    annotation.merge_inferred(file, inferred, [], set.new(), set.new())
   let merged_effects =
     annotation.extract_annotations(merged)
     |> list.filter(fn(a) { a.kind == Effects })
@@ -630,13 +632,125 @@ pub fn merge_inferred_drops_effect_for_external_test() {
     EffectAnnotation(Effects, "app.other", [], effect_term.pure()),
   ]
   let effects_fns =
-    annotation.merge_inferred(file, inferred, [], set.new())
+    annotation.merge_inferred(file, inferred, [], set.new(), set.new())
     |> annotation.extract_annotations
     |> list.filter(fn(a) { a.kind == Effects })
     |> list.map(fn(a) { a.function })
     |> set.from_list()
   set.contains(effects_fns, "app.ffi") |> should.be_false()
   set.contains(effects_fns, "app.other") |> should.be_true()
+}
+
+pub fn merge_inferred_keeps_an_external_returns_line_test() {
+  // A declaration is preserved in place and never regenerated, and the inferred
+  // `returns` line for the same name is dropped: one name, one answer.
+  let declared =
+    ExternalReturnsLine(types.ReturnsAnnotation(
+      function: "app.make",
+      operator: TLabels(set.from_list(["Net"])),
+    ))
+  let file = types.GradedFile(lines: [declared])
+  let inferred_returns = [
+    types.ReturnsAnnotation(function: "app.make", operator: TLabels(set.new())),
+    types.ReturnsAnnotation(function: "app.other", operator: TLabels(set.new())),
+  ]
+  let merged =
+    annotation.merge_inferred(file, [], inferred_returns, set.new(), set.new())
+  merged.lines
+  |> should.equal([
+    declared,
+    ReturnsLine(types.ReturnsAnnotation(
+      function: "app.other",
+      operator: TLabels(set.new()),
+    )),
+  ])
+}
+
+pub fn merge_inferred_keeps_an_unmatched_external_returns_line_test() {
+  // A declaration for a function inference no longer reports a summary for is
+  // still the author's line, so the stale-removal path that drops an unmatched
+  // `returns` line does not reach it.
+  let declared =
+    ExternalReturnsLine(types.ReturnsAnnotation(
+      function: "app.make",
+      operator: TLabels(set.from_list(["Net"])),
+    ))
+  let file = types.GradedFile(lines: [declared])
+  annotation.merge_inferred(file, [], [], set.new(), set.new())
+  |> should.equal(file)
+}
+
+pub fn merge_inferred_rewrites_a_stale_external_returns_line_test() {
+  // The line names one of this package's own ordinary functions, so it declares
+  // nothing: it is deleted and the inferred `returns` line it was suppressing
+  // is written in its place.
+  let file =
+    types.GradedFile(lines: [
+      ExternalReturnsLine(types.ReturnsAnnotation(
+        function: "app.make",
+        operator: TLabels(set.from_list(["Net"])),
+      )),
+    ])
+  let inferred_returns = [
+    types.ReturnsAnnotation(
+      function: "app.make",
+      operator: TLabels(set.from_list(["Disk"])),
+    ),
+  ]
+  annotation.merge_inferred(
+    file,
+    [],
+    inferred_returns,
+    set.new(),
+    set.from_list(["app.make"]),
+  )
+  |> should.equal(
+    types.GradedFile(lines: [
+      ReturnsLine(types.ReturnsAnnotation(
+        function: "app.make",
+        operator: TLabels(set.from_list(["Disk"])),
+      )),
+    ]),
+  )
+}
+
+pub fn merge_inferred_keeps_the_two_stale_channels_apart_test() {
+  // A stale `external returns` name reaching the effects channel's filters
+  // would delete the function's own `effects` line, which nothing declared
+  // anything about.
+  let file =
+    types.GradedFile(lines: [
+      ExternalReturnsLine(types.ReturnsAnnotation(
+        function: "app.make",
+        operator: TLabels(set.from_list(["Net"])),
+      )),
+      AnnotationLine(EffectAnnotation(
+        Effects,
+        "app.make",
+        [],
+        TLabels(set.new()),
+      )),
+    ])
+  let inferred = [
+    EffectAnnotation(Effects, "app.make", [], TLabels(set.from_list(["Disk"]))),
+  ]
+  annotation.merge_inferred(
+    file,
+    inferred,
+    [],
+    set.new(),
+    set.from_list(["app.make"]),
+  )
+  |> should.equal(
+    types.GradedFile(lines: [
+      AnnotationLine(EffectAnnotation(
+        Effects,
+        "app.make",
+        [],
+        TLabels(set.from_list(["Disk"])),
+      )),
+    ]),
+  )
 }
 
 // Second-order serialization

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -5035,6 +5035,35 @@ pub fn call_kind_unrecognised_sentinel_is_unclassified_test() {
   |> should.equal(checker.UnclassifiedCall)
 }
 
+// A warning's wording is the only place a reader learns what a dropped line does
+// and what happens next, so the sentence is pinned like a violation's.
+pub fn format_warning_stale_external_returns_test() {
+  types.StaleExternalReturnsWarning(function: "lib.make")
+  |> checker.format_warning("proj.graded", _)
+  |> should.equal(
+    "proj.graded: warning: external returns lib.make names a function of this package with a Gleam body — every caller resolves what it returns from that body, so the line declares nothing and is ignored. `graded infer` removes it; where the function returns an operator, the inferred `returns` line takes its place",
+  )
+}
+
+pub fn format_warning_dotless_external_returns_test() {
+  types.DotlessExternalReturnsWarning(name: "lib")
+  |> checker.format_warning("proj.graded", _)
+  |> should.equal(
+    "proj.graded: warning: external returns lib names a module, not a function — a returns declaration is per-function; the line resolves nothing",
+  )
+}
+
+pub fn format_warning_type_shaped_external_returns_test() {
+  // The multi-dot name reaches for the `type` line's field shape. Reported as
+  // the dotless case, the sentence would tell the author their name names a
+  // module, which it does not.
+  types.TypeShapedExternalReturnsWarning(name: "app.Handler.run")
+  |> checker.format_warning("proj.graded", _)
+  |> should.equal(
+    "proj.graded: warning: external returns app.Handler.run names a type field, not a function — a returns declaration is per-function; write a `type` line to give a field's effects, and the line resolves nothing as written",
+  )
+}
+
 // A resolved qualified call keeps the format the README documents.
 pub fn format_violation_direct_call_test() {
   violation(

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -1573,6 +1573,38 @@ pub fn a_dependency_returns_line_for_its_own_external_is_refused_test() {
   |> should.be_true()
 }
 
+pub fn one_dep_specs_returns_line_cannot_bury_anothers_declaration_test() {
+  // Two installed specs keying the same name: `alib` declares what its own
+  // producer hands back, `zlib` carries a stray inferred `returns` line for it.
+  // The packages are folded in whatever order the directory yields, so the rule
+  // has to be the merge's, not the order's — declared outranks inferred across
+  // specs as it does within one.
+  let root = "build/eff_cross_package_stray_returns"
+  write_fixture(root, [
+    #(dep_spec_path("alib"), "external returns alib/mod.make : [Stdout]\n"),
+    #(dep_spec_path("zlib"), "returns alib/mod.make : [Net]\n"),
+  ])
+  let kb =
+    effects.load_knowledge_base(
+      root <> "/packages",
+      root <> "/missing_manifest.toml",
+      dict.new(),
+    )
+  cleanup(root)
+  let assert Ok(found) =
+    effects.lookup_returned_operator(kb, QualifiedName("alib/mod", "make"))
+  found.operator
+  |> should.equal(
+    effect_term.from_effect_set(
+      Specific(
+        set.from_list([
+          "Stdout",
+        ]),
+      ),
+    ),
+  )
+}
+
 // Target-narrowed foreign lookups
 //
 // A Gleam fallback body runs only on the targets its own declaration leaves

--- a/test/fixtures/fixtures.graded
+++ b/test/fixtures/fixtures.graded
@@ -108,6 +108,9 @@ check external_budget.calls_wired_external : []
 check foreign_values.calls_returned_operator : [Disk]
 check foreign_values.calls_partial_operator : [Disk]
 check foreign_values.calls_native_operator : [Disk]
+// The one value channel a declaration reaches: the operator the producer hands
+// back is declared, so the call of it costs what the line says.
+check foreign_values.calls_declared_operator : [Disk]
 check foreign_values.calls_built_field : [Disk]
 check foreign_values.calls_native_built_field : [Disk]
 check foreign_values.calls_updated_field : [Disk]
@@ -130,10 +133,14 @@ external effects foreign_values.disk_read : [Disk]
 external effects foreign_values.portable_disk_read : [Disk]
 // Declared, and still refused on every value channel: what a declaration says
 // about calling a function says nothing about the value it returns.
+external effects foreign_values.declared_returns_operator : []
 external effects foreign_values.returns_operator : []
 external effects foreign_values.partial_returns_operator : []
 external effects foreign_values.builds : []
 external effects foreign_values.with_run : []
+// What the producer above hands back, which no `external effects` line states.
+external returns foreign_values.declared_returns_operator : [Disk]
+
 // A module-level external over a module that is not a project module and not a
 // dependency: every name under `fake_clock` resolves to [Time], including ones
 // nothing defines, which is what `graded effect`'s carve-out answers from. The

--- a/test/fixtures/foreign_values.gleam
+++ b/test/fixtures/foreign_values.gleam
@@ -5,7 +5,9 @@
 // the operator such a function returns, the provenance of the record it builds,
 // and the fields a factory or update builder of it wires are all [Unknown] —
 // even where an `external effects` line declares what calling it costs, since
-// nothing in that line describes the value it hands back.
+// nothing in that line describes the value it hands back. One channel has a
+// declaring form of its own: `external returns` states the operator a producer
+// hands back, and the producer below carrying one resolves.
 //
 // Every case below is paired with the same shape written as ordinary Gleam,
 // whose budget passes: the rule refuses foreign values, not values.
@@ -63,6 +65,14 @@ pub fn with_run(base: Handler, run: fn() -> Nil) -> Handler {
   Handler(..base, run: run)
 }
 
+// Bodyless and declared on both targets, so the declaration stands alone: what
+// it hands back is what `external returns` says, the one value channel a
+// declaration reaches. Its caller sits in this module, so the producer is keyed
+// with no module of its own.
+@external(erlang, "some_ffi_module", "make_reader")
+@external(javascript, "some_ffi_module", "make_reader")
+pub fn declared_returns_operator() -> fn() -> Nil
+
 // The ordinary twins of the three above.
 pub fn native_returns_operator() -> fn() -> Nil {
   fn() { disk_read() }
@@ -88,6 +98,11 @@ pub fn calls_returned_operator() -> Nil {
 
 pub fn calls_partial_operator() -> Nil {
   let handle = partial_returns_operator()
+  handle()
+}
+
+pub fn calls_declared_operator() -> Nil {
+  let handle = declared_returns_operator()
   handle()
 }
 

--- a/test/format_cli_test.gleam
+++ b/test/format_cli_test.gleam
@@ -53,6 +53,16 @@ pub fn format_stdin_sorts_and_normalizes_test() {
   |> should.equal(Ok("check myapp.a : []\n\neffects myapp.b : [Http]\n"))
 }
 
+pub fn format_stdin_sorts_external_returns_before_returns_test() {
+  graded.run_format_stdin("returns m.f : [Net]\nexternal returns m.g : [Net]")
+  |> should.equal(Ok("external returns m.g : [Net]\n\nreturns m.f : [Net]\n"))
+}
+
+pub fn format_stdin_is_idempotent_over_external_returns_test() {
+  let formatted = "external returns m.g : [Net]\n\nreturns m.f : [Net]\n"
+  graded.run_format_stdin(formatted) |> should.equal(Ok(formatted))
+}
+
 pub fn format_stdin_fails_on_unparseable_input_test() {
   graded.run_format_stdin(bad_spec) |> should.be_error
 }

--- a/test/format_test.gleam
+++ b/test/format_test.gleam
@@ -5,7 +5,7 @@ import gleeunit/should
 import graded/internal/annotation
 import graded/internal/types.{
   AnnotationLine, BlankLine, Check, CommentLine, Effects, ExternalLine,
-  ReturnsLine, TypeFieldLine,
+  ExternalReturnsLine, ReturnsLine, TypeFieldLine,
 }
 import qcheck
 
@@ -96,13 +96,14 @@ fn section_index(line: types.GradedLine) -> Int {
   case line {
     CommentLine(_) -> 0
     ExternalLine(_) -> 1
-    TypeFieldLine(_) -> 2
+    ExternalReturnsLine(_) -> 2
+    TypeFieldLine(_) -> 3
     AnnotationLine(a) ->
       case a.kind {
-        Check -> 3
-        Effects -> 4
+        Check -> 4
+        Effects -> 5
       }
-    ReturnsLine(_) -> 5
+    ReturnsLine(_) -> 6
     BlankLine -> -1
   }
 }

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -8295,3 +8295,169 @@ pub fn running() -> Nil {
   ])
   support.cleanup(root)
 }
+
+// Tier precedence on the returns channel
+//
+// Which spec's line answers for a name when several key it. Four rules, one per
+// collision the channel can hold: a spec states summaries only about code it
+// ships, the consumer's declaration is in reach while a path dependency is
+// inferred, an installed dependency outranks a path dependency, and a
+// declaration outranks an inferred summary across packages as well as within
+// one.
+
+pub fn a_dependency_cannot_declare_a_return_for_the_consumers_code_test() {
+  // The dep's spec names `lib.make` — an ordinary Gleam function of the
+  // *consumer*, whose body every caller can already see. Loaded, it would sit in
+  // a tier above the summary this run infers from that body and answer [Net] for
+  // a closure that prints. A spec speaks for the modules its package ships and
+  // for the names a foreign scan records; `lib` is neither.
+  let root = "build/declared_returns_dep_over_consumer"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.caller : []
+external effects lib.write : [Stdout]
+",
+    ),
+    #("build/packages/dep/dep.graded", "external returns lib.make : [Net]\n"),
+    #(
+      "build/packages/dep/src/dep.gleam",
+      "pub fn nothing() -> Nil {\n  Nil\n}\n",
+    ),
+    #(
+      "lib.gleam",
+      "@external(erlang, \"lib_ffi\", \"write\")
+@external(javascript, \"lib_ffi\", \"write\")
+pub fn write() -> Nil
+
+pub fn make() -> fn() -> Nil {
+  fn() { write() }
+}
+",
+    ),
+    #(
+      "app.gleam",
+      "import lib
+
+pub fn caller() -> Nil {
+  let handle = lib.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Stdout"])))
+  support.cleanup(root)
+}
+
+pub fn an_installed_dependencys_declaration_outranks_a_path_deps_test() {
+  // The same package reached twice — installed under `build/packages` and
+  // declared as a path dependency — with the two copies' specs declaring
+  // different returns for the same producer. Dependency specs rank above path
+  // dependencies, so the installed copy's [Stdout] is the answer; the path-dep
+  // fold gap-fills rather than writing over the tier above it.
+  let app_root = "build/declared_returns_dep_over_path_dep_app"
+  let dep_root = "build/declared_returns_dep_over_path_dep_dep"
+  let producer =
+    "@external(erlang, \"dep_ffi\", \"make\")
+@external(javascript, \"dep_ffi\", \"make\")
+pub fn make() -> fn() -> Nil
+"
+  support.write_fixture(dep_root, [
+    #("gleam.toml", "name = \"dep\"\n"),
+    #("src/dep/ffi.gleam", producer),
+    #(
+      "dep.graded",
+      "external effects dep/ffi.make : []
+external returns dep/ffi.make : [Net]
+",
+    ),
+  ])
+  support.write_fixture(app_root, [
+    #(
+      "gleam.toml",
+      "name = \"app\"\n\n[dependencies]\ndep = { path = \"../declared_returns_dep_over_path_dep_dep\" }\n",
+    ),
+    #("app.graded", "check app.wrapper : []\n"),
+    #("build/packages/dep/src/dep/ffi.gleam", producer),
+    #(
+      "build/packages/dep/dep.graded",
+      "external effects dep/ffi.make : []
+external returns dep/ffi.make : [Stdout]
+",
+    ),
+    #(
+      "app.gleam",
+      "import dep/ffi
+
+pub fn wrapper() -> Nil {
+  let handle = ffi.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Stdout"])))
+  support.cleanup(app_root)
+  support.cleanup(dep_root)
+}
+
+pub fn one_packages_returns_line_cannot_bury_anothers_declaration_test() {
+  // `alib` declares what its own Gleam-bodied producer hands back — the
+  // cross-package keep case — and `zlib`'s spec carries a stray inferred
+  // `returns` line for the very same name. Whichever order the two specs are
+  // folded in, the declaration is the one that answers: it is not zlib's code to
+  // state a summary about, and declared outranks inferred across specs as it
+  // does within one.
+  let root = "build/declared_returns_cross_package_stray"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #("proj.graded", "check app.wrapper : []\n"),
+    #(
+      "build/packages/alib/alib.graded",
+      "effects alib/mod.make : []
+external returns alib/mod.make : [Stdout]
+",
+    ),
+    #(
+      "build/packages/alib/src/alib/mod.gleam",
+      "pub fn make() -> fn() -> Nil {
+  fn() { Nil }
+}
+",
+    ),
+    #("build/packages/zlib/zlib.graded", "returns alib/mod.make : [Net]\n"),
+    #(
+      "build/packages/zlib/src/zlib.gleam",
+      "pub fn nothing() -> Nil {\n  Nil\n}\n",
+    ),
+    #(
+      "app.gleam",
+      "import alib/mod
+
+pub fn wrapper() -> Nil {
+  let handle = mod.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Stdout"])))
+  support.cleanup(root)
+}

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -2884,9 +2884,10 @@ pub fn calls_built_field() -> Nil {
 }
 
 pub fn a_polymorphic_declared_return_is_not_loaded_test() {
-  // Its free variables are unsanitized, which is the substitution a serialized
-  // summary is already refused for. The loader drops the line rather than
-  // trusting it, so the call stays [Unknown].
+  // The operator's `f` is the producer's own parameter, left free: substituting
+  // through it is exactly what a serialized summary is refused for, since
+  // nothing sanitized the name. The loader drops the line rather than trusting
+  // it, so the call stays [Unknown].
   let root = "build/declared_returns_polymorphic"
   support.write_fixture(root, [
     #("gleam.toml", "name = \"proj\"\n"),
@@ -2894,7 +2895,7 @@ pub fn a_polymorphic_declared_return_is_not_loaded_test() {
       "proj.graded",
       "check app.calls_wrapped : []
 external effects ffi.wrap : []
-external returns ffi.wrap : fn(cb) -> [cb]
+external returns ffi.wrap : [f]
 ",
     ),
     #(
@@ -2964,6 +2965,14 @@ pub fn calls_returned_operator() -> Nil {
     list.find(r.violations, fn(v) { v.explanation.call.module == "<returned>" })
   applied.explanation.actual
   |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  applied.explanation.reason |> should.equal(Some(types.UnbuiltExternal))
+  // And it says what a direct call to the same `@external` says: one reading,
+  // one sentence, two channels.
+  checker.format_violation(r.file, applied)
+  |> string.contains(
+    "an external declared only for a target this build does not compile",
+  )
+  |> should.be_true()
   support.cleanup(root)
 }
 
@@ -3022,6 +3031,13 @@ pub fn calls_covered() -> Nil {
   violation.function |> should.equal("calls_partial")
   violation.explanation.actual
   |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  violation.explanation.reason
+  |> should.equal(Some(types.RefusedDeclaredReturn))
+  checker.format_violation(r.file, violation)
+  |> string.contains(
+    "whose declared return is refused where its Gleam fallback body also runs",
+  )
+  |> should.be_true()
   support.cleanup(root)
 }
 
@@ -3278,6 +3294,115 @@ pub fn caller() -> Nil {
   violation.explanation.actual
   |> should.equal(types.Specific(set.from_list(["Stdout"])))
   support.cleanup(root)
+}
+
+pub fn the_lint_flags_every_dead_external_returns_line_test() {
+  // The four ways the line can be dead, and the one live line beside them. Two
+  // are the existence branches the `external effects` lint already had; two are
+  // this form's own, and both are lines the loader silently drops — the warning
+  // is the only place a reader learns the line does nothing.
+  let root = "build/declared_returns_lint"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "external returns ffi.wrap : [f]
+external returns lib : [Net]
+external returns lib.make : [Disk]
+external returns lib.nope : [Disk]
+external returns ffi.make : [Net]
+",
+    ),
+    #(
+      "ffi.gleam",
+      "@external(erlang, \"ffi_module\", \"wrap\")
+@external(javascript, \"ffi_module\", \"wrap\")
+pub fn wrap(callback: fn() -> Nil) -> fn() -> Nil
+
+@external(erlang, \"ffi_module\", \"make\")
+@external(javascript, \"ffi_module\", \"make\")
+pub fn make() -> fn() -> Nil
+",
+    ),
+    #(
+      "lib.gleam",
+      "pub fn make() -> fn() -> Nil {
+  fn() { Nil }
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  results
+  |> list.flat_map(fn(r) { r.warnings })
+  |> should.equal([
+    types.PolymorphicExternalReturnsWarning(function: "ffi.wrap"),
+    types.DotlessExternalReturnsWarning(name: "lib"),
+    types.StaleExternalReturnsWarning(function: "lib.make"),
+    types.UnmatchedExternalReturnsWarning(function: "lib.nope"),
+  ])
+  support.cleanup(root)
+}
+
+pub fn why_names_the_declaration_that_resolved_a_producer_test() {
+  // The call used to print ", whose producer could not be resolved,". It now
+  // names the line that answered, in the words that say *declaration* rather
+  // than a file name — which is the distinction the feature exists to surface.
+  let root = "build/declared_returns_why"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.caller : [Net]
+external effects ffi.make_client : [Net]
+external returns ffi.make_client : [Net]
+",
+    ),
+    #(
+      "ffi.gleam",
+      "@external(erlang, \"ffi_module\", \"make_client\")
+@external(javascript, \"ffi_module\", \"make_client\")
+pub fn make_client() -> fn() -> Nil
+",
+    ),
+    #(
+      "app.gleam",
+      "import ffi
+
+pub fn caller() -> Nil {
+  let send = ffi.make_client()
+  send()
+}
+",
+    ),
+  ])
+  let assert Ok(why) = graded.run_why(root, "app.caller")
+  let assert Ok(line) = contributor_line(why, "returned")
+  line
+  |> string.contains(
+    "calls a function returned by `ffi.make_client` with effects [Net]"
+    <> " (from your spec's external declaration)",
+  )
+  |> should.be_true()
+  why
+  |> string.contains("whose producer could not be resolved")
+  |> should.be_false()
+  support.cleanup(root)
+}
+
+pub fn the_fixture_declared_producer_resolves_from_its_line_test() {
+  // The shared fixture set's own declared producer, whose caller sits in the
+  // same module — the resolution path that consults no knowledge base for an
+  // inferred summary. Its `check` line passing says the call resolved; this
+  // says what it resolved to, and from where.
+  let assert Ok(why) =
+    graded.run_why("test/fixtures", "foreign_values.calls_declared_operator")
+  why
+  |> string.contains(
+    "calls a function returned by `declared_returns_operator` with effects"
+    <> " [Disk] (from your spec's external declaration)",
+  )
+  |> should.be_true()
 }
 
 // The spec declaring the same-module producer's return, and the spec that

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -8356,6 +8356,53 @@ pub fn caller() -> Nil {
   support.cleanup(root)
 }
 
+pub fn a_declaration_governs_a_spec_less_path_deps_inference_test() {
+  // The path dependency ships no spec, so its bodies are summarized from source
+  // during this run — and the body being summarized calls the closure its own
+  // `@external` hands back. Both consumer declarations have to be in reach while
+  // that pass runs, not merely afterwards: the `external effects` line so the
+  // producer call is charged, the `external returns` line so the closure call is.
+  // Folded after it, the helper is settled at [Unknown] and the consumer reads
+  // that instead.
+  let r =
+    run_path_dep_project(
+      "declared_returns_path_dep_inference",
+      [
+        #(
+          "ffi.gleam",
+          "@external(erlang, \"dep_ffi\", \"make\")
+@external(javascript, \"dep_ffi\", \"make\")
+pub fn make() -> fn() -> Nil
+",
+        ),
+        #(
+          "helper.gleam",
+          "import ffi
+
+pub fn use_it() -> Nil {
+  let handle = ffi.make()
+  handle()
+}
+",
+        ),
+      ],
+      None,
+      "check app.wrapper : []
+external effects ffi.make : []
+external returns ffi.make : [Disk]
+",
+      "import helper
+
+pub fn wrapper() -> Nil {
+  helper.use_it()
+}
+",
+    )
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
 pub fn an_installed_dependencys_declaration_outranks_a_path_deps_test() {
   // The same package reached twice — installed under `build/packages` and
   // declared as a path dependency — with the two copies' specs declaring

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -8508,3 +8508,29 @@ pub fn wrapper() -> Nil {
   |> should.equal(types.Specific(set.from_list(["Stdout"])))
   support.cleanup(root)
 }
+
+pub fn the_lint_names_the_type_line_for_a_field_shaped_returns_test() {
+  // `app.Handler.run` is the `type` line's shape, not this one's. The loader
+  // drops it either way; the warning has to say which mistake it is, or the
+  // author reads "names a module, not a function" about a name that names no
+  // module.
+  let root = "build/declared_returns_type_shaped"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #("proj.graded", "external returns app.Handler.run : [Net]\n"),
+    #(
+      "app.gleam",
+      "pub type Handler {
+  Handler(run: fn() -> Nil)
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  results
+  |> list.flat_map(fn(r) { r.warnings })
+  |> should.equal([
+    types.TypeShapedExternalReturnsWarning(name: "app.Handler.run"),
+  ])
+  support.cleanup(root)
+}

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -2797,6 +2797,271 @@ fn contributor_line(output: String, name: String) -> Result(String, Nil) {
   |> list.first
 }
 
+// Declared FFI returns
+//
+// `external returns` declares the operator a foreign producer hands back — the
+// one value channel a declaration reaches. It answers on both resolution paths
+// (a same-module `@external` and a cross-module one), only where the
+// declaration stands alone against what the build compiles, and only ground.
+
+pub fn a_declared_return_resolves_a_same_module_producer_test() {
+  // The producer and its caller in one module: the callee is keyed with no
+  // module at all, so this path never consults the knowledge base for an
+  // ordinary summary. The declaration is the only thing that can answer, and
+  // the same fixture without the line is what says the budget is not vacuous.
+  let root = "build/declared_returns_same_module"
+  let declared = same_module_violations(root, declared_same_module_spec)
+  declared |> should.equal([])
+
+  let undeclared = same_module_violations(root, inferred_same_module_spec)
+  let assert [violation] = undeclared
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+}
+
+pub fn a_declared_return_resolves_a_cross_module_producer_test() {
+  // One module away, where the summary is read from the knowledge base. The
+  // record-building external beside it stays opaque: the declaration describes
+  // the returned operator and nothing else, so the provenance channel is
+  // unchanged.
+  let root = "build/declared_returns_cross_module"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.calls_returned_operator : [Disk]
+check app.calls_built_field : [Disk]
+external effects ffi.disk_read : [Disk]
+external effects ffi.make : []
+external effects ffi.builds : []
+external returns ffi.make : [Disk]
+",
+    ),
+    #(
+      "ffi.gleam",
+      "pub type Handler {
+  Handler(run: fn() -> Nil, name: String)
+}
+
+@external(erlang, \"ffi_module\", \"disk_read\")
+@external(javascript, \"ffi_module\", \"disk_read\")
+pub fn disk_read() -> Nil
+
+@external(erlang, \"ffi_module\", \"make\")
+@external(javascript, \"ffi_module\", \"make\")
+pub fn make() -> fn() -> Nil
+
+@external(erlang, \"ffi_module\", \"builds\")
+pub fn builds(run: fn() -> Nil) -> Handler {
+  Handler(run: run, name: \"ffi\")
+}
+",
+    ),
+    #(
+      "app.gleam",
+      "import ffi
+
+pub fn calls_returned_operator() -> Nil {
+  let handle = ffi.make()
+  handle()
+}
+
+pub fn calls_built_field() -> Nil {
+  let handler = ffi.builds(fn() { ffi.disk_read() })
+  handler.run()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  r.violations
+  |> list.map(fn(v) { v.function })
+  |> should.equal(["calls_built_field"])
+  support.cleanup(root)
+}
+
+pub fn a_polymorphic_declared_return_is_not_loaded_test() {
+  // Its free variables are unsanitized, which is the substitution a serialized
+  // summary is already refused for. The loader drops the line rather than
+  // trusting it, so the call stays [Unknown].
+  let root = "build/declared_returns_polymorphic"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.calls_wrapped : []
+external effects ffi.wrap : []
+external returns ffi.wrap : fn(cb) -> [cb]
+",
+    ),
+    #(
+      "ffi.gleam",
+      "@external(erlang, \"ffi_module\", \"wrap\")
+@external(javascript, \"ffi_module\", \"wrap\")
+pub fn wrap(callback: fn() -> Nil) -> fn() -> Nil
+",
+    ),
+    #(
+      "app.gleam",
+      "import ffi
+
+pub fn calls_wrapped() -> Nil {
+  let wrapped = ffi.wrap(fn() { Nil })
+  wrapped()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  support.cleanup(root)
+}
+
+pub fn a_declared_return_out_of_reach_answers_nothing_test() {
+  // The declaration names a target this build does not compile, so nothing it
+  // describes is what runs — the same reading that drops the external's own
+  // declared effects drops what it declares about the value.
+  let root = "build/declared_returns_unbuilt"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\ntarget = \"erlang\"\n"),
+    #(
+      "proj.graded",
+      "check app.calls_returned_operator : []
+external effects ffi.make : []
+external returns ffi.make : []
+",
+    ),
+    #(
+      "ffi.gleam",
+      "@external(javascript, \"ffi_module\", \"make\")
+pub fn make() -> fn() -> Nil
+",
+    ),
+    #(
+      "app.gleam",
+      "import ffi
+
+pub fn calls_returned_operator() -> Nil {
+  let handle = ffi.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  // The producer call is charged [Unknown] too — nothing this build compiles
+  // implements it — so the applied operator is picked out by its own sentinel.
+  let assert Ok(applied) =
+    list.find(r.violations, fn(v) { v.explanation.call.module == "<returned>" })
+  applied.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  support.cleanup(root)
+}
+
+pub fn a_declared_return_beside_a_running_fallback_answers_nothing_test() {
+  // Both halves in reach: the foreign implementation on the target the line
+  // names, the Gleam body on the one it leaves uncovered. The effects channel
+  // unions the two; there is no union of operators, and the closure the body
+  // hands back needn't be the foreign one, so the declaration answers nothing.
+  // The fully covered producer beside it is what says the refusal is the
+  // fallback's doing.
+  let root = "build/declared_returns_fallback"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.calls_partial : []
+check app.calls_covered : []
+external effects ffi.partial : []
+external effects ffi.covered : []
+external returns ffi.partial : []
+external returns ffi.covered : []
+",
+    ),
+    #(
+      "ffi.gleam",
+      "@external(javascript, \"ffi_module\", \"partial\")
+pub fn partial() -> fn() -> Nil {
+  fn() { Nil }
+}
+
+@external(erlang, \"ffi_module\", \"covered\")
+@external(javascript, \"ffi_module\", \"covered\")
+pub fn covered() -> fn() -> Nil
+",
+    ),
+    #(
+      "app.gleam",
+      "import ffi
+
+pub fn calls_partial() -> Nil {
+  let handle = ffi.partial()
+  handle()
+}
+
+pub fn calls_covered() -> Nil {
+  let handle = ffi.covered()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.function |> should.equal("calls_partial")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  support.cleanup(root)
+}
+
+// The spec declaring the same-module producer's return, and the spec that
+// leaves it to inference — which writes no summary for an `@external` at all.
+const declared_same_module_spec = "check ffi.caller : [Net]
+external effects ffi.make_client : [Net]
+external returns ffi.make_client : [Net]
+"
+
+const inferred_same_module_spec = "check ffi.caller : [Net]
+external effects ffi.make_client : [Net]
+"
+
+// The violations of a one-module project whose `@external` producer and its
+// caller sit side by side, checked against `spec`.
+fn same_module_violations(root: String, spec: String) -> List(types.Violation) {
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #("proj.graded", spec),
+    #(
+      "ffi.gleam",
+      "@external(erlang, \"ffi_module\", \"make_client\")
+@external(javascript, \"ffi_module\", \"make_client\")
+pub fn make_client() -> fn() -> Nil
+
+pub fn caller() -> Nil {
+  let send = make_client()
+  send()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/ffi.gleam" })
+  support.cleanup(root)
+  r.violations
+}
+
 pub fn a_governed_sibling_charges_its_module_what_it_charges_everyone_test() {
   // `external effects m : [Disk]` answers for every caller of `m.logs`, and a
   // sibling is a caller. Walking the body for the sibling and reading the

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -3187,6 +3187,99 @@ pub fn wrapper() -> Nil {
   support.cleanup(root)
 }
 
+pub fn a_stale_external_returns_line_is_ignored_and_repaired_test() {
+  // The line names one of this package's own ordinary functions, whose returned
+  // closure every caller can see for itself — so it declares nothing. It is
+  // ignored at load, not merely warned about: trusted between `infer` runs it
+  // would be a per-function override of the walk. `infer` then deletes it and
+  // writes the `returns` line it was suppressing.
+  let root = "build/declared_returns_stale"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.caller : []
+external returns lib.make : [Disk]
+",
+    ),
+    #(
+      "lib.gleam",
+      "pub fn make() -> fn() -> Nil {
+  fn() { Nil }
+}
+",
+    ),
+    #(
+      "app.gleam",
+      "import lib
+
+pub fn caller() -> Nil {
+  let handle = lib.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
+
+  let assert Ok(preview) = graded.run_infer_dry_run(root)
+  let changed =
+    preview
+    |> string.split("\n")
+    |> list.filter(fn(line) {
+      string.starts_with(line, "- ") || string.starts_with(line, "+ ")
+    })
+  changed
+  |> list.contains("- external returns lib.make : [Disk]")
+  |> should.be_true()
+  changed |> list.contains("+ returns lib.make : []") |> should.be_true()
+  support.cleanup(root)
+}
+
+pub fn a_declared_return_leaves_the_effects_channel_alone_test() {
+  // The two stale channels are separate sets. Were the returns one to reach the
+  // effects channel's filters, the committed `effects lib.make` line would be
+  // dropped and the call charged by inference instead — so the call's [Stdout]
+  // is what says they stayed apart, and the applied operator's absence from the
+  // charge is what says the stale declaration was still ignored.
+  let root = "build/declared_returns_cross_channel"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.caller : []
+effects lib.make : [Stdout]
+external returns lib.make : [Disk]
+",
+    ),
+    #(
+      "lib.gleam",
+      "pub fn make() -> fn() -> Nil {
+  fn() { Nil }
+}
+",
+    ),
+    #(
+      "app.gleam",
+      "import lib
+
+pub fn caller() -> Nil {
+  let handle = lib.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Stdout"])))
+  support.cleanup(root)
+}
+
 // The spec declaring the same-module producer's return, and the spec that
 // leaves it to inference — which writes no summary for an `@external` at all.
 const declared_same_module_spec = "check ffi.caller : [Net]

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -3025,6 +3025,168 @@ pub fn calls_covered() -> Nil {
   support.cleanup(root)
 }
 
+pub fn infer_and_check_agree_about_a_declared_return_test() {
+  // The declaration is state no inference pass re-derives, so both commands
+  // have to load it: `infer` publishes what `check` scores. The stale inferred
+  // `returns` line beside it is the window an author is in between the function
+  // becoming `@external` and the next `infer` — the declaration answers over it.
+  let root = "build/declared_returns_infer"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "check app.caller : [Net]
+external effects ffi.make_client : [Net]
+external returns ffi.make_client : [Net]
+returns ffi.make_client : [Disk]
+",
+    ),
+    #(
+      "ffi.gleam",
+      "@external(erlang, \"ffi_module\", \"make_client\")
+@external(javascript, \"ffi_module\", \"make_client\")
+pub fn make_client() -> fn() -> Nil
+",
+    ),
+    #(
+      "app.gleam",
+      "import ffi
+
+pub fn caller() -> Nil {
+  let send = ffi.make_client()
+  send()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
+
+  let assert Ok(Nil) = graded.run_infer(root)
+  let assert Ok(written) = simplifile.read(root <> "/proj.graded")
+  written |> string.contains("effects app.caller : [Net]") |> should.be_true()
+  written
+  |> string.contains("external returns ffi.make_client : [Net]")
+  |> should.be_true()
+  support.cleanup(root)
+}
+
+pub fn a_dependency_declares_what_its_own_producer_returns_test() {
+  // The dep author's line about their own `@external` factory. The consumer
+  // reads it from the shipped spec, tagged as the declaration it is — tagged
+  // like an inferred summary instead, the whole tier would no-op, since a
+  // dependency's declared name is foreign by definition.
+  let root = "build/declared_returns_dep"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #("proj.graded", "check app.wrapper : []\n"),
+    #(
+      "build/packages/dep/dep.graded",
+      "external effects dep/ffi.make : []
+external returns dep/ffi.make : [Disk]
+",
+    ),
+    #(
+      "build/packages/dep/src/dep/ffi.gleam",
+      "@external(erlang, \"dep_ffi\", \"make\")
+@external(javascript, \"dep_ffi\", \"make\")
+pub fn make() -> fn() -> Nil
+",
+    ),
+    #(
+      "app.gleam",
+      "import dep/ffi
+
+pub fn wrapper() -> Nil {
+  let handle = ffi.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+  support.cleanup(root)
+}
+
+pub fn a_path_dependency_declares_what_its_own_producer_returns_test() {
+  // The same line one dependency kind over, where the spec is committed beside
+  // the source rather than shipped under build/packages.
+  let r =
+    run_path_dep_spec_fixture(
+      "declared_returns_path_dep",
+      [
+        #(
+          "dep.gleam",
+          "@external(erlang, \"dep_ffi\", \"make\")
+@external(javascript, \"dep_ffi\", \"make\")
+pub fn make() -> fn() -> Nil
+",
+        ),
+      ],
+      "external effects dep.make : []
+external returns dep.make : [Disk]
+",
+      "check app.wrapper : []\n",
+      "import dep
+
+pub fn wrapper() -> Nil {
+  let handle = dep.make()
+  handle()
+}
+",
+    )
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+pub fn a_dependency_declares_a_return_for_its_own_gleam_function_test() {
+  // Over one of the dependency's *ordinary* functions the line is kept, not
+  // dropped: arbitrating a spec against the source beside it is the dep author's
+  // job at their own `infer` time, and the effects channel already trusts their
+  // `external effects` line in exactly this position.
+  let root = "build/declared_returns_dep_native"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #("proj.graded", "check app.wrapper : []\n"),
+    #(
+      "build/packages/dep/dep.graded",
+      "effects dep/ffi.make : []
+external returns dep/ffi.make : [Disk]
+",
+    ),
+    #(
+      "build/packages/dep/src/dep/ffi.gleam",
+      "pub fn make() -> fn() -> Nil {
+  fn() { Nil }
+}
+",
+    ),
+    #(
+      "app.gleam",
+      "import dep/ffi
+
+pub fn wrapper() -> Nil {
+  let handle = ffi.make()
+  handle()
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+  support.cleanup(root)
+}
+
 // The spec declaring the same-module producer's return, and the spec that
 // leaves it to inference — which writes no summary for an `@external` at all.
 const declared_same_module_spec = "check ffi.caller : [Net]


### PR DESCRIPTION
The boundary work in #60 settled what an `external effects` line speaks for, and
in settling it left a gap it named at every call: a declaration says what
*calling* foreign code costs, and nothing said what that code hands back. So
`@external fn make_client() -> fn(Request) -> Response` could declare its own
cost, while every call of the closure it returns stayed `[Unknown]` forever —
`graded why` printing ", whose producer could not be resolved," each time.

This adds the declaring form. New annotation kind, so it targets **v0.13.0**.

## Added

**`external returns <module>.<function> : <operator>`** declares the operator an
FFI producer hands back, so calling it resolves:

```
external effects myapp/ffi.make_client : [Net]
external returns myapp/ffi.make_client : [Net]
```

```
$ graded why myapp.caller
myapp.caller has effects [Net]
declared check myapp.caller : [Net]
  calls myapp/ffi.make_client with effects [Net] (from your spec's external declaration)
  calls a function returned by `myapp/ffi.make_client` with effects [Net] (from your spec's external declaration)
```

Hand-written like `external effects` and never regenerated: `graded infer`
preserves the line and writes none of its own. Dependencies and path
dependencies can ship it for their own producers, and a consumer's line outranks
a dependency's for the same name. The bundled catalog does not carry the line
yet.

It answers only where the declaration stands alone, and a call that refuses it
says which reading refused:

- the declaration names only targets this build does not compile — the same
  reading that already drops the external's own declared effects, and it prints
  the same sentence;
- a Gleam fallback body runs beside it. Effects union the declaration and the
  body; there is no union of operators, and the closure the body hands back
  needn't be the foreign one.

Three shapes are dropped rather than trusted, each with its own warning from the
spec lint: an operator with free effect variables (a foreign decorator — wrap it
in Gleam, as before), a name with no function part, and a name that is one of
your own ordinary Gleam functions, whose body every caller can already see.
`graded infer` replaces that last one with the inferred `returns` line, the same
repair it does for a stale `external effects` line.

## Scope

Ground operators only. A polymorphic one carries free effect variables nothing
sanitized, which is exactly the substitution a serialized summary is already
refused for; lifting the restriction needs its own soundness argument. The one
place the declared tag is stamped drops anything else, so the rule holds for
every tier that feeds it.

Nothing else about foreign values changed. `external returns` describes one
channel: return provenance, factory and update-builder signatures stay opaque
for an `@external`, declared or not, and an inferred `returns` line for one is
still refused. Tests pin each of those.

## Notes for review

- The motivating call has two resolution paths — producer and caller in one
  module, and one module apart — and each passes while the other is broken.
  Both are covered by real fixtures, including one wired into the shared
  fixture set.
- `check` and `infer` must agree about the same body, so both load the
  declarations; the `graded effect` fast path deliberately does not, and its
  comment says why.
- Staleness on this channel is its own set, derived and threaded apart from the
  effects channel's. Letting the two mix would delete a function's `effects`
  lines because its *value* was declared; there is a test for it.
