### PR TITLE
Add `graded catalog`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ gleam run -m graded infer [dir]            # infer and write the spec file + cac
 gleam run -m graded infer --dry-run [dir]  # preview the spec changes, writing nothing
 gleam run -m graded effect <name> [dir]    # look up one function/type-field effect
 gleam run -m graded why <name> [dir]       # explain where a function's effects come from
+gleam run -m graded catalog                # list the bundled catalog files
+gleam run -m graded catalog <pkg> [dir]    # print the catalog file selected for <pkg>
+gleam run -m graded catalog <pkg>@<ver>    # print exactly that bundled catalog file
 gleam run -m graded format [dir]           # format the spec file
 gleam run -m graded format --check [dir]   # CI mode, exits non-zero on diffs
 gleam run -m graded format --stdin         # editor integration: format from stdin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `graded catalog [package[@version]]` command: lists the bundled catalog
   files, or prints the one selected for an installed package (or an explicit
   version), as a valid `.graded` file with a header comment naming the
-  selection. Shows the bundled catalog only; `graded effect` answers what wins
-  for a name.
+  selection. Selection follows the `manifest.toml` of the package enclosing the
+  directory given — or the current directory, from a subdirectory too — and a
+  directory, manifest or catalog directory it cannot read is reported by name
+  instead of answered around. Shows the bundled catalog only; `graded effect`
+  answers what wins for a name.
+
+### Fixed
+
+- A dependency installed at a pre-release or build-metadata version
+  (`1.2.0-rc.1`, `1.2.0+build.5`) now resolves against the catalog entry for
+  its `1.2.0` release. Such a version compared as `0.0.0`, so the highest
+  bundled entry stood in for it.
 
 ## [0.13.0] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New `graded catalog [package[@version]]` command: lists the bundled catalog
+  files, or prints the one selected for an installed package (or an explicit
+  version), as a valid `.graded` file with a header comment naming the
+  selection. Shows the bundled catalog only; `graded effect` answers what wins
+  for a name.
+
 ## [0.13.0] - 2026-08-20
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,11 @@ for third-party Gleam packages, so consumers resolve calls into those packages
 without writing their own annotations. Adding one is the most self-contained way
 to contribute.
 
-1. Create `priv/catalog/{package}@{version}.graded`. The version is the lowest
-   release whose surface the file describes; at resolution time graded picks the
-   highest catalog version `<= ` the consumer's installed version.
+1. Create `priv/catalog/{package}@{version}.graded`. The version is a plain
+   `major.minor.patch` (no pre-release or build suffix — selection compares
+   those three numbers and nothing else) and names the lowest release whose
+   surface the file describes; at resolution time graded picks the highest
+   catalog version `<= ` the consumer's installed version.
 2. Write `effects` / `external effects` / `type` lines with **module-qualified**
    names. The grammar, every annotation kind, and the effect-set syntax are in
    [docs/REFERENCE.md](docs/REFERENCE.md); existing entries (e.g.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ gleam run -m graded infer --dry-run [directory] # preview the spec changes, writ
 gleam run -m graded effect <name> [directory] # look up one effect, writing nothing
 gleam run -m graded effect <name> --format=graded # ... as a .graded line instead of prose
 gleam run -m graded why <name> [directory]    # explain a function's effects, writing nothing
+gleam run -m graded catalog                   # list graded's bundled catalog files
+gleam run -m graded catalog <package>         # print the catalog file selected for <package>
+gleam run -m graded catalog <package>@<version> # print exactly that bundled catalog file
 gleam run -m graded format [directory]        # normalize .graded file formatting
 gleam run -m graded format --check [directory] # verify formatting (CI mode)
 gleam run -m graded format --stdin            # format from stdin (editor integration)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -821,7 +821,11 @@ file each of your packages resolves to comes from `manifest.toml`, found by
 walking up from the directory you name — or from the current directory when you
 name none, so a run from anywhere inside a package reads that package's
 manifest. A directory that isn't there is an error, not a walk up to whatever
-project the shell is sitting in.
+project the shell is sitting in. Where there is no readable `manifest.toml` —
+a fresh clone before `gleam deps download`, or a manifest with a TOML error —
+no package has an installed version to select on: the listing says so on its
+first line and marks nothing, and `graded catalog <package>` is an error naming
+the file it looked for rather than a report that the package is not installed.
 
 With no argument it lists every bundled file, marking the one each of your
 installed packages resolves to:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -811,11 +811,49 @@ between patch versions. A new catalog file is only needed when a library adds
 modules or changes effect semantics. A dependency that ships its own `.graded` spec
 overrides the catalog (resolution order step 3 above).
 
-Browse [`priv/catalog/`](../priv/catalog/) for the exact set of covered packages
-and the effects each one declares — the files are plain `.graded` and readable at a
-glance. It covers the core `gleam-lang` packages and the most-used community
-libraries. For a package the catalog doesn't cover, add an `external effects`
-declaration in your spec file.
+The catalog covers the core `gleam-lang` packages and the most-used community
+libraries.
+
+### Reading the catalog
+
+`graded catalog` prints what the bundled catalog holds, writing nothing. Run it
+from the package root — like every command, it finds `manifest.toml` by walking
+up from there.
+
+With no argument it lists every bundled file, marking the one each of your
+installed packages resolves to:
+
+```sh
+$ gleam run -m graded catalog
+argv@1.1.0  // selected for argv 1.1.0
+gleam_stdlib@0.70.0  // selected for gleam_stdlib 1.0.3
+lustre@4.0.0
+lustre@5.0.0
+```
+
+With a package it prints that file, under a header naming it and why it was
+chosen — so the output is itself a valid `.graded` file you can redirect into a
+spec and edit down to `external effects` overrides:
+
+```sh
+$ gleam run -m graded catalog gleam_stdlib
+// gleam_stdlib@0.70.0.graded — selected for gleam_stdlib 1.0.3 in manifest.toml
+// gleam_stdlib — pure modules and effectful functions
+
+external effects gleam/list : []
+...
+```
+
+`graded catalog <package>@<version>` prints exactly that bundled file and reads
+no manifest, which is also how you read a package you don't depend on: the
+implicit form means "the file *your project* resolves against", so a bundled
+package missing from `manifest.toml` is an error that names the bundled versions
+and the command that prints one.
+
+What it shows is the bundled catalog alone — what `graded effect` names as a
+package's *catalog entry*. A dependency's shipped spec, a path dependency's spec
+and your own externals may all still override its entries, so
+`graded effect <name>` is what says which source wins for a name.
 
 ### Declaring uncatalogued dependencies
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -816,9 +816,12 @@ libraries.
 
 ### Reading the catalog
 
-`graded catalog` prints what the bundled catalog holds, writing nothing. Run it
-from the package root — like every command, it finds `manifest.toml` by walking
-up from there.
+`graded catalog` prints what the bundled catalog holds, writing nothing. Which
+file each of your packages resolves to comes from `manifest.toml`, found by
+walking up from the directory you name — or from the current directory when you
+name none, so a run from anywhere inside a package reads that package's
+manifest. A directory that isn't there is an error, not a walk up to whatever
+project the shell is sitting in.
 
 With no argument it lists every bundled file, marking the one each of your
 installed packages resolves to:

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -13,6 +13,9 @@
 //// gleam run -m graded effect <name> [directory] # look up one effect, writing nothing
 //// gleam run -m graded effect <name> --format=graded  # ... as a .graded line
 //// gleam run -m graded why <name> [directory]    # explain a function's effects
+//// gleam run -m graded catalog                   # list the bundled catalog files
+//// gleam run -m graded catalog <package>         # print the catalog file selected for it
+//// gleam run -m graded catalog <package>@<ver>   # print exactly that bundled file
 //// gleam run -m graded format [directory]        # normalize .graded file formatting
 //// ```
 ////
@@ -23,8 +26,9 @@
 //// effects and write `.graded` files, or `run_infer_dry_run` to get back a
 //// diff of what that write would change without performing it. Use
 //// `run_effect` to resolve one function or type-field name and get its
-//// `.graded` line back, or `run_why` to get the effects of one function
-//// explained call by call — both touching nothing on disk.
+//// `.graded` line back, `run_why` to get the effects of one function explained
+//// call by call, or `run_catalog` to read graded's own bundled catalog — none
+//// of them touching anything on disk.
 ////
 
 import argv

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -37,6 +37,7 @@ import gleam/int
 import gleam/io
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/order
 import gleam/result
 import gleam/set.{type Set}
 import gleam/string
@@ -103,6 +104,20 @@ pub type GradedError {
   /// was missing, its identity didn't match the project, the configured
   /// `spec_file` path was unsafe, or the tarball transform failed.
   PackError(message: String)
+  /// `graded catalog` could not answer: see `CatalogProblem`.
+  CatalogError(problem: CatalogProblem)
+}
+
+/// Why `graded catalog` could not answer.
+pub type CatalogProblem {
+  /// No bundled file names this package.
+  NoCatalogEntry(package: String)
+  /// The package is bundled, but not at the version asked for.
+  NoBundledVersion(package: String, requested: String, bundled: List(String))
+  /// The package is bundled but not in this project's manifest.
+  NotInstalled(package: String, bundled: List(String))
+  /// The catalog directory exists but holds no catalog file.
+  EmptyCatalog(directory: String)
 }
 
 pub fn main() -> Nil {
@@ -159,6 +174,8 @@ pub fn main() -> Nil {
         let #(name, directory) = arguments
         run_why(directory, name)
       })
+
+    ["catalog", ..rest] -> report(cli.parse_catalog_args(rest), run_catalog)
 
     [first] -> dispatch_unknown(first)
 
@@ -243,6 +260,9 @@ Usage:
     --format=prose              Describe the answer in sentences (default)
     --format=graded             Print it as a `.graded` line, provenance in a comment
   graded why <name> [dir]       Explain where a function's effects come from (read-only)
+  graded catalog                List the bundled catalog files (read-only)
+  graded catalog <pkg> [dir]    Print the catalog file selected for the installed <pkg>
+  graded catalog <pkg>@<ver>    Print that bundled version ([dir] accepted); bundled catalog only
   graded pack [directory]       Inject the spec into the hex tarball for release
   graded format [directory]     Format the spec file
   graded format --check [dir]   Verify formatting without writing (CI mode)
@@ -2136,6 +2156,216 @@ fn why_block(
   |> string.join("\n")
 }
 
+// Catalog
+//
+// The `catalog` command: what graded's own bundled `priv/catalog/` holds. The
+// listing marks the file each installed package resolves to; the show forms
+// print one file verbatim under a header naming it and why it was chosen.
+
+/// List the bundled catalog, or print one bundled catalog file.
+///
+/// `ListCatalog` prints one `package@version` line per bundled file, sorted,
+/// with a comment on the line each of this project's installed packages
+/// resolves to. `ShowCatalog` prints one file: at the version this project
+/// installs, or at the version the request names, under a `//` header line that
+/// says which file it is and why — so the output is itself a valid `.graded`
+/// file.
+///
+/// This is graded's bundled catalog alone: a dependency's shipped spec, a path
+/// dependency's spec and your own `external effects` all override it, so
+/// `run_effect` is what answers which source wins for a name. Nothing is
+/// written to disk.
+pub fn run_catalog(request: cli.CatalogRequest) -> Result(String, GradedError) {
+  // The listing takes no directory of its own, so it reads the manifest every
+  // other command defaults to.
+  let directory = case request {
+    cli.ListCatalog -> "src"
+    cli.ShowCatalog(directory:, ..) -> directory
+  }
+  catalog_report(
+    effects.catalog_directory(),
+    manifest_path(resolve_package_root(source_scope(directory).analysed)),
+    request,
+  )
+}
+
+// Render `request` against the catalog directory and manifest it names. The
+// seam `main`'s `catalog` branch dispatches through, so both forms are
+// reachable from tests.
+@internal
+pub fn catalog_report(
+  catalog_dir: String,
+  manifest_path: String,
+  request: cli.CatalogRequest,
+) -> Result(String, GradedError) {
+  use files <- result.try(
+    effects.bundled_catalog_files(catalog_dir)
+    |> result.map_error(fn(cause) { DirectoryReadError(catalog_dir, cause) }),
+  )
+  // A directory holding no `{package}@{version}.graded` file is not graded's
+  // catalog, whichever way the lookup landed on it.
+  use <- bool.guard(
+    when: files == [],
+    return: Error(CatalogError(EmptyCatalog(catalog_dir))),
+  )
+  let installed = effects.manifest_versions(manifest_path)
+  case request {
+    cli.ListCatalog -> Ok(catalog_listing(files, installed))
+    cli.ShowCatalog(package:, version:, directory: _) ->
+      catalog_file_output(files, installed, package, version)
+  }
+}
+
+// One `package@version` line per bundled file, sorted by package then version,
+// with the note of the file the manifest resolves that package to.
+fn catalog_listing(
+  files: List(effects.CatalogFile),
+  installed: Dict(String, String),
+) -> String {
+  let notes = listing_notes(files, installed)
+  files
+  |> list.sort(compare_catalog_files)
+  |> list.map(fn(file) {
+    let label = catalog_label(file)
+    case dict.get(notes, file.path) {
+      Ok(note) -> label <> "  // " <> note
+      Error(Nil) -> label
+    }
+  })
+  |> string.join("\n")
+}
+
+// The note each selected file's line carries, keyed by path. A package the
+// manifest doesn't list selects nothing, so none of its files are marked.
+fn listing_notes(
+  files: List(effects.CatalogFile),
+  installed: Dict(String, String),
+) -> Dict(String, String) {
+  files
+  |> list.map(fn(file) { file.package })
+  |> list.unique
+  |> list.fold(dict.new(), fn(notes, package) {
+    case dict.get(installed, package) {
+      Error(Nil) -> notes
+      Ok(version) ->
+        case effects.select_catalog_file(files, package, version) {
+          Error(Nil) -> notes
+          Ok(file) ->
+            dict.insert(notes, file.path, case eligible_for(file, version) {
+              True -> "selected for " <> package <> " " <> version
+              False -> "highest bundled; none ≤ " <> package <> " " <> version
+            })
+        }
+    }
+  })
+}
+
+// One bundled file, printed under the header that names it. The explicit form
+// consults no manifest: the version asked for is the one printed, whatever the
+// project installs.
+fn catalog_file_output(
+  files: List(effects.CatalogFile),
+  installed: Dict(String, String),
+  package: String,
+  version: Option(String),
+) -> Result(String, GradedError) {
+  let bundled = list.filter(files, fn(file) { file.package == package })
+  use <- bool.guard(
+    when: bundled == [],
+    return: Error(CatalogError(NoCatalogEntry(package))),
+  )
+  case version {
+    Some(version) ->
+      case list.find(bundled, fn(file) { file.version == version }) {
+        Ok(file) -> print_catalog_file(file, "bundled version, as requested")
+        Error(Nil) ->
+          Error(
+            CatalogError(NoBundledVersion(
+              package:,
+              requested: version,
+              bundled: catalog_labels(bundled),
+            )),
+          )
+      }
+    None ->
+      case dict.get(installed, package) {
+        Error(Nil) ->
+          Error(
+            CatalogError(NotInstalled(
+              package:,
+              bundled: catalog_labels(bundled),
+            )),
+          )
+        Ok(version) ->
+          case effects.select_catalog_file(bundled, package, version) {
+            // Unreachable: a non-empty list for the package always selects.
+            Error(Nil) -> Error(CatalogError(NoCatalogEntry(package)))
+            Ok(file) ->
+              print_catalog_file(file, selection_note(file, package, version))
+          }
+      }
+  }
+}
+
+// Why the implicit form chose this file: the installed version it covers, or
+// the fall-back that fires when nothing bundled is old enough.
+fn selection_note(
+  file: effects.CatalogFile,
+  package: String,
+  version: String,
+) -> String {
+  case eligible_for(file, version) {
+    True -> "selected for " <> package <> " " <> version <> " in manifest.toml"
+    False ->
+      "highest bundled version; no bundled " <> package <> " ≤ " <> version
+  }
+}
+
+// Whether the file's version is at or below the installed one — the rule
+// `select_catalog_file` picks by, so a `False` here is its fall-back.
+fn eligible_for(file: effects.CatalogFile, version: String) -> Bool {
+  effects.semver_lte(file.parsed, effects.parse_semver(version))
+}
+
+// The header line, then the file verbatim. `report` prints with `io.println`,
+// which appends a newline, so exactly one trailing newline is dropped here for
+// it to put back: a file that ends in one prints byte-identically.
+fn print_catalog_file(
+  file: effects.CatalogFile,
+  note: String,
+) -> Result(String, GradedError) {
+  use contents <- result.map(
+    simplifile.read(file.path)
+    |> result.map_error(fn(cause) { FileReadError(file.path, cause) }),
+  )
+  let header = "// " <> filepath.base_name(file.path) <> " — " <> note
+  let output = header <> "\n" <> contents
+  case string.ends_with(output, "\n") {
+    True -> string.drop_end(output, 1)
+    False -> output
+  }
+}
+
+// Bundled files as `package@version` tokens, ascending by version: what an
+// error message lists, and where its suggestion reads the highest off the end.
+fn catalog_labels(files: List(effects.CatalogFile)) -> List(String) {
+  files |> list.sort(compare_catalog_files) |> list.map(catalog_label)
+}
+
+fn catalog_label(file: effects.CatalogFile) -> String {
+  file.package <> "@" <> file.version
+}
+
+fn compare_catalog_files(
+  left: effects.CatalogFile,
+  right: effects.CatalogFile,
+) -> order.Order {
+  case string.compare(left.package, right.package) {
+    order.Eq -> effects.compare_semver(left.parsed, right.parsed)
+    other -> other
+  }
+}
+
 // Formatting
 //
 // The `format` command and its `--check`/`--stdin` variants: parse the spec
@@ -3928,6 +4158,33 @@ fn format_error(error: GradedError) -> String {
       <> name
       <> "` (`why` explains functions defined in this project's modules, named as `module/path.function`)"
     PackError(message:) -> message
+    CatalogError(problem:) -> format_catalog_problem(problem)
+  }
+}
+
+// The message a `CatalogError` prints. Exposed so the wording of each problem —
+// the recovery command `NotInstalled` names in particular — is covered without
+// going through the branch that prints and halts.
+@internal
+pub fn format_catalog_problem(problem: CatalogProblem) -> String {
+  case problem {
+    NoCatalogEntry(package:) -> "no catalog entry for `" <> package <> "`"
+    NoBundledVersion(package:, requested:, bundled:) ->
+      "no bundled `"
+      <> package
+      <> "@"
+      <> requested
+      <> "`; bundled: "
+      <> string.join(bundled, ", ")
+    NotInstalled(package:, bundled:) ->
+      "`"
+      <> package
+      <> "` is not in manifest.toml; bundled: "
+      <> string.join(bundled, ", ")
+      <> " — run `graded catalog "
+      <> result.unwrap(list.last(bundled), package)
+      <> "` to print one"
+    EmptyCatalog(directory:) -> "no catalog files under " <> directory
   }
 }
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -126,6 +126,8 @@ pub type CatalogProblem {
   NoManifest(path: String)
   /// The catalog directory exists but holds no catalog file.
   EmptyCatalog(directory: String)
+  /// None of the paths graded looks for its bundled catalog under exists.
+  NoCatalogDirectory(candidates: List(String))
 }
 
 pub fn main() -> Nil {
@@ -2193,7 +2195,13 @@ pub fn run_catalog(request: cli.CatalogRequest) -> Result(String, GradedError) {
       catalog_manifest_path(directory)
     }
   })
-  catalog_report(effects.catalog_directory(), manifest, request)
+  use catalog_dir <- result.try(
+    effects.find_catalog_directory()
+    |> result.map_error(fn(candidates) {
+      CatalogError(NoCatalogDirectory(candidates))
+    }),
+  )
+  catalog_report(catalog_dir, manifest, request)
 }
 
 // The `manifest.toml` of the package `directory` belongs to, found by walking
@@ -4232,6 +4240,9 @@ pub fn format_catalog_problem(problem: CatalogProblem) -> String {
       <> "; run `gleam deps download` in that package, or name the version to "
       <> "print: `graded catalog <package>@<version>`"
     EmptyCatalog(directory:) -> "no catalog files under " <> directory
+    NoCatalogDirectory(candidates:) ->
+      "no bundled catalog directory; looked in "
+      <> string.join(candidates, ", ")
   }
 }
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -35,6 +35,7 @@ import argv
 import filepath
 import girard
 import glance
+import gleam/bit_array
 import gleam/bool
 import gleam/dict.{type Dict}
 import gleam/int
@@ -2331,10 +2332,18 @@ fn print_catalog_file(
     |> result.map_error(fn(cause) { FileReadError(file.path, cause) }),
   )
   let header = "// " <> catalog_label(file) <> ".graded — " <> note
-  let output = header <> "\n" <> contents
-  case string.ends_with(output, "\n") {
-    True -> string.drop_end(output, 1)
-    False -> output
+  header <> "\n" <> drop_trailing_newline(contents)
+}
+
+// `text` without the newline byte it ends in, if it ends in one. Byte-wise: a
+// `\r\n` is a single grapheme, so dropping the last grapheme would take the
+// carriage return with it and a CRLF file would not print as it reads.
+fn drop_trailing_newline(text: String) -> String {
+  let bytes = bit_array.from_string(text)
+  let without_last = bit_array.slice(bytes, 0, bit_array.byte_size(bytes) - 1)
+  case string.ends_with(text, "\n"), without_last {
+    True, Ok(trimmed) -> bit_array.to_string(trimmed) |> result.unwrap(text)
+    True, Error(Nil) | False, Ok(_) | False, Error(Nil) -> text
   }
 }
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -2181,17 +2181,41 @@ fn why_block(
 /// `run_effect` is what answers which source wins for a name. Nothing is
 /// written to disk.
 pub fn run_catalog(request: cli.CatalogRequest) -> Result(String, GradedError) {
-  // The listing takes no directory of its own, so it reads the manifest every
-  // other command defaults to.
-  let directory = case request {
-    cli.ListCatalog -> "src"
-    cli.ShowCatalog(directory:, ..) -> directory
-  }
-  catalog_report(
-    effects.catalog_directory(),
-    manifest_path(resolve_package_root(source_scope(directory).analysed)),
-    request,
-  )
+  use manifest <- result.try(case request {
+    // The listing takes no directory of its own, so it walks up from the one
+    // the process runs in.
+    cli.ListCatalog -> Ok(catalog_manifest_path(working_directory()))
+    cli.ShowCatalog(directory:, ..) -> {
+      use _ <- result.map(read_directory(directory))
+      catalog_manifest_path(directory)
+    }
+  })
+  catalog_report(effects.catalog_directory(), manifest, request)
+}
+
+// The `manifest.toml` of the package `directory` belongs to, found by walking
+// up from it as every command's knowledge base does. Exposed so a test can walk
+// up from a fixture subdirectory.
+@internal
+pub fn catalog_manifest_path(directory: String) -> String {
+  manifest_path(resolve_package_root(source_scope(directory).analysed))
+}
+
+// The process's own directory, absolute so the walk to a package root is a real
+// one: the relative `.` a failed lookup falls back to is its own parent, which
+// halts the walk where it starts.
+fn working_directory() -> String {
+  simplifile.current_directory() |> result.unwrap(".")
+}
+
+// Read `directory` for the sake of failing on one that isn't there. A directory
+// argument names the project whose manifest is read, and a missing one would
+// otherwise walk up to whichever project the process sits in and answer for
+// that.
+fn read_directory(directory: String) -> Result(Nil, GradedError) {
+  simplifile.read_directory(directory)
+  |> result.replace(Nil)
+  |> result.map_error(DirectoryReadError(directory, _))
 }
 
 // Render `request` against the catalog directory and manifest it names. One

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -2193,9 +2193,9 @@ pub fn run_catalog(request: cli.CatalogRequest) -> Result(String, GradedError) {
   )
 }
 
-// Render `request` against the catalog directory and manifest it names. The
-// seam `main`'s `catalog` branch dispatches through, so both forms are
-// reachable from tests.
+// Render `request` against the catalog directory and manifest it names. One
+// layer below `run_catalog`, taking both paths as arguments so a test can point
+// it at a fixture catalog and manifest.
 @internal
 pub fn catalog_report(
   catalog_dir: String,
@@ -2212,11 +2212,11 @@ pub fn catalog_report(
     when: files == [],
     return: Error(CatalogError(EmptyCatalog(catalog_dir))),
   )
-  let installed = effects.manifest_versions(manifest_path)
   case request {
-    cli.ListCatalog -> Ok(catalog_listing(files, installed))
+    cli.ListCatalog ->
+      Ok(catalog_listing(files, effects.manifest_versions(manifest_path)))
     cli.ShowCatalog(package:, version:, directory: _) ->
-      catalog_file_output(files, installed, package, version)
+      catalog_file_output(files, manifest_path, package, version)
   }
 }
 
@@ -2226,12 +2226,11 @@ fn catalog_listing(
   files: List(effects.CatalogFile),
   installed: Dict(String, String),
 ) -> String {
-  let notes = listing_notes(files, installed)
   files
   |> list.sort(compare_catalog_files)
   |> list.map(fn(file) {
     let label = catalog_label(file)
-    case dict.get(notes, file.path) {
+    case listing_suffix(files, installed, file) {
       Ok(note) -> label <> "  // " <> note
       Error(Nil) -> label
     }
@@ -2239,37 +2238,34 @@ fn catalog_listing(
   |> string.join("\n")
 }
 
-// The note each selected file's line carries, keyed by path. A package the
-// manifest doesn't list selects nothing, so none of its files are marked.
-fn listing_notes(
+// The note this file's line carries. A package the manifest doesn't list
+// selects nothing, and a file its package's installed version resolves past
+// carries no note.
+fn listing_suffix(
   files: List(effects.CatalogFile),
   installed: Dict(String, String),
-) -> Dict(String, String) {
-  files
-  |> list.map(fn(file) { file.package })
-  |> list.unique
-  |> list.fold(dict.new(), fn(notes, package) {
-    case dict.get(installed, package) {
-      Error(Nil) -> notes
-      Ok(version) ->
-        case effects.select_catalog_file(files, package, version) {
-          Error(Nil) -> notes
-          Ok(file) ->
-            dict.insert(notes, file.path, case eligible_for(file, version) {
-              True -> "selected for " <> package <> " " <> version
-              False -> "highest bundled; none ≤ " <> package <> " " <> version
-            })
-        }
-    }
+  file: effects.CatalogFile,
+) -> Result(String, Nil) {
+  use version <- result.try(dict.get(installed, file.package))
+  use selection <- result.try(effects.select_catalog_file(
+    files,
+    file.package,
+    version,
+  ))
+  use <- bool.guard(when: selection.file.path != file.path, return: Error(Nil))
+  Ok(case selection {
+    effects.Selected(_) -> "selected for " <> file.package <> " " <> version
+    effects.HighestBundled(_) ->
+      "highest bundled; none ≤ " <> file.package <> " " <> version
   })
 }
 
 // One bundled file, printed under the header that names it. The explicit form
-// consults no manifest: the version asked for is the one printed, whatever the
+// reads no manifest: the version asked for is the one printed, whatever the
 // project installs.
 fn catalog_file_output(
   files: List(effects.CatalogFile),
-  installed: Dict(String, String),
+  manifest_path: String,
   package: String,
   version: Option(String),
 ) -> Result(String, GradedError) {
@@ -2278,57 +2274,49 @@ fn catalog_file_output(
     when: bundled == [],
     return: Error(CatalogError(NoCatalogEntry(package))),
   )
-  case version {
+  use #(file, note) <- result.try(case version {
     Some(version) ->
-      case list.find(bundled, fn(file) { file.version == version }) {
-        Ok(file) -> print_catalog_file(file, "bundled version, as requested")
-        Error(Nil) ->
-          Error(
-            CatalogError(NoBundledVersion(
-              package:,
-              requested: version,
-              bundled: catalog_labels(bundled),
-            )),
-          )
-      }
-    None ->
-      case dict.get(installed, package) {
-        Error(Nil) ->
-          Error(
-            CatalogError(NotInstalled(
-              package:,
-              bundled: catalog_labels(bundled),
-            )),
-          )
-        Ok(version) ->
-          case effects.select_catalog_file(bundled, package, version) {
-            // Unreachable: a non-empty list for the package always selects.
-            Error(Nil) -> Error(CatalogError(NoCatalogEntry(package)))
-            Ok(file) ->
-              print_catalog_file(file, selection_note(file, package, version))
-          }
-      }
-  }
+      list.find(bundled, fn(file) { file.version == version })
+      |> result.map(fn(file) { #(file, "bundled version, as requested") })
+      |> result.replace_error(
+        CatalogError(NoBundledVersion(
+          package:,
+          requested: version,
+          bundled: catalog_labels(bundled),
+        )),
+      )
+    None -> {
+      use version <- result.map(
+        dict.get(effects.manifest_versions(manifest_path), package)
+        |> result.replace_error(
+          CatalogError(NotInstalled(package:, bundled: catalog_labels(bundled))),
+        ),
+      )
+      // A non-empty list for the package always selects one of its files, so a
+      // failure here is a broken invariant rather than a case to render.
+      // nolint: assert_ok_pattern -- a broken invariant, not an error to handle
+      let assert Ok(selection) =
+        effects.select_catalog_file(bundled, package, version)
+        as "a package with bundled files always selects one"
+      #(selection.file, selection_note(selection, package, version))
+    }
+  })
+  print_catalog_file(file, note)
 }
 
 // Why the implicit form chose this file: the installed version it covers, or
 // the fall-back that fires when nothing bundled is old enough.
 fn selection_note(
-  file: effects.CatalogFile,
+  selection: effects.CatalogSelection,
   package: String,
   version: String,
 ) -> String {
-  case eligible_for(file, version) {
-    True -> "selected for " <> package <> " " <> version <> " in manifest.toml"
-    False ->
+  case selection {
+    effects.Selected(_) ->
+      "selected for " <> package <> " " <> version <> " in manifest.toml"
+    effects.HighestBundled(_) ->
       "highest bundled version; no bundled " <> package <> " ≤ " <> version
   }
-}
-
-// Whether the file's version is at or below the installed one — the rule
-// `select_catalog_file` picks by, so a `False` here is its fall-back.
-fn eligible_for(file: effects.CatalogFile, version: String) -> Bool {
-  effects.semver_lte(file.parsed, effects.parse_semver(version))
 }
 
 // The header line, then the file verbatim. `report` prints with `io.println`,
@@ -2342,7 +2330,7 @@ fn print_catalog_file(
     simplifile.read(file.path)
     |> result.map_error(fn(cause) { FileReadError(file.path, cause) }),
   )
-  let header = "// " <> filepath.base_name(file.path) <> " — " <> note
+  let header = "// " <> catalog_label(file) <> ".graded — " <> note
   let output = header <> "\n" <> contents
   case string.ends_with(output, "\n") {
     True -> string.drop_end(output, 1)
@@ -2364,10 +2352,8 @@ fn compare_catalog_files(
   left: effects.CatalogFile,
   right: effects.CatalogFile,
 ) -> order.Order {
-  case string.compare(left.package, right.package) {
-    order.Eq -> effects.compare_semver(left.parsed, right.parsed)
-    other -> other
-  }
+  string.compare(left.package, right.package)
+  |> order.break_tie(effects.compare_semver(left.parsed, right.parsed))
 }
 
 // Formatting

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -121,6 +121,9 @@ pub type CatalogProblem {
   NoBundledVersion(package: String, requested: String, bundled: List(String))
   /// The package is bundled but not in this project's manifest.
   NotInstalled(package: String, bundled: List(String))
+  /// There is no manifest to read at the path the command consulted, or its
+  /// TOML is malformed, so no package has an installed version to select on.
+  NoManifest(path: String)
   /// The catalog directory exists but holds no catalog file.
   EmptyCatalog(directory: String)
 }
@@ -2238,29 +2241,41 @@ pub fn catalog_report(
     return: Error(CatalogError(EmptyCatalog(catalog_dir))),
   )
   case request {
-    cli.ListCatalog ->
-      Ok(catalog_listing(files, effects.manifest_versions(manifest_path)))
+    cli.ListCatalog -> Ok(catalog_listing(files, manifest_path))
     cli.ShowCatalog(package:, version:, directory: _) ->
       catalog_file_output(files, manifest_path, package, version)
   }
 }
 
 // One `package@version` line per bundled file, sorted by package then version,
-// with the note of the file the manifest resolves that package to.
+// with the note of the file the manifest resolves that package to. Where there
+// is no manifest to read, nothing selects and the listing leads with a line
+// saying so — undecorated lines otherwise read as a project the catalog covers
+// none of.
 fn catalog_listing(
   files: List(effects.CatalogFile),
-  installed: Dict(String, String),
+  manifest_path: String,
 ) -> String {
-  files
-  |> list.sort(compare_catalog_files)
-  |> list.map(fn(file) {
-    let label = catalog_label(file)
-    case listing_suffix(files, installed, file) {
-      Ok(note) -> label <> "  // " <> note
-      Error(Nil) -> label
-    }
-  })
-  |> string.join("\n")
+  let manifest = effects.read_manifest_versions(manifest_path)
+  let installed = result.unwrap(manifest, dict.new())
+  let lines =
+    files
+    |> list.sort(compare_catalog_files)
+    |> list.map(fn(file) {
+      let label = catalog_label(file)
+      case listing_suffix(files, installed, file) {
+        Ok(note) -> label <> "  // " <> note
+        Error(Nil) -> label
+      }
+    })
+  case manifest {
+    Ok(_versions) -> string.join(lines, "\n")
+    Error(Nil) ->
+      string.join(
+        ["// no readable manifest.toml at " <> manifest_path, ..lines],
+        "\n",
+      )
+  }
 }
 
 // The note this file's line carries. A package the manifest doesn't list
@@ -2311,8 +2326,12 @@ fn catalog_file_output(
         )),
       )
     None -> {
+      use installed <- result.try(
+        effects.read_manifest_versions(manifest_path)
+        |> result.replace_error(CatalogError(NoManifest(manifest_path))),
+      )
       use version <- result.map(
-        dict.get(effects.manifest_versions(manifest_path), package)
+        dict.get(installed, package)
         |> result.replace_error(
           CatalogError(NotInstalled(package:, bundled: catalog_labels(bundled))),
         ),
@@ -4207,6 +4226,11 @@ pub fn format_catalog_problem(problem: CatalogProblem) -> String {
       <> " — run `graded catalog "
       <> result.unwrap(list.last(bundled), package)
       <> "` to print one"
+    NoManifest(path:) ->
+      "no readable manifest.toml at "
+      <> path
+      <> "; run `gleam deps download` in that package, or name the version to "
+      <> "print: `graded catalog <package>@<version>`"
     EmptyCatalog(directory:) -> "no catalog files under " <> directory
   }
 }

--- a/src/graded/internal/cli.gleam
+++ b/src/graded/internal/cli.gleam
@@ -1,5 +1,6 @@
 import gleam/bool
 import gleam/list
+import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import graded/internal/answer
@@ -23,6 +24,9 @@ pub type ArgumentError {
   UnexpectedArgument(argument: String)
   // `--format=` given a value that names no output format.
   UnknownFormat(value: String)
+  // A token in the package position that names no package: an empty package or
+  // an empty version around the `@`.
+  InvalidPackage(argument: String)
 }
 
 // Decode the optional directory argument shared by check/infer/format/pack
@@ -100,6 +104,50 @@ pub fn parse_why_args(
   parse_name_and_directory("why", rest)
 }
 
+// What `graded catalog` was asked for: the whole bundled catalog, or one
+// package's file — at the version the project installs, or at the version the
+// argument named.
+pub type CatalogRequest {
+  ListCatalog
+  ShowCatalog(package: String, version: Option(String), directory: String)
+}
+
+// Decode the arguments of `graded catalog [package[@version]] [directory]`. The
+// package comes first, so a lone argument is always read as one and the listing
+// cannot be pointed at another project; the directory that may follow it
+// follows `parse_directory_args`' rules. `@` splits the package from the
+// version at its first occurrence, so a version may carry one of its own; a
+// half left empty on either side names no package.
+pub fn parse_catalog_args(
+  rest: List(String),
+) -> Result(CatalogRequest, ArgumentError) {
+  case rest {
+    [] -> Ok(ListCatalog)
+    [subject, ..directory_args] -> {
+      use <- reject_option(subject)
+      use #(package, version) <- result.try(split_package_version(subject))
+      use directory <- result.map(parse_directory_args(directory_args))
+      ShowCatalog(package:, version:, directory:)
+    }
+  }
+}
+
+// Split a `package` or `package@version` token. Neither half may be empty: a
+// bare `@`, a trailing one, or a leading one names no package.
+fn split_package_version(
+  subject: String,
+) -> Result(#(String, Option(String)), ArgumentError) {
+  case string.split_once(subject, "@") {
+    Ok(#("", _)) | Ok(#(_, "")) -> Error(InvalidPackage(subject))
+    Ok(#(package, version)) -> Ok(#(package, Some(version)))
+    Error(Nil) ->
+      case subject {
+        "" -> Error(InvalidPackage(subject))
+        package -> Ok(#(package, None))
+      }
+  }
+}
+
 // The positions a name-taking command shares: a required name, then the
 // optional directory `parse_directory_args` decodes. `command` names the one
 // asking, so a missing name reports the command the user typed.
@@ -148,6 +196,8 @@ pub fn format_argument_error(error: ArgumentError) -> String {
     UnexpectedArgument(argument:) -> "unexpected argument `" <> argument <> "`"
     UnknownFormat(value:) ->
       "unknown format `" <> value <> "` (expected `prose` or `graded`)"
+    InvalidPackage(argument:) ->
+      "expected a package or package@version, got `" <> argument <> "`"
   }
 }
 

--- a/src/graded/internal/cli.gleam
+++ b/src/graded/internal/cli.gleam
@@ -137,14 +137,11 @@ pub fn parse_catalog_args(
 fn split_package_version(
   subject: String,
 ) -> Result(#(String, Option(String)), ArgumentError) {
+  use <- bool.guard(when: subject == "", return: Error(InvalidPackage(subject)))
   case string.split_once(subject, "@") {
+    Error(Nil) -> Ok(#(subject, None))
     Ok(#("", _)) | Ok(#(_, "")) -> Error(InvalidPackage(subject))
     Ok(#(package, version)) -> Ok(#(package, Some(version)))
-    Error(Nil) ->
-      case subject {
-        "" -> Error(InvalidPackage(subject))
-        package -> Ok(#(package, None))
-      }
   }
 }
 

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1516,7 +1516,7 @@ pub fn packages_with_sources(packages_directory: String) -> Set(String) {
 // The packages the manifest lists, by name. What an installed tree is measured
 // against.
 pub fn manifest_package_names(manifest_path: String) -> Set(String) {
-  parse_manifest_versions(manifest_path) |> dict.keys |> set.from_list
+  manifest_versions(manifest_path) |> dict.keys |> set.from_list
 }
 
 // Map of module path -> source file for every `.gleam` under `source_dir` (a
@@ -2069,12 +2069,8 @@ pub fn load_catalog(
   Dict(QualifiedName, List(ParamBound)),
   List(#(TypeFieldAnnotation, LookupOrigin)),
 ) {
-  let installed_versions = parse_manifest_versions(manifest_path)
-  let catalog_files = case simplifile.get_files(catalog_dir) {
-    Ok(files) ->
-      list.filter(files, fn(file) { string.ends_with(file, ".graded") })
-    Error(_) -> []
-  }
+  let installed_versions = manifest_versions(manifest_path)
+  let catalog_files = bundled_catalog_files(catalog_dir) |> result.unwrap([])
   let selected = resolve_catalog_files(catalog_files, installed_versions)
   let initial =
     CatalogAcc(dict.new(), dict.new(), dict.new(), dict.new(), dict.new(), [])
@@ -2157,56 +2153,90 @@ fn fold_catalog_file(acc: CatalogAcc, entry: #(String, String)) -> CatalogAcc {
   }
 }
 
+// One bundled catalog file, as its `{package}@{version}.graded` name reads. The
+// raw `version` string is what a caller prints; `parsed` is what selection and
+// sorting compare, and drops anything `parse_semver` does not read (`1.2.0-rc1`
+// parses to `#(1, 2, 0)`).
+pub type CatalogFile {
+  CatalogFile(
+    package: String,
+    version: String,
+    parsed: #(Int, Int, Int),
+    path: String,
+  )
+}
+
+// Every `{package}@{version}.graded` file under `catalog_dir`, in directory
+// order. A file whose name carries no `@`, or more than one, names no package
+// and version and is skipped. The read error is returned rather than folded
+// into an empty list, so a caller for which the directory is the subject can
+// tell "no catalog there" from "nothing bundled".
+pub fn bundled_catalog_files(
+  catalog_dir: String,
+) -> Result(List(CatalogFile), simplifile.FileError) {
+  use paths <- result.map(simplifile.get_files(catalog_dir))
+  paths
+  |> list.filter(fn(path) { string.ends_with(path, ".graded") })
+  |> list.filter_map(fn(path) {
+    let filename =
+      path
+      |> string.split("/")
+      |> list.last()
+      |> result.unwrap("")
+      |> string.replace(".graded", "")
+    case string.split(filename, "@") {
+      [package, version] ->
+        Ok(CatalogFile(package:, version:, parsed: parse_semver(version), path:))
+      _ -> Error(Nil)
+    }
+  })
+}
+
+// The file `package` resolves to for its `installed` version: the highest
+// bundled version at or below it, else the highest bundled. Ties are broken by
+// input order; the release lint guarantees bundled files never tie.
+pub fn select_catalog_file(
+  files: List(CatalogFile),
+  package: String,
+  installed: String,
+) -> Result(CatalogFile, Nil) {
+  files
+  |> list.filter(fn(file) { file.package == package })
+  |> list.map(fn(file) { #(file.parsed, file) })
+  |> pick_best_version(parse_semver(installed))
+}
+
 // Each selected file as `#(package, path)`: the package name the catalog's
 // `{package}@{version}.graded` file name carries, which the fold records as the
 // origin of that file's entries.
 fn resolve_catalog_files(
-  catalog_files: List(String),
+  catalog_files: List(CatalogFile),
   installed_versions: Dict(String, String),
 ) -> List(#(String, String)) {
-  // Parse filenames: "path/to/gleam_stdlib@0.70.0.graded" → #("gleam_stdlib", #(0,70,0), path)
-  let parsed =
-    list.filter_map(catalog_files, fn(path) {
-      let filename =
-        path
-        |> string.split("/")
-        |> list.last()
-        |> result.unwrap("")
-        |> string.replace(".graded", "")
-      case string.split(filename, "@") {
-        [package, version] -> Ok(#(package, parse_semver(version), path))
-        _ -> Error(Nil)
-      }
-    })
-
   // Group by package name
   let grouped =
-    list.fold(parsed, dict.new(), fn(accumulator, entry) {
-      let #(package, version, path) = entry
-      let existing = dict.get(accumulator, package) |> result.unwrap([])
-      dict.insert(accumulator, package, [#(version, path), ..existing])
+    list.fold(catalog_files, dict.new(), fn(accumulator, file) {
+      let existing = dict.get(accumulator, file.package) |> result.unwrap([])
+      dict.insert(accumulator, file.package, [file, ..existing])
     })
 
   // For each installed package, pick best catalog version
-  dict.fold(grouped, [], fn(selected, package, versions) {
+  dict.fold(grouped, [], fn(selected, package, files) {
     case dict.get(installed_versions, package) {
       Error(Nil) -> selected
-      Ok(installed_str) -> {
-        let installed = parse_semver(installed_str)
-        let best = pick_best_version(versions, installed)
-        case best {
-          Ok(path) -> [#(package, path), ..selected]
+      Ok(installed) ->
+        case select_catalog_file(files, package, installed) {
+          Ok(file) -> [#(package, file.path), ..selected]
           Error(Nil) -> selected
         }
-      }
     }
   })
 }
 
 pub fn pick_best_version(
-  versions: List(#(#(Int, Int, Int), String)),
+  versions: List(#(#(Int, Int, Int), a)),
   installed: #(Int, Int, Int),
-) -> Result(String, Nil) {
+) -> Result(a, Nil) {
   // Pick highest version ≤ installed; if none, pick highest available
   let eligible =
     list.filter(versions, fn(version) { semver_lte(version.0, installed) })
@@ -2261,7 +2291,9 @@ pub fn compare_semver(
   }
 }
 
-fn parse_manifest_versions(manifest_path: String) -> Dict(String, String) {
+// The installed version of each package `manifest_path` lists. An unreadable
+// or malformed manifest yields an empty dict.
+pub fn manifest_versions(manifest_path: String) -> Dict(String, String) {
   let parsed = {
     use content <- result.try(
       simplifile.read(manifest_path) |> result.map_error(fn(_) { Nil }),

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -2199,69 +2199,70 @@ pub type CatalogSelection {
 }
 
 // The file `package` resolves to for its `installed` version, and which of the
-// two rules chose it. Ties are broken by input order; the release lint
-// guarantees bundled files never tie.
+// two rules chose it. Two files whose versions parse alike are ordered by path,
+// so every caller reaches the same file whatever order it holds the catalog in.
 pub fn select_catalog_file(
   files: List(CatalogFile),
   package: String,
   installed: String,
 ) -> Result(CatalogSelection, Nil) {
-  let installed = parse_semver(installed)
-  use file <- result.map(
+  use pick <- result.map(
     files
     |> list.filter(fn(file) { file.package == package })
+    |> list.sort(fn(left, right) {
+      compare_semver(left.parsed, right.parsed)
+      |> order.break_tie(string.compare(left.path, right.path))
+    })
     |> list.map(fn(file) { #(file.parsed, file) })
-    |> pick_best_version(installed),
+    |> pick_best_version(parse_semver(installed)),
   )
-  case semver_lte(file.parsed, installed) {
-    True -> Selected(file)
-    False -> HighestBundled(file)
+  case pick {
+    AtOrBelowInstalled(file) -> Selected(file)
+    HighestAvailable(file) -> HighestBundled(file)
   }
 }
 
-// Each selected file as `#(package, path)`: the package name the catalog's
-// `{package}@{version}.graded` file name carries, which the fold records as the
-// origin of that file's entries.
+// The file each installed package resolves to, as `#(package, path)`: the
+// package name the catalog's `{package}@{version}.graded` file name carries,
+// which the fold records as the origin of that file's entries. An installed
+// package the catalog does not bundle selects nothing.
 fn resolve_catalog_files(
   catalog_files: List(CatalogFile),
   installed_versions: Dict(String, String),
 ) -> List(#(String, String)) {
-  // Group by package name
-  let grouped =
-    list.fold(catalog_files, dict.new(), fn(accumulator, file) {
-      let existing = dict.get(accumulator, file.package) |> result.unwrap([])
-      dict.insert(accumulator, file.package, [file, ..existing])
-    })
-
-  // For each installed package, pick best catalog version
-  dict.fold(grouped, [], fn(selected, package, files) {
-    case dict.get(installed_versions, package) {
+  dict.fold(installed_versions, [], fn(selected, package, installed) {
+    case select_catalog_file(catalog_files, package, installed) {
+      Ok(selection) -> [#(package, selection.file.path), ..selected]
       Error(Nil) -> selected
-      Ok(installed) ->
-        case select_catalog_file(files, package, installed) {
-          Ok(selection) -> [#(package, selection.file.path), ..selected]
-          Error(Nil) -> selected
-        }
     }
   })
+}
+
+// Which of the two rules picked a version, carrying what it picked. A caller
+// that renders the pick reads the rule off this rather than re-deriving it, so
+// the two cannot disagree.
+pub type VersionPick(a) {
+  // The highest version at or below the installed one.
+  AtOrBelowInstalled(value: a)
+  // Nothing sits at or below the installed version, so the highest available
+  // one stands in.
+  HighestAvailable(value: a)
 }
 
 pub fn pick_best_version(
   versions: List(#(#(Int, Int, Int), a)),
   installed: #(Int, Int, Int),
-) -> Result(a, Nil) {
-  // Pick highest version ≤ installed; if none, pick highest available
+) -> Result(VersionPick(a), Nil) {
   let eligible =
     list.filter(versions, fn(version) { semver_lte(version.0, installed) })
     |> list.sort(fn(left, right) { compare_semver(right.0, left.0) })
   case eligible {
-    [best, ..] -> Ok(best.1)
+    [best, ..] -> Ok(AtOrBelowInstalled(best.1))
     [] ->
-      // No entry ≤ installed: fall back to the highest available version.
       case
         list.sort(versions, fn(left, right) { compare_semver(right.0, left.0) })
       {
-        [best, ..] -> Ok(best.1)
+        [best, ..] -> Ok(HighestAvailable(best.1))
         [] -> Error(Nil)
       }
   }

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -181,7 +181,7 @@ pub type BundledCatalog {
 // versions.
 pub fn load_project_catalog(manifest_path: String) -> BundledCatalog {
   let #(functions, modules, param_bounds, type_fields) =
-    load_catalog(find_catalog_directory(), manifest_path)
+    load_catalog(catalog_directory(), manifest_path)
   BundledCatalog(functions:, modules:, param_bounds:, type_fields:)
 }
 
@@ -253,7 +253,7 @@ pub fn new_knowledge_base() -> KnowledgeBase {
 
 // Build a knowledge base from the catalog only (no dependency scanning).
 pub fn empty_knowledge_base() -> KnowledgeBase {
-  let catalog_dir = find_catalog_directory()
+  let catalog_dir = catalog_directory()
   let #(cat_effects, cat_module_effects, cat_params, cat_type_fields) =
     load_catalog(catalog_dir, "manifest.toml")
   KnowledgeBase(
@@ -1999,18 +1999,29 @@ fn load_dependencies(
 // directory, selecting the best version per installed package against the
 // manifest, and folding the selected files into effect maps.
 
-// The resolved bundled-catalog directory (see `find_catalog_directory`).
+// The resolved bundled-catalog directory for a caller that reads the catalog
+// alongside everything else it resolves against. When no candidate exists, warn
+// and return the cwd-relative default — an empty catalog collapses every
+// catalogued call to `[Unknown]`, so the degradation is surfaced instead of
+// silent.
 pub fn catalog_directory() -> String {
-  find_catalog_directory()
+  case find_catalog_directory() {
+    Ok(directory) -> directory
+    Error(_candidates) -> {
+      io.println_error(
+        "graded: warning: catalog directory not found; catalogued calls will resolve to [Unknown]",
+      )
+      "priv/catalog"
+    }
+  }
 }
 
-// Resolve graded's bundled `priv/catalog`. The install location (via
-// `code:priv_dir`) is tried first so the catalog is found regardless of the
-// process's working directory; the cwd-relative layouts follow as a fallback.
-// When no candidate exists, warn and return the cwd-relative default — an empty
-// catalog collapses every catalogued call to `[Unknown]`, so the degradation is
-// surfaced instead of silent.
-fn find_catalog_directory() -> String {
+// Resolve graded's bundled `priv/catalog`, or return the candidate paths tried.
+// The install location (via `code:priv_dir`) is tried first so the catalog is
+// found regardless of the process's working directory; the cwd-relative layouts
+// follow as a fallback. A caller for which the catalog directory is the subject
+// reports the candidates rather than reading a path that was never a catalog.
+pub fn find_catalog_directory() -> Result(String, List(String)) {
   let cwd_relative = ["build/packages/graded/priv/catalog", "priv/catalog"]
   // The install-location candidate (anchored on graded's own priv) is tried
   // ahead of the cwd-relative ones; absent when the priv directory can't be
@@ -2019,15 +2030,8 @@ fn find_catalog_directory() -> String {
     Ok(priv) -> [filepath.join(priv, "catalog"), ..cwd_relative]
     Error(Nil) -> cwd_relative
   }
-  case list.find(candidates, is_existing_directory) {
-    Ok(directory) -> directory
-    Error(Nil) -> {
-      io.println_error(
-        "graded: warning: catalog directory not found; catalogued calls will resolve to [Unknown]",
-      )
-      "priv/catalog"
-    }
-  }
+  list.find(candidates, is_existing_directory)
+  |> result.replace_error(candidates)
 }
 
 fn is_existing_directory(path: String) -> Bool {

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -2178,13 +2178,8 @@ pub fn bundled_catalog_files(
   paths
   |> list.filter(fn(path) { string.ends_with(path, ".graded") })
   |> list.filter_map(fn(path) {
-    let filename =
-      path
-      |> string.split("/")
-      |> list.last()
-      |> result.unwrap("")
-      |> string.replace(".graded", "")
-    case string.split(filename, "@") {
+    let name = path |> filepath.base_name |> filepath.strip_extension
+    case string.split(name, "@") {
       [package, version] ->
         Ok(CatalogFile(package:, version:, parsed: parse_semver(version), path:))
       _ -> Error(Nil)
@@ -2192,18 +2187,35 @@ pub fn bundled_catalog_files(
   })
 }
 
-// The file `package` resolves to for its `installed` version: the highest
-// bundled version at or below it, else the highest bundled. Ties are broken by
-// input order; the release lint guarantees bundled files never tie.
+// Which rule chose a package's catalog file. Both variants carry it as `file`,
+// so a caller that only wants the file reads that field and ignores the rule.
+pub type CatalogSelection {
+  // A bundled version at or below the installed one, the highest such.
+  Selected(file: CatalogFile)
+  // Nothing bundled sits at or below the installed version, so the highest
+  // bundled one stands in.
+  HighestBundled(file: CatalogFile)
+}
+
+// The file `package` resolves to for its `installed` version, and which of the
+// two rules chose it. Ties are broken by input order; the release lint
+// guarantees bundled files never tie.
 pub fn select_catalog_file(
   files: List(CatalogFile),
   package: String,
   installed: String,
-) -> Result(CatalogFile, Nil) {
-  files
-  |> list.filter(fn(file) { file.package == package })
-  |> list.map(fn(file) { #(file.parsed, file) })
-  |> pick_best_version(parse_semver(installed))
+) -> Result(CatalogSelection, Nil) {
+  let installed = parse_semver(installed)
+  use file <- result.map(
+    files
+    |> list.filter(fn(file) { file.package == package })
+    |> list.map(fn(file) { #(file.parsed, file) })
+    |> pick_best_version(installed),
+  )
+  case semver_lte(file.parsed, installed) {
+    True -> Selected(file)
+    False -> HighestBundled(file)
+  }
 }
 
 // Each selected file as `#(package, path)`: the package name the catalog's
@@ -2226,7 +2238,7 @@ fn resolve_catalog_files(
       Error(Nil) -> selected
       Ok(installed) ->
         case select_catalog_file(files, package, installed) {
-          Ok(file) -> [#(package, file.path), ..selected]
+          Ok(selection) -> [#(package, selection.file.path), ..selected]
           Error(Nil) -> selected
         }
     }

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -2321,33 +2321,38 @@ pub fn compare_semver(
 }
 
 // The installed version of each package `manifest_path` lists. An unreadable
-// or malformed manifest yields an empty dict.
+// or malformed manifest yields an empty dict, which reads as a project with no
+// dependencies installed; a caller for which the manifest is the subject calls
+// `read_manifest_versions` and tells the two apart.
 pub fn manifest_versions(manifest_path: String) -> Dict(String, String) {
-  let parsed = {
-    use content <- result.try(
-      simplifile.read(manifest_path) |> result.map_error(fn(_) { Nil }),
-    )
-    use toml <- result.try(
-      tom.parse(content) |> result.map_error(fn(_) { Nil }),
-    )
-    use packages <- result.try(
-      tom.get_array(toml, ["packages"]) |> result.map_error(fn(_) { Nil }),
-    )
-    Ok(
-      list.fold(packages, dict.new(), fn(accumulator, package) {
-        case package {
-          tom.InlineTable(table) ->
-            case
-              tom.get_string(table, ["name"]),
-              tom.get_string(table, ["version"])
-            {
-              Ok(name), Ok(version) -> dict.insert(accumulator, name, version)
-              _, _ -> accumulator
-            }
-          _ -> accumulator
-        }
-      }),
-    )
-  }
-  result.unwrap(parsed, dict.new())
+  read_manifest_versions(manifest_path) |> result.unwrap(dict.new())
+}
+
+// The installed version of each package `manifest_path` lists, or `Error(Nil)`
+// where there is no manifest to read or its TOML does not parse.
+pub fn read_manifest_versions(
+  manifest_path: String,
+) -> Result(Dict(String, String), Nil) {
+  use content <- result.try(
+    simplifile.read(manifest_path) |> result.map_error(fn(_) { Nil }),
+  )
+  use toml <- result.try(tom.parse(content) |> result.map_error(fn(_) { Nil }))
+  use packages <- result.try(
+    tom.get_array(toml, ["packages"]) |> result.map_error(fn(_) { Nil }),
+  )
+  Ok(
+    list.fold(packages, dict.new(), fn(accumulator, package) {
+      case package {
+        tom.InlineTable(table) ->
+          case
+            tom.get_string(table, ["name"]),
+            tom.get_string(table, ["version"])
+          {
+            Ok(name), Ok(version) -> dict.insert(accumulator, name, version)
+            _, _ -> accumulator
+          }
+        _ -> accumulator
+      }
+    }),
+  )
 }

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -2154,9 +2154,10 @@ fn fold_catalog_file(acc: CatalogAcc, entry: #(String, String)) -> CatalogAcc {
 }
 
 // One bundled catalog file, as its `{package}@{version}.graded` name reads. The
-// raw `version` string is what a caller prints; `parsed` is what selection and
-// sorting compare, and drops anything `parse_semver` does not read (`1.2.0-rc1`
-// parses to `#(1, 2, 0)`).
+// raw `version` string is what a caller prints; `parsed` is the
+// `major.minor.patch` prefix `parse_semver` reads off it, which selection and
+// sorting compare and which drops any pre-release or build suffix
+// (`1.2.0-rc.1` parses to `#(1, 2, 0)`).
 pub type CatalogFile {
   CatalogFile(
     package: String,
@@ -2266,11 +2267,12 @@ pub fn pick_best_version(
   }
 }
 
-// Parse a `major.minor.patch` string into a comparable tuple. Non-numeric
-// components (e.g. a `-rc1` suffix) parse as `0`, so `1.2.0-rc1` reads as
-// `#(1, 2, 0)`.
+// Parse a version string into the comparable `major.minor.patch` tuple it
+// starts with. A pre-release or build suffix is dropped before the components
+// are read, so `1.2.0-rc.1` and `1.2.0+build.5` both read as `#(1, 2, 0)`. A
+// version that names no numeric components reads as `#(0, 0, 0)`.
 pub fn parse_semver(version: String) -> #(Int, Int, Int) {
-  case string.split(version, ".") {
+  case string.split(version_core(version), ".") {
     [major, minor, patch] -> #(
       int.parse(major) |> result.unwrap(0),
       int.parse(minor) |> result.unwrap(0),
@@ -2282,6 +2284,20 @@ pub fn parse_semver(version: String) -> #(Int, Int, Int) {
       0,
     )
     _ -> #(0, 0, 0)
+  }
+}
+
+// The `major.minor.patch` prefix of a version: everything before the first `-`
+// or `+`, which start the pre-release and build suffixes semver orders
+// separately.
+fn version_core(version: String) -> String {
+  version |> take_before("-") |> take_before("+")
+}
+
+fn take_before(text: String, marker: String) -> String {
+  case string.split_once(text, marker) {
+    Ok(#(prefix, _rest)) -> prefix
+    Error(Nil) -> text
   }
 }
 

--- a/test/catalog_cli_test.gleam
+++ b/test/catalog_cli_test.gleam
@@ -125,14 +125,34 @@ pub fn the_listing_marks_the_fall_back_as_such_test() {
 }
 
 pub fn the_listing_without_a_manifest_test() {
-  // The listing is about the catalog; the manifest only decorates it.
+  // The listing is about the catalog; the manifest only decorates it. Nothing
+  // is marked, and the first line says why — plain lines alone would read as a
+  // project none of the bundled files covers.
   use catalog_dir, manifest <- with_catalog(
     "build/catalog_cli_listing_no_manifest",
     None,
   )
   catalog_report(catalog_dir, manifest, cli.ListCatalog)
   |> lines
-  |> should.equal(["argv@1.1.0", "lustre@4.0.0", "lustre@5.0.0"])
+  |> should.equal([
+    "// no readable manifest.toml at build/catalog_cli_listing_no_manifest/manifest.toml",
+    "argv@1.1.0", "lustre@4.0.0", "lustre@5.0.0",
+  ])
+}
+
+pub fn the_listing_with_a_malformed_manifest_test() {
+  // A manifest whose TOML does not parse lists no versions, which is the same
+  // answer as no manifest at all and gets the same line.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_listing_bad_manifest",
+    Some("packages = [\n"),
+  )
+  catalog_report(catalog_dir, manifest, cli.ListCatalog)
+  |> lines
+  |> should.equal([
+    "// no readable manifest.toml at build/catalog_cli_listing_bad_manifest/manifest.toml",
+    "argv@1.1.0", "lustre@4.0.0", "lustre@5.0.0",
+  ])
 }
 
 // Printing one file
@@ -300,6 +320,32 @@ pub fn the_suggested_version_is_the_highest_bundled_test() {
   |> should.equal(
     "`lustre` is not in manifest.toml; bundled: lustre@4.0.0, lustre@5.0.0 — run `graded catalog lustre@5.0.0` to print one",
   )
+}
+
+pub fn a_bundled_package_with_no_manifest_to_read_test() {
+  // No manifest is not "the package is not installed": nothing was consulted,
+  // so the message names the file that was looked for.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_no_manifest",
+    None,
+  )
+  let problem = catalog_problem(catalog_dir, manifest, show("lustre", None))
+  problem |> should.equal(graded.NoManifest(manifest))
+  graded.format_catalog_problem(problem)
+  |> should.equal(
+    "no readable manifest.toml at "
+    <> manifest
+    <> "; run `gleam deps download` in that package, or name the version to print: `graded catalog <package>@<version>`",
+  )
+}
+
+pub fn a_bundled_package_with_a_malformed_manifest_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_bad_manifest",
+    Some("packages = [\n"),
+  )
+  catalog_problem(catalog_dir, manifest, show("lustre", None))
+  |> should.equal(graded.NoManifest(manifest))
 }
 
 pub fn a_package_the_catalog_does_not_bundle_test() {

--- a/test/catalog_cli_test.gleam
+++ b/test/catalog_cli_test.gleam
@@ -407,6 +407,41 @@ pub fn the_seam_prints_the_selected_bundled_file_test() {
   |> should.be_true()
 }
 
+pub fn a_directory_that_does_not_exist_is_read_and_fails_test() {
+  // Without the read the walk up to a package root falls back to the process's
+  // own project, and the command answers for a manifest the user never named.
+  graded.run_catalog(cli.ShowCatalog(
+    "gleam_stdlib",
+    None,
+    "definitely_not_a_dir",
+  ))
+  |> should.equal(
+    Error(graded.DirectoryReadError("definitely_not_a_dir", simplifile.Enoent)),
+  )
+}
+
+pub fn a_directory_inside_the_project_reads_its_manifest_test() {
+  let assert Ok(output) =
+    graded.run_catalog(cli.ShowCatalog("gleam_stdlib", None, "src/graded"))
+  output
+  |> string.contains("— selected for gleam_stdlib ")
+  |> should.be_true()
+}
+
+pub fn the_manifest_is_the_enclosing_packages_test() {
+  // The walk up from a subdirectory reaches the package root, so a listing run
+  // from one is decorated by the same manifest a run from the root reads.
+  let root =
+    support.write_fixture("build/catalog_cli_subdirectory", [
+      #("gleam.toml", "name = \"app\"\n"),
+      #("manifest.toml", manifest_for("lustre", "5.7.0")),
+      #("src/app/nested/keep.gleam", "pub fn main() -> Nil {\n  Nil\n}\n"),
+    ])
+  let manifest = graded.catalog_manifest_path(root <> "/src/app/nested")
+  support.cleanup(root)
+  manifest |> should.equal(root <> "/manifest.toml")
+}
+
 // Two files one version apart
 //
 // Bundled versions that parse alike cannot be ordered by version, so the file

--- a/test/catalog_cli_test.gleam
+++ b/test/catalog_cli_test.gleam
@@ -207,6 +207,26 @@ pub fn a_file_ending_in_two_newlines_keeps_both_test() {
   |> should.be_true()
 }
 
+pub fn a_file_ending_in_a_carriage_return_keeps_it_test() {
+  // `\r\n` is one grapheme and two bytes: only the newline is the one
+  // `println` puts back, so only the newline comes off.
+  let root =
+    support.write_fixture("build/catalog_cli_crlf", [
+      #("catalog/crlf@1.0.0.graded", "external effects crlf.run : []\r\n"),
+    ])
+  let output =
+    catalog_report(
+      root <> "/catalog",
+      "no_such_manifest.toml",
+      show("crlf", Some("1.0.0")),
+    )
+  support.cleanup(root)
+  output
+  |> should.equal(
+    "// crlf@1.0.0.graded — bundled version, as requested\nexternal effects crlf.run : []\r",
+  )
+}
+
 pub fn an_explicit_version_needs_no_manifest_test() {
   use catalog_dir, _manifest <- with_catalog(
     "build/catalog_cli_show_explicit",

--- a/test/catalog_cli_test.gleam
+++ b/test/catalog_cli_test.gleam
@@ -405,6 +405,21 @@ pub fn a_catalog_directory_that_does_not_exist_test() {
   |> should.be_error
 }
 
+pub fn no_catalog_directory_at_all_test() {
+  // The paths tried are what a user can act on; the cwd-relative default the
+  // resolver falls back to was never a catalog and naming it reads as one.
+  graded.format_catalog_problem(
+    graded.NoCatalogDirectory(["opt/graded/priv/catalog", "priv/catalog"]),
+  )
+  |> should.equal(
+    "no bundled catalog directory; looked in opt/graded/priv/catalog, priv/catalog",
+  )
+}
+
+pub fn the_bundled_catalog_directory_is_found_test() {
+  effects.find_catalog_directory() |> should.be_ok
+}
+
 pub fn a_directory_holding_no_catalog_file_test() {
   // Not graded's catalog, whichever form asked: an empty listing would read as
   // "nothing is bundled".

--- a/test/catalog_cli_test.gleam
+++ b/test/catalog_cli_test.gleam
@@ -139,20 +139,62 @@ pub fn the_listing_without_a_manifest_test() {
 // `io.println` and the output has exactly one trailing newline dropped for it.
 
 pub fn the_printed_file_is_the_header_and_the_bytes_test() {
-  use catalog_dir, manifest <- with_catalog(
+  expect_show(
     "build/catalog_cli_show",
     Some(manifest_for("lustre", "5.7.0")),
+    show("lustre", None),
+    "lustre@5.0.0.graded — selected for lustre 5.7.0 in manifest.toml",
+    lustre_five,
   )
-  let output = catalog_report(catalog_dir, manifest, show("lustre", None))
-  should.equal(
-    output <> "\n",
-    "// lustre@5.0.0.graded — selected for lustre 5.7.0 in manifest.toml\n"
-      <> newline_terminated(lustre_five),
+}
+
+pub fn the_selected_file_follows_the_installed_version_test() {
+  expect_show(
+    "build/catalog_cli_show_lower",
+    Some(manifest_for("lustre", "4.5.0")),
+    show("lustre", None),
+    "lustre@4.0.0.graded — selected for lustre 4.5.0 in manifest.toml",
+    lustre_four,
+  )
+}
+
+pub fn the_fall_back_prints_the_highest_bundled_file_test() {
+  expect_show(
+    "build/catalog_cli_show_fallback",
+    Some(manifest_for("lustre", "3.0.0")),
+    show("lustre", None),
+    "lustre@5.0.0.graded — highest bundled version; no bundled lustre ≤ 3.0.0",
+    lustre_five,
+  )
+}
+
+pub fn an_explicit_version_ignores_the_manifest_test() {
+  // The manifest installs 5.7.0, which the implicit form would resolve to the
+  // 5.0.0 file: the explicit form neither consults it nor re-selects.
+  expect_show(
+    "build/catalog_cli_show_explicit_installed",
+    Some(manifest_for("lustre", "5.7.0")),
+    show("lustre", Some("4.0.0")),
+    "lustre@4.0.0.graded — bundled version, as requested",
+    lustre_four,
+  )
+}
+
+pub fn a_file_ending_in_no_newline_gains_one_test() {
+  // `argv@1.1.0` ends in none, so `println` supplies it — the one place the
+  // printed bytes differ from the file's.
+  expect_show(
+    "build/catalog_cli_show_none",
+    Some(manifest_for("lustre", "5.7.0")),
+    show("argv", Some("1.1.0")),
+    "argv@1.1.0.graded — bundled version, as requested",
+    argv_entry,
   )
 }
 
 pub fn a_file_ending_in_two_newlines_keeps_both_test() {
-  // `lustre@5.0.0` ends in two: an over-eager trim would eat the second.
+  // `lustre@5.0.0` ends in two: an over-eager trim would eat the second, which
+  // the equation above cannot see because it appends the one `println` adds.
   use catalog_dir, manifest <- with_catalog(
     "build/catalog_cli_show_two",
     Some(manifest_for("lustre", "5.7.0")),
@@ -160,56 +202,6 @@ pub fn a_file_ending_in_two_newlines_keeps_both_test() {
   catalog_report(catalog_dir, manifest, show("lustre", Some("5.0.0")))
   |> string.ends_with("[Dom]\n")
   |> should.be_true()
-}
-
-pub fn a_file_ending_in_no_newline_gains_one_test() {
-  // `argv@1.1.0` ends in none, so `println` supplies it — the one place the
-  // printed bytes differ from the file's.
-  use catalog_dir, manifest <- with_catalog(
-    "build/catalog_cli_show_none",
-    Some(manifest_for("lustre", "5.7.0")),
-  )
-  let output =
-    catalog_report(catalog_dir, manifest, show("argv", Some("1.1.0")))
-  should.equal(
-    output <> "\n",
-    "// argv@1.1.0.graded — bundled version, as requested\n"
-      <> newline_terminated(argv_entry),
-  )
-}
-
-pub fn the_printed_file_parses_as_a_spec_test() {
-  use catalog_dir, manifest <- with_catalog(
-    "build/catalog_cli_show_parses",
-    Some(manifest_for("lustre", "5.7.0")),
-  )
-  catalog_report(catalog_dir, manifest, show("lustre", None))
-  |> annotation.parse_file
-  |> should.be_ok
-}
-
-pub fn the_selected_file_follows_the_installed_version_test() {
-  use catalog_dir, manifest <- with_catalog(
-    "build/catalog_cli_show_lower",
-    Some(manifest_for("lustre", "4.5.0")),
-  )
-  should.equal(
-    catalog_report(catalog_dir, manifest, show("lustre", None)) <> "\n",
-    "// lustre@4.0.0.graded — selected for lustre 4.5.0 in manifest.toml\n"
-      <> newline_terminated(lustre_four),
-  )
-}
-
-pub fn the_fall_back_prints_the_highest_bundled_file_test() {
-  use catalog_dir, manifest <- with_catalog(
-    "build/catalog_cli_show_fallback",
-    Some(manifest_for("lustre", "3.0.0")),
-  )
-  should.equal(
-    catalog_report(catalog_dir, manifest, show("lustre", None)) <> "\n",
-    "// lustre@5.0.0.graded — highest bundled version; no bundled lustre ≤ 3.0.0\n"
-      <> newline_terminated(lustre_five),
-  )
 }
 
 pub fn an_explicit_version_needs_no_manifest_test() {
@@ -229,17 +221,29 @@ pub fn an_explicit_version_needs_no_manifest_test() {
   )
 }
 
-pub fn an_explicit_version_ignores_the_manifest_test() {
-  // The manifest installs 5.7.0, which the implicit form would resolve to the
-  // 5.0.0 file: the explicit form neither consults it nor re-selects.
+pub fn the_printed_file_parses_as_a_spec_test() {
   use catalog_dir, manifest <- with_catalog(
-    "build/catalog_cli_show_explicit_installed",
+    "build/catalog_cli_show_parses",
     Some(manifest_for("lustre", "5.7.0")),
   )
+  catalog_report(catalog_dir, manifest, show("lustre", None))
+  |> annotation.parse_file
+  |> should.be_ok
+}
+
+// What `report` puts on stdout for `request`: the header line, then the file,
+// with the single trailing newline `io.println` appends.
+fn expect_show(
+  root: String,
+  manifest: Option(String),
+  request: cli.CatalogRequest,
+  header: String,
+  body: String,
+) -> Nil {
+  use catalog_dir, manifest <- with_catalog(root, manifest)
   should.equal(
-    catalog_report(catalog_dir, manifest, show("lustre", Some("4.0.0"))) <> "\n",
-    "// lustre@4.0.0.graded — bundled version, as requested\n"
-      <> newline_terminated(lustre_four),
+    catalog_report(catalog_dir, manifest, request) <> "\n",
+    "// " <> header <> "\n" <> newline_terminated(body),
   )
 }
 
@@ -364,15 +368,15 @@ pub fn the_seam_prints_the_selected_bundled_file_test() {
     effects.bundled_catalog_files(effects.catalog_directory())
   let assert Ok(installed) =
     dict.get(effects.manifest_versions("manifest.toml"), "gleam_stdlib")
-  let assert Ok(selected) =
+  let assert Ok(selection) =
     effects.select_catalog_file(files, "gleam_stdlib", installed)
-  let assert Ok(contents) = simplifile.read(selected.path)
+  let assert Ok(contents) = simplifile.read(selection.file.path)
   let assert Ok(output) =
     graded.run_catalog(cli.ShowCatalog("gleam_stdlib", None, "src"))
 
   output
   |> string.starts_with(
-    "// gleam_stdlib@" <> selected.version <> ".graded — selected for ",
+    "// gleam_stdlib@" <> selection.file.version <> ".graded — selected for ",
   )
   |> should.be_true()
   { output <> "\n" }

--- a/test/catalog_cli_test.gleam
+++ b/test/catalog_cli_test.gleam
@@ -7,13 +7,16 @@
 // catalog.
 
 import gleam/dict
+import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleeunit/should
 import graded
 import graded/internal/annotation
 import graded/internal/cli
+import graded/internal/effect_term
 import graded/internal/effects
+import graded/internal/types
 import simplifile
 import support
 
@@ -381,6 +384,46 @@ pub fn the_seam_prints_the_selected_bundled_file_test() {
   |> should.be_true()
   { output <> "\n" }
   |> string.ends_with("\n" <> newline_terminated(contents))
+  |> should.be_true()
+}
+
+// Two files one version apart
+//
+// Bundled versions that parse alike cannot be ordered by version, so the file
+// the command names and the file the resolver folds have to be settled by
+// something both share.
+
+pub fn a_tie_selects_one_file_for_both_paths_test() {
+  let root =
+    support.write_fixture("build/catalog_cli_tie", [
+      #("catalog/foo@1.0.0.graded", "external effects foo/x.run : [Release]\n"),
+      #(
+        "catalog/foo@1.0.0-rc1.graded",
+        "external effects foo/x.run : [Prerelease]\n",
+      ),
+      #("manifest.toml", manifest_for("foo", "1.0.0")),
+    ])
+  let printed =
+    catalog_report(
+      root <> "/catalog",
+      root <> "/manifest.toml",
+      show("foo", None),
+    )
+  let #(function_effects, _module_effects, _params, _type_fields) =
+    effects.load_catalog(root <> "/catalog", root <> "/manifest.toml")
+  support.cleanup(root)
+
+  // Each file declares the same function with an effect only it names, so the
+  // effect the knowledge base answers with says which file the resolver folded.
+  let assert Ok(#(term, _origin)) =
+    dict.get(function_effects, types.QualifiedName("foo/x", "run"))
+  let assert Ok(resolved) =
+    ["Release", "Prerelease"]
+    |> list.find(fn(label) {
+      effect_term.to_effect_set(term) == types.from_labels([label])
+    })
+  printed
+  |> string.contains("[" <> resolved <> "]")
   |> should.be_true()
 }
 

--- a/test/catalog_cli_test.gleam
+++ b/test/catalog_cli_test.gleam
@@ -1,0 +1,467 @@
+// The `catalog` command
+//
+// Decoding its argument forms, the listing and its per-package suffixes, the
+// bytes and header one printed file carries, and every way the command can fail
+// to answer. The report tests run against a fixture catalog written under
+// `build/`; the last section goes through the seam against graded's own bundled
+// catalog.
+
+import gleam/dict
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import gleeunit/should
+import graded
+import graded/internal/annotation
+import graded/internal/cli
+import graded/internal/effects
+import simplifile
+import support
+
+// Argument decoding
+//
+// `[package[@version]] [directory]`, package first: a lone argument is always a
+// package, and `@` splits it from a version at its first occurrence.
+
+pub fn no_arguments_list_the_catalog_test() {
+  cli.parse_catalog_args([])
+  |> should.equal(Ok(cli.ListCatalog))
+}
+
+pub fn a_package_alone_takes_the_default_directory_test() {
+  cli.parse_catalog_args(["lustre"])
+  |> should.equal(Ok(cli.ShowCatalog("lustre", None, "src")))
+}
+
+pub fn a_package_at_a_version_with_a_directory_test() {
+  cli.parse_catalog_args(["lustre@5.0.0", "app"])
+  |> should.equal(Ok(cli.ShowCatalog("lustre", Some("5.0.0"), "app")))
+}
+
+pub fn a_version_carrying_its_own_at_sign_test() {
+  // The split is on the first `@`, so the rest is the version — which the
+  // catalog then has no file for, rather than the argument being a usage error.
+  cli.parse_catalog_args(["lustre@5@x"])
+  |> should.equal(Ok(cli.ShowCatalog("lustre", Some("5@x"), "src")))
+}
+
+pub fn an_empty_version_is_a_usage_error_test() {
+  cli.parse_catalog_args(["lustre@"])
+  |> should.equal(Error(cli.InvalidPackage("lustre@")))
+}
+
+pub fn an_empty_package_is_a_usage_error_test() {
+  cli.parse_catalog_args(["@5.0.0"])
+  |> should.equal(Error(cli.InvalidPackage("@5.0.0")))
+}
+
+pub fn a_flag_in_the_package_position_is_an_unknown_option_test() {
+  cli.parse_catalog_args(["--x"])
+  |> should.equal(Error(cli.UnknownOption("--x")))
+}
+
+pub fn a_third_positional_is_rejected_test() {
+  cli.parse_catalog_args(["lustre", "a", "b"])
+  |> should.equal(Error(cli.UnexpectedArgument("b")))
+}
+
+pub fn the_rejection_messages_test() {
+  cli.format_argument_error(cli.InvalidPackage("lustre@"))
+  |> should.equal("expected a package or package@version, got `lustre@`")
+  cli.format_argument_error(cli.UnknownOption("--x"))
+  |> should.equal("unknown option `--x`")
+  cli.format_argument_error(cli.UnexpectedArgument("b"))
+  |> should.equal("unexpected argument `b`")
+}
+
+// The listing
+//
+// One `package@version` line per bundled file, sorted, with a comment on the
+// line each installed package resolves to. All three suffix shapes come out of
+// the same three files under three manifests.
+
+pub fn the_listing_marks_the_selected_file_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_listing",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  catalog_report(catalog_dir, manifest, cli.ListCatalog)
+  |> lines
+  |> should.equal([
+    "argv@1.1.0", "lustre@4.0.0", "lustre@5.0.0  // selected for lustre 5.7.0",
+  ])
+}
+
+pub fn the_listing_marks_a_file_below_the_highest_test() {
+  // Installed between the two bundled versions: the lower file is the one
+  // selected, so the suffix lands there and nowhere else.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_listing_lower",
+    Some(manifest_for("lustre", "4.5.0")),
+  )
+  catalog_report(catalog_dir, manifest, cli.ListCatalog)
+  |> lines
+  |> should.equal([
+    "argv@1.1.0", "lustre@4.0.0  // selected for lustre 4.5.0", "lustre@5.0.0",
+  ])
+}
+
+pub fn the_listing_marks_the_fall_back_as_such_test() {
+  // Nothing bundled at or below the installed version, so the highest file is
+  // taken — and says so, rather than claiming to be selected for a version it
+  // sits above.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_listing_fallback",
+    Some(manifest_for("lustre", "3.0.0")),
+  )
+  catalog_report(catalog_dir, manifest, cli.ListCatalog)
+  |> lines
+  |> should.equal([
+    "argv@1.1.0", "lustre@4.0.0",
+    "lustre@5.0.0  // highest bundled; none ≤ lustre 3.0.0",
+  ])
+}
+
+pub fn the_listing_without_a_manifest_test() {
+  // The listing is about the catalog; the manifest only decorates it.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_listing_no_manifest",
+    None,
+  )
+  catalog_report(catalog_dir, manifest, cli.ListCatalog)
+  |> lines
+  |> should.equal(["argv@1.1.0", "lustre@4.0.0", "lustre@5.0.0"])
+}
+
+// Printing one file
+//
+// The header names the file and why it was chosen; the rest is the file. What
+// reaches stdout is `header <> "\n" <> file bytes`, since `report` prints with
+// `io.println` and the output has exactly one trailing newline dropped for it.
+
+pub fn the_printed_file_is_the_header_and_the_bytes_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  let output = catalog_report(catalog_dir, manifest, show("lustre", None))
+  should.equal(
+    output <> "\n",
+    "// lustre@5.0.0.graded — selected for lustre 5.7.0 in manifest.toml\n"
+      <> newline_terminated(lustre_five),
+  )
+}
+
+pub fn a_file_ending_in_two_newlines_keeps_both_test() {
+  // `lustre@5.0.0` ends in two: an over-eager trim would eat the second.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_two",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  catalog_report(catalog_dir, manifest, show("lustre", Some("5.0.0")))
+  |> string.ends_with("[Dom]\n")
+  |> should.be_true()
+}
+
+pub fn a_file_ending_in_no_newline_gains_one_test() {
+  // `argv@1.1.0` ends in none, so `println` supplies it — the one place the
+  // printed bytes differ from the file's.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_none",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  let output =
+    catalog_report(catalog_dir, manifest, show("argv", Some("1.1.0")))
+  should.equal(
+    output <> "\n",
+    "// argv@1.1.0.graded — bundled version, as requested\n"
+      <> newline_terminated(argv_entry),
+  )
+}
+
+pub fn the_printed_file_parses_as_a_spec_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_parses",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  catalog_report(catalog_dir, manifest, show("lustre", None))
+  |> annotation.parse_file
+  |> should.be_ok
+}
+
+pub fn the_selected_file_follows_the_installed_version_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_lower",
+    Some(manifest_for("lustre", "4.5.0")),
+  )
+  should.equal(
+    catalog_report(catalog_dir, manifest, show("lustre", None)) <> "\n",
+    "// lustre@4.0.0.graded — selected for lustre 4.5.0 in manifest.toml\n"
+      <> newline_terminated(lustre_four),
+  )
+}
+
+pub fn the_fall_back_prints_the_highest_bundled_file_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_fallback",
+    Some(manifest_for("lustre", "3.0.0")),
+  )
+  should.equal(
+    catalog_report(catalog_dir, manifest, show("lustre", None)) <> "\n",
+    "// lustre@5.0.0.graded — highest bundled version; no bundled lustre ≤ 3.0.0\n"
+      <> newline_terminated(lustre_five),
+  )
+}
+
+pub fn an_explicit_version_needs_no_manifest_test() {
+  use catalog_dir, _manifest <- with_catalog(
+    "build/catalog_cli_show_explicit",
+    None,
+  )
+  should.equal(
+    catalog_report(
+      catalog_dir,
+      "no_such_manifest.toml",
+      show("lustre", Some("4.0.0")),
+    )
+      <> "\n",
+    "// lustre@4.0.0.graded — bundled version, as requested\n"
+      <> newline_terminated(lustre_four),
+  )
+}
+
+pub fn an_explicit_version_ignores_the_manifest_test() {
+  // The manifest installs 5.7.0, which the implicit form would resolve to the
+  // 5.0.0 file: the explicit form neither consults it nor re-selects.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_show_explicit_installed",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  should.equal(
+    catalog_report(catalog_dir, manifest, show("lustre", Some("4.0.0"))) <> "\n",
+    "// lustre@4.0.0.graded — bundled version, as requested\n"
+      <> newline_terminated(lustre_four),
+  )
+}
+
+// Why the command could not answer
+//
+// The catalog is consulted before the manifest, so a package with no bundled
+// file is `NoCatalogEntry` whether or not it is installed — and every other
+// problem has a non-empty list of bundled versions to name.
+
+pub fn a_bundled_package_that_is_not_installed_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_not_installed",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  let problem = catalog_problem(catalog_dir, manifest, show("argv", None))
+  problem
+  |> should.equal(graded.NotInstalled("argv", ["argv@1.1.0"]))
+  graded.format_catalog_problem(problem)
+  |> should.equal(
+    "`argv` is not in manifest.toml; bundled: argv@1.1.0 — run `graded catalog argv@1.1.0` to print one",
+  )
+}
+
+pub fn the_suggested_version_is_the_highest_bundled_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_not_installed_highest",
+    Some(manifest_for("argv", "1.1.0")),
+  )
+  catalog_problem(catalog_dir, manifest, show("lustre", None))
+  |> graded.format_catalog_problem
+  |> should.equal(
+    "`lustre` is not in manifest.toml; bundled: lustre@4.0.0, lustre@5.0.0 — run `graded catalog lustre@5.0.0` to print one",
+  )
+}
+
+pub fn a_package_the_catalog_does_not_bundle_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_no_entry",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  let problem = catalog_problem(catalog_dir, manifest, show("wisp", None))
+  problem |> should.equal(graded.NoCatalogEntry("wisp"))
+  graded.format_catalog_problem(problem)
+  |> should.equal("no catalog entry for `wisp`")
+}
+
+pub fn an_installed_package_the_catalog_does_not_bundle_test() {
+  // The check order: the catalog is asked first, so being installed does not
+  // turn a missing entry into `NotInstalled`.
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_no_entry_installed",
+    Some(manifest_for("wisp", "1.0.0")),
+  )
+  catalog_problem(catalog_dir, manifest, show("wisp", None))
+  |> should.equal(graded.NoCatalogEntry("wisp"))
+}
+
+pub fn an_explicit_version_of_an_unbundled_package_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_no_entry_explicit",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  catalog_problem(catalog_dir, manifest, show("wisp", Some("1.0.0")))
+  |> should.equal(graded.NoCatalogEntry("wisp"))
+}
+
+pub fn a_version_the_catalog_does_not_bundle_test() {
+  use catalog_dir, manifest <- with_catalog(
+    "build/catalog_cli_no_version",
+    Some(manifest_for("lustre", "5.7.0")),
+  )
+  let problem =
+    catalog_problem(catalog_dir, manifest, show("lustre", Some("3.0.0")))
+  problem
+  |> should.equal(
+    graded.NoBundledVersion("lustre", "3.0.0", ["lustre@4.0.0", "lustre@5.0.0"]),
+  )
+  graded.format_catalog_problem(problem)
+  |> should.equal(
+    "no bundled `lustre@3.0.0`; bundled: lustre@4.0.0, lustre@5.0.0",
+  )
+}
+
+pub fn a_catalog_directory_that_does_not_exist_test() {
+  graded.catalog_report(
+    "build/catalog_cli_missing",
+    "no_such_manifest.toml",
+    cli.ListCatalog,
+  )
+  |> should.be_error
+}
+
+pub fn a_directory_holding_no_catalog_file_test() {
+  // Not graded's catalog, whichever form asked: an empty listing would read as
+  // "nothing is bundled".
+  let root =
+    support.write_fixture("build/catalog_cli_empty", [
+      #("catalog/README", "not a catalog file\n"),
+    ])
+  let catalog_dir = root <> "/catalog"
+  let empty = graded.CatalogError(graded.EmptyCatalog(catalog_dir))
+  graded.catalog_report(catalog_dir, "no_such_manifest.toml", cli.ListCatalog)
+  |> should.equal(Error(empty))
+  graded.catalog_report(
+    catalog_dir,
+    "no_such_manifest.toml",
+    show("lustre", None),
+  )
+  |> should.equal(Error(empty))
+  graded.format_catalog_problem(graded.EmptyCatalog(catalog_dir))
+  |> should.equal("no catalog files under " <> catalog_dir)
+  support.cleanup(root)
+}
+
+// Through the seam
+//
+// `run_catalog` against graded's own bundled catalog and this project's
+// manifest: what the command prints is the file the catalog tier folded.
+
+pub fn the_seam_prints_the_selected_bundled_file_test() {
+  let assert Ok(files) =
+    effects.bundled_catalog_files(effects.catalog_directory())
+  let assert Ok(installed) =
+    dict.get(effects.manifest_versions("manifest.toml"), "gleam_stdlib")
+  let assert Ok(selected) =
+    effects.select_catalog_file(files, "gleam_stdlib", installed)
+  let assert Ok(contents) = simplifile.read(selected.path)
+  let assert Ok(output) =
+    graded.run_catalog(cli.ShowCatalog("gleam_stdlib", None, "src"))
+
+  output
+  |> string.starts_with(
+    "// gleam_stdlib@" <> selected.version <> ".graded — selected for ",
+  )
+  |> should.be_true()
+  { output <> "\n" }
+  |> string.ends_with("\n" <> newline_terminated(contents))
+  |> should.be_true()
+}
+
+// Fixtures
+//
+// One catalog of three files under two packages, whose contents differ and
+// whose trailing newlines are none, one and two — the counts the printed-bytes
+// equation has to hold for.
+
+const argv_entry = "external effects argv.load : [Args]
+external effects argv.raw : [Args]"
+
+const lustre_four = "external effects lustre/four.build : []
+external effects lustre/four.render : [Dom]
+"
+
+const lustre_five = "external effects lustre/five.build : []
+external effects lustre/five.render : [Dom]
+
+"
+
+// Write the fixture catalog (and, where one is given, a manifest) under `root`,
+// hand `run` the two paths `catalog_report` takes, and delete the fixture.
+fn with_catalog(
+  root: String,
+  manifest: Option(String),
+  run: fn(String, String) -> a,
+) -> a {
+  let catalog = [
+    #("catalog/argv@1.1.0.graded", argv_entry),
+    #("catalog/lustre@4.0.0.graded", lustre_four),
+    #("catalog/lustre@5.0.0.graded", lustre_five),
+  ]
+  let files = case manifest {
+    Some(contents) -> [#("manifest.toml", contents), ..catalog]
+    None -> catalog
+  }
+  let root = support.write_fixture(root, files)
+  let output = run(root <> "/catalog", root <> "/manifest.toml")
+  support.cleanup(root)
+  output
+}
+
+fn manifest_for(package: String, version: String) -> String {
+  "packages = [\n  { name = \""
+  <> package
+  <> "\", version = \""
+  <> version
+  <> "\" },\n]\n"
+}
+
+fn show(package: String, version: Option(String)) -> cli.CatalogRequest {
+  cli.ShowCatalog(package:, version:, directory: "src")
+}
+
+// The report a request is expected to answer with.
+fn catalog_report(
+  catalog_dir: String,
+  manifest: String,
+  request: cli.CatalogRequest,
+) -> String {
+  let assert Ok(output) = graded.catalog_report(catalog_dir, manifest, request)
+  output
+}
+
+// The problem a request is expected to fail with.
+fn catalog_problem(
+  catalog_dir: String,
+  manifest: String,
+  request: cli.CatalogRequest,
+) -> graded.CatalogProblem {
+  let assert Error(graded.CatalogError(problem)) =
+    graded.catalog_report(catalog_dir, manifest, request)
+  problem
+}
+
+fn lines(output: String) -> List(String) {
+  string.split(output, "\n")
+}
+
+// `text` with the single trailing newline `io.println` supplies, whether or not
+// it already ends in one.
+fn newline_terminated(text: String) -> String {
+  case string.ends_with(text, "\n") {
+    True -> text
+    False -> text <> "\n"
+  }
+}

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -1156,8 +1156,85 @@ pub fn a_source_inferred_path_dep_yields_to_the_catalog_test() {
 
 // Catalog version selection
 //
-// pick_best_version returns an eligible entry (at or below the installed
-// version) whenever one exists.
+// Reading the bundled `{package}@{version}.graded` names off disk, and picking
+// the file a package's installed version resolves to: an eligible entry (at or
+// below the installed version) whenever one exists, else the highest bundled.
+
+// The three-file catalog the selection tests below select from, plus a name
+// that carries no version and is skipped.
+fn catalog_fixture(root: String) -> List(effects.CatalogFile) {
+  let root =
+    write_fixture(root, [
+      #("lustre@4.0.0.graded", "effects lustre/x.a : []\n"),
+      #("lustre@5.0.0.graded", "effects lustre/x.a : []\n"),
+      #("argv@1.1.0.graded", "effects argv.load : []\n"),
+      #("README", "not a catalog file\n"),
+    ])
+  let assert Ok(files) = effects.bundled_catalog_files(root)
+  cleanup(root)
+  files
+}
+
+// Catalog files by `package@version`, so an assertion does not depend on the
+// order the directory walk returns them in.
+fn file_labels(files: List(effects.CatalogFile)) -> List(String) {
+  files
+  |> list.map(fn(file) { file.package <> "@" <> file.version })
+  |> list.sort(string.compare)
+}
+
+pub fn bundled_catalog_files_reads_the_versioned_names_test() {
+  catalog_fixture("build/eff_catalog_listing")
+  |> file_labels
+  |> should.equal(["argv@1.1.0", "lustre@4.0.0", "lustre@5.0.0"])
+}
+
+pub fn bundled_catalog_files_keeps_the_raw_version_string_test() {
+  // `parse_semver` reads `1.2.0-rc1` as `#(1, 2, 0)`; the raw string is what a
+  // caller prints, so both survive side by side.
+  let root =
+    write_fixture("build/eff_catalog_prerelease", [
+      #("beta@1.2.0-rc1.graded", "effects beta.run : []\n"),
+    ])
+  let assert Ok(files) = effects.bundled_catalog_files(root)
+  cleanup(root)
+  files
+  |> list.map(fn(file) { #(file.package, file.version, file.parsed) })
+  |> should.equal([#("beta", "1.2.0-rc1", #(1, 2, 0))])
+}
+
+pub fn bundled_catalog_files_reports_an_unreadable_directory_test() {
+  effects.bundled_catalog_files("build/eff_catalog_missing")
+  |> result.is_error
+  |> should.be_true()
+}
+
+pub fn select_catalog_file_picks_the_highest_at_or_below_installed_test() {
+  let files = catalog_fixture("build/eff_catalog_select")
+  effects.select_catalog_file(files, "lustre", "5.7.0")
+  |> result.map(fn(file) { file.version })
+  |> should.equal(Ok("5.0.0"))
+  // Below the highest bundled file: the lower one is the eligible pick, which
+  // is what tells "highest ≤ installed" apart from "highest bundled".
+  effects.select_catalog_file(files, "lustre", "4.5.0")
+  |> result.map(fn(file) { file.version })
+  |> should.equal(Ok("4.0.0"))
+}
+
+pub fn select_catalog_file_falls_back_to_the_highest_bundled_test() {
+  // Nothing bundled at or below 3.0.0, so the fall-back is the highest file,
+  // not the lowest.
+  catalog_fixture("build/eff_catalog_select_fallback")
+  |> effects.select_catalog_file("lustre", "3.0.0")
+  |> result.map(fn(file) { file.version })
+  |> should.equal(Ok("5.0.0"))
+}
+
+pub fn select_catalog_file_without_a_file_for_the_package_test() {
+  catalog_fixture("build/eff_catalog_select_absent")
+  |> effects.select_catalog_file("wisp", "1.0.0")
+  |> should.equal(Error(Nil))
+}
 
 pub fn pick_best_version_eligible_test() {
   use #(versions, installed) <- qcheck.given(

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -1279,13 +1279,19 @@ pub fn pick_best_version_eligible_test() {
     ),
   )
   case effects.pick_best_version(versions, installed) {
-    Ok(label) -> {
-      let assert Ok(picked) = list.find(versions, fn(v) { v.1 == label })
+    Ok(pick) -> {
+      let assert Ok(picked) = list.find(versions, fn(v) { v.1 == pick.value })
       let has_eligible =
         list.any(versions, fn(v) { effects.semver_lte(v.0, installed) })
-      case has_eligible {
-        True -> effects.semver_lte(picked.0, installed) |> should.be_true()
-        False -> Nil
+      // The rule the pick reports is the rule that fired, so a caller
+      // rendering it says what the pick actually did.
+      case has_eligible, pick {
+        True, effects.AtOrBelowInstalled(_) ->
+          effects.semver_lte(picked.0, installed) |> should.be_true()
+        False, effects.HighestAvailable(_) -> Nil
+        True, effects.HighestAvailable(_)
+        | False, effects.AtOrBelowInstalled(_)
+        -> should.fail()
       }
     }
     Error(Nil) -> Nil

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -1212,22 +1212,38 @@ pub fn bundled_catalog_files_reports_an_unreadable_directory_test() {
 pub fn select_catalog_file_picks_the_highest_at_or_below_installed_test() {
   let files = catalog_fixture("build/eff_catalog_select")
   effects.select_catalog_file(files, "lustre", "5.7.0")
-  |> result.map(fn(file) { file.version })
-  |> should.equal(Ok("5.0.0"))
+  |> selected_version
+  |> should.equal(Ok(#("5.0.0", Eligible)))
   // Below the highest bundled file: the lower one is the eligible pick, which
   // is what tells "highest ≤ installed" apart from "highest bundled".
   effects.select_catalog_file(files, "lustre", "4.5.0")
-  |> result.map(fn(file) { file.version })
-  |> should.equal(Ok("4.0.0"))
+  |> selected_version
+  |> should.equal(Ok(#("4.0.0", Eligible)))
 }
 
 pub fn select_catalog_file_falls_back_to_the_highest_bundled_test() {
   // Nothing bundled at or below 3.0.0, so the fall-back is the highest file,
-  // not the lowest.
+  // not the lowest — and the selection says which rule it was.
   catalog_fixture("build/eff_catalog_select_fallback")
   |> effects.select_catalog_file("lustre", "3.0.0")
-  |> result.map(fn(file) { file.version })
-  |> should.equal(Ok("5.0.0"))
+  |> selected_version
+  |> should.equal(Ok(#("5.0.0", FellBack)))
+}
+
+// Which rule a selection reports, as a value an assertion can name.
+type SelectionRule {
+  Eligible
+  FellBack
+}
+
+fn selected_version(
+  selection: Result(effects.CatalogSelection, Nil),
+) -> Result(#(String, SelectionRule), Nil) {
+  use selection <- result.map(selection)
+  case selection {
+    effects.Selected(file) -> #(file.version, Eligible)
+    effects.HighestBundled(file) -> #(file.version, FellBack)
+  }
 }
 
 pub fn select_catalog_file_without_a_file_for_the_package_test() {

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -401,6 +401,20 @@ pub fn parse_semver_roundtrip_test() {
   reparsed |> should.equal(s)
 }
 
+pub fn parse_semver_reads_the_version_before_its_suffix_test() {
+  // A pre-release or build suffix orders separately in semver and carries no
+  // `major.minor.patch` of its own, so the components are read off the prefix
+  // that does — a version whose suffix is dotted included.
+  effects.parse_semver("1.2.0") |> should.equal(#(1, 2, 0))
+  effects.parse_semver("4.2.0-rc.1") |> should.equal(#(4, 2, 0))
+  effects.parse_semver("1.2.0+build.5") |> should.equal(#(1, 2, 0))
+  effects.parse_semver("1.2.0-rc.1+build.5") |> should.equal(#(1, 2, 0))
+}
+
+pub fn parse_semver_without_numeric_components_test() {
+  effects.parse_semver("latest") |> should.equal(#(0, 0, 0))
+}
+
 // Path dependencies
 //
 // Extracting `{ path = ... }` dependencies from gleam.toml, tolerating files

--- a/test/release_test.gleam
+++ b/test/release_test.gleam
@@ -1,15 +1,21 @@
-// Tests for the Lustre 5 catalog entries and the spec-annotation lint that
-// warns on `check`/`type` lines whose target exists nowhere in the project.
+// Tests for the Lustre 5 catalog entries, the lint over the bundled catalog's
+// own file names, and the spec-annotation lint that warns on `check`/`type`
+// lines whose target exists nowhere in the project.
 //
 // Like the topo tests, fixtures are materialised under `/tmp/` so the Gleam
-// compiler doesn't try to compile them as project modules.
+// compiler doesn't try to compile them as project modules. The file-name lint
+// is the exception: it reads the real `priv/catalog/`.
 
+import gleam/int
 import gleam/list
+import gleam/order
 import gleam/set
+import gleam/string
 import gleeunit/should
 import graded
 import graded/internal/annotation
 import graded/internal/effect_term
+import graded/internal/effects
 import graded/internal/types.{
   type EffectSet, type Warning, Specific, UnmatchedCheckWarning,
   UnmatchedTypeFieldWarning,
@@ -354,4 +360,53 @@ pub fn non_function_field_annotation_warns_test() {
     #("app.graded", "type rec.Rec.count : []\n"),
   ])
   |> expect_warning(UnmatchedTypeFieldWarning(name: "rec.Rec.count"))
+}
+
+// Bundled catalog file names
+//
+// Version selection compares `#(major, minor, patch)`, so two bundled files for
+// one package that parse to the same tuple cannot be ordered and the winner is
+// whatever order the directory walk returns.
+
+pub fn no_two_catalog_files_parse_to_one_version_test() {
+  let assert Ok(files) =
+    effects.bundled_catalog_files(effects.catalog_directory())
+  colliding_catalog_files(files) |> should.equal([])
+}
+
+// One message per pair of bundled files that parse to the same version, so a
+// failure names the files a contributor has to fix.
+fn colliding_catalog_files(files: List(effects.CatalogFile)) -> List(String) {
+  list.flat_map(files, fn(file) {
+    files
+    |> list.filter(fn(other) {
+      other.package == file.package
+      && other.parsed == file.parsed
+      && string.compare(other.path, file.path) == order.Gt
+    })
+    |> list.map(fn(other) { collision_message(file, other) })
+  })
+}
+
+fn collision_message(
+  file: effects.CatalogFile,
+  other: effects.CatalogFile,
+) -> String {
+  file.path
+  <> " and "
+  <> other.path
+  <> " both parse to "
+  <> format_version(file.parsed)
+  <> "; version selection cannot order them, so which one wins is filesystem "
+  <> "order. Give one a distinct major.minor.patch or drop it."
+}
+
+fn format_version(version: #(Int, Int, Int)) -> String {
+  "#("
+  <> int.to_string(version.0)
+  <> ", "
+  <> int.to_string(version.1)
+  <> ", "
+  <> int.to_string(version.2)
+  <> ")"
 }

--- a/test/release_test.gleam
+++ b/test/release_test.gleam
@@ -6,9 +6,8 @@
 // compiler doesn't try to compile them as project modules. The file-name lint
 // is the exception: it reads the real `priv/catalog/`.
 
-import gleam/int
+import gleam/dict
 import gleam/list
-import gleam/order
 import gleam/set
 import gleam/string
 import gleeunit/should
@@ -374,39 +373,26 @@ pub fn no_two_catalog_files_parse_to_one_version_test() {
   colliding_catalog_files(files) |> should.equal([])
 }
 
-// One message per pair of bundled files that parse to the same version, so a
+// One message per group of bundled files that parse to the same version, so a
 // failure names the files a contributor has to fix.
 fn colliding_catalog_files(files: List(effects.CatalogFile)) -> List(String) {
-  list.flat_map(files, fn(file) {
-    files
-    |> list.filter(fn(other) {
-      other.package == file.package
-      && other.parsed == file.parsed
-      && string.compare(other.path, file.path) == order.Gt
-    })
-    |> list.map(fn(other) { collision_message(file, other) })
+  files
+  |> list.group(fn(file) { #(file.package, file.parsed) })
+  |> dict.values
+  |> list.filter_map(fn(group) {
+    case group {
+      [_] | [] -> Error(Nil)
+      [_, _, ..] -> Ok(collision_message(group))
+    }
   })
 }
 
-fn collision_message(
-  file: effects.CatalogFile,
-  other: effects.CatalogFile,
-) -> String {
-  file.path
-  <> " and "
-  <> other.path
-  <> " both parse to "
-  <> format_version(file.parsed)
-  <> "; version selection cannot order them, so which one wins is filesystem "
-  <> "order. Give one a distinct major.minor.patch or drop it."
-}
-
-fn format_version(version: #(Int, Int, Int)) -> String {
-  "#("
-  <> int.to_string(version.0)
-  <> ", "
-  <> int.to_string(version.1)
-  <> ", "
-  <> int.to_string(version.2)
-  <> ")"
+fn collision_message(group: List(effects.CatalogFile)) -> String {
+  group
+  |> list.map(fn(file) { file.path })
+  |> list.sort(string.compare)
+  |> string.join(" and ")
+  <> " parse to the same major.minor.patch; version selection cannot order "
+  <> "them, so which one wins is filesystem order. Give one a distinct "
+  <> "version or drop it."
 }

--- a/test/release_test.gleam
+++ b/test/release_test.gleam
@@ -6,7 +6,9 @@
 // compiler doesn't try to compile them as project modules. The file-name lint
 // is the exception: it reads the real `priv/catalog/`.
 
+import filepath
 import gleam/dict
+import gleam/int
 import gleam/list
 import gleam/set
 import gleam/string
@@ -363,9 +365,49 @@ pub fn non_function_field_annotation_warns_test() {
 
 // Bundled catalog file names
 //
-// Version selection compares `#(major, minor, patch)`, so two bundled files for
-// one package that parse to the same tuple cannot be ordered and the winner is
-// whatever order the directory walk returns.
+// Every bundled file is named `{package}@{major.minor.patch}.graded`. A name
+// that does not split that way is dropped before it can be selected, and a
+// version selection cannot order is one whose file wins on directory order
+// rather than on the version it declares.
+
+pub fn every_catalog_file_names_a_package_and_a_version_test() {
+  let assert Ok(paths) = simplifile.get_files(effects.catalog_directory())
+  paths
+  |> list.filter(string.ends_with(_, ".graded"))
+  |> list.filter_map(malformed_catalog_name)
+  |> should.equal([])
+}
+
+// The complaint about one file name, or `Error(Nil)` for a name that reads as a
+// package and a `major.minor.patch` version — the shape `bundled_catalog_files`
+// keeps and `parse_semver` compares. A pre-release or build suffix is not one:
+// selection compares the version prefix alone, so the suffix would name a file
+// nothing distinguishes from its release.
+fn malformed_catalog_name(path: String) -> Result(String, Nil) {
+  let name = path |> filepath.base_name |> filepath.strip_extension
+  case string.split(name, "@") {
+    [_package, version] ->
+      case list.try_map(string.split(version, "."), int.parse) {
+        Ok([major, minor, patch]) if #(major, minor, patch) != #(0, 0, 0) ->
+          Error(Nil)
+        Ok(_) | Error(Nil) ->
+          Ok(
+            path
+            <> " names the version `"
+            <> version
+            <> "`, which is not a `major.minor.patch` above 0.0.0. Version "
+            <> "selection compares those three numbers, so it cannot place "
+            <> "this file. Rename it.",
+          )
+      }
+    _ ->
+      Ok(
+        path
+        <> " is not named `{package}@{version}.graded`, so no package claims "
+        <> "it and it is never selected. Rename it or drop it.",
+      )
+  }
+}
 
 pub fn no_two_catalog_files_parse_to_one_version_test() {
   let assert Ok(files) =


### PR DESCRIPTION
A read-only third query beside `effect` and `why`, answering what the bundled
`priv/catalog/` holds. The Reference used to say "browse `priv/catalog/`" —
fine for a human with the repo checked out, useless for an agent working in a
project where graded is a build dependency.

## Added

**`graded catalog`** lists every bundled file as `package@version`, sorted,
marking the line each of this project's installed packages resolves to — and
saying so when that file is the highest bundled rather than one the installed
version covers:

```
$ graded catalog
argv@1.1.0  // selected for argv 1.1.0
gleam_stdlib@0.70.0  // selected for gleam_stdlib 1.0.3
lustre@4.0.0
lustre@5.0.0
```

**`graded catalog <package>`** prints the file selected for the installed
version, **`graded catalog <package>@<version>`** exactly that bundled file,
reading no manifest. Selection is the resolver's own `pick_best_version`, so
what is printed is the file the catalog tier folded for that package —
including the "nothing bundled is old enough, fell back to the highest" case,
which the header names:

```
$ graded catalog gleam_stdlib
// gleam_stdlib@0.70.0.graded — selected for gleam_stdlib 1.0.3 in manifest.toml
// gleam_stdlib — pure modules and effectful functions

external effects gleam/list : []
...
```

The output is a valid `.graded` file — one `//` header line, then the file
verbatim — so it can be redirected into a spec and edited down to
`external effects` overrides. Same move as `graded effect --format=graded`:
provenance in a comment, the rest parses back.

It shows the bundled catalog alone. A dependency's shipped spec, a path
dependency's spec and your own externals all override it, and `graded effect
<name>` is what says which source wins for a name.

## Errors

Each exits non-zero with the next command in the message, rather than
degrading to a listing — the *shape* of stdout shouldn't depend on the
manifest:

- `no catalog entry for \`girard\`` — nothing bundled names it, whether or not
  it is installed. The catalog is consulted before the manifest, so this is
  never reported as "not installed".
- `` `lustre` is not in manifest.toml; bundled: lustre@4.0.0, lustre@5.0.0 — run `graded catalog lustre@5.0.0` to print one `` — the implicit form means
  "the file *your project* resolves against"; guessing a version for a package
  you don't have would print something with no relation to your build.
- `` no bundled `lustre@9.9.9`; bundled: lustre@4.0.0, lustre@5.0.0 ``
- `no catalog files under <dir>` — a directory that exists but holds no
  `{package}@{version}.graded` file is not graded's catalog.

## Internals

`resolve_catalog_files` splits into the two halves the command needs
separately — `bundled_catalog_files` (the names on disk) and
`select_catalog_file` (which one a version resolves to, and by which of the
two rules). `pick_best_version` is generalised over its payload, and
`parse_manifest_versions` becomes the public `manifest_versions`. The
resolver's selection *and fold order* are unchanged: `resolve_catalog_files`
still groups by package with the same prepending fold and iterates the
catalog's packages, so the file `load_catalog` folds for a package, and the
order it folds them in, are what they were.

New release lint: no two bundled files for one package may parse to the same
`#(major, minor, patch)`. Selection compares that tuple only, so a tie would
be broken by filesystem order — and the command's guarantee that it prints
what the resolver folded rests on there being none.

## Not in this version

No module filter. A catalog file is a few dozen lines of plain text, `grep`
does it, and a filter would need a third positional that collides with the
directory argument.
