### PR TITLE
Charge a dependency external's fallback body, walked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [Disk]` line, not only a bare `assume Runner.run`. Such a line keyed nothing,
   so the call stayed polymorphic in the field and a caller constructing the
   record specialized the declared effect away.
+- A field `assume` in your own spec for a dependency's type is now read when
+  that dependency's fallback bodies are walked. The walk ran before those lines
+  were folded in, so it resolved field calls without them.
 
 ## [0.15.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that dependency's module before answering, so the query and `graded check`
   quote the same charge.
 
+### Fixed
+
+- A field call on a parameter typed from its annotation alone (`insert(r:
+  Runner)`) now reads a module-qualified `assume myapp/store.Runner.run :
+  [Disk]` line, not only a bare `assume Runner.run`. Such a line keyed nothing,
+  so the call stayed polymorphic in the field and a caller constructing the
+  record specialized the declared effect away.
+
 ## [0.15.0] - 2026-08-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [Disk]` line, not only a bare `assume Runner.run`. Such a line keyed nothing,
   so the call stayed polymorphic in the field and a caller constructing the
   record specialized the declared effect away.
+- A field call on a parameter annotated with an imported type (`insert(r:
+  model.Runner)`, however that import is written) now reads the field `assume`
+  keyed by the module defining it. A qualified annotation named no type at all,
+  so the call cost `[Unknown]`.
 - A field `assume` in your own spec for a dependency's type is now read when
   that dependency's fallback bodies are walked. The walk ran before those lines
   were folded in, so it resolved field calls without them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- A call into a dependency `@external` whose Gleam fallback body runs on a
+  target you compile is now charged what that body does — read from the
+  dependency's source under `build/packages` and walked like one of your own —
+  instead of `[Unknown]`. Callers of `gleam/dict.insert` and its stdlib kin
+  lose their inherited `[Unknown]`, so a `check f : [Unknown]` written over
+  the old answer now fails, and a committed `effects` line for such a caller
+  changes on the next `graded infer`.
+- `graded effect` for a dependency `@external` with a running fallback now reads
+  that dependency's module before answering, so the query and `graded check`
+  quote the same charge.
+
 ## [0.15.0] - 2026-08-23
 
 ### Changed

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -655,9 +655,12 @@ summary *about* is narrower: the modules that package ships, plus the names a
 scan of dependency source records as `@external`. A clause for anyone else's
 code — your own modules included — is dropped, so no dependency can overrule what
 your own body says it hands back. Where a
-dependency's external carries a fallback body that runs on some target, its
-declaration is widened by `[Unknown]` — the union graded performs against a
-walked fallback in the defining package has no second operand one package away.
+dependency's external carries a fallback body that runs on some target, that body
+is walked — read from the dependency's own source, on the targets your build
+compiles — and its effects are unioned into the declaration, exactly as they are
+for one of your own. `[Unknown]` joins the union only where the walk reaches a
+name nothing declares, or where graded could not read the module the body lives
+in.
 
 `graded effect` answers for the public API, so a *private* `@external` exits
 non-zero there as a private ordinary function does — including one a valid

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -701,11 +701,19 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     |> with_spec_declared_returns(spec, stale_returns_clauses)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
+    // Ahead of the fallback walk below, not merely ahead of the inference pass:
+    // the field a dependency's fallback body calls may be declared here rather
+    // than in that dependency's own spec, a consumer's line for a dependency's
+    // type. Folded after the walk it was not there to answer, the call stayed
+    // polymorphic in the field, and a caller constructing the record settled
+    // the summary at whatever it wired in.
+    |> with_spec_type_fields(spec)
     // Every layer that can key a dependency name is folded by here — the
-    // catalog, the dependency specs, the module-level assumes, and a spec-less
-    // path dependency's own inference — so a fallback body is walked against
-    // everything a caller of it would resolve against. Before this package's
-    // own inference, whose walks read the summaries this leaves behind.
+    // catalog, the dependency specs, the module-level assumes, a spec-less
+    // path dependency's own inference, and the field lines above — so a
+    // fallback body is walked against everything a caller of it would resolve
+    // against. Before this package's own inference, whose walks read the
+    // summaries this leaves behind.
     |> with_dependency_fallback_effects(dep_sources, registry, package_targets)
     |> with_committed_spec(spec, stale_externals)
     // Recorded before the inference pass below, so an `@external` resolves to
@@ -738,12 +746,12 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     )
     // Before the inference pass, not after it, and in the order `infer` folds
     // them: a body walked during inference resolves its field calls through the
-    // same field `assume` lines and factory signatures a body walked at check time
-    // does. Installed afterwards, the pass ran without them and a function
-    // whose effects it settled — an `@external`'s running fallback, whose
-    // callers read the summary and never the body — kept an answer the two
-    // commands would then disagree about.
-    |> with_spec_type_fields(spec)
+    // same factory signatures a body walked at check time does — the field
+    // `assume` lines they read beside these fold earlier still, above.
+    // Installed afterwards, the pass ran without them and a function whose
+    // effects it settled — an `@external`'s running fallback, whose callers
+    // read the summary and never the body — kept an answer the two commands
+    // would then disagree about.
     |> effects.with_factories(
       qualify_by_module(index, extract.factory_map(
         _,
@@ -3027,6 +3035,9 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
     |> with_spec_declared_returns(spec, stale_returns_clauses)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
+    // As in `project_context`: in reach of the fallback walk below, which
+    // resolves a dependency body's field calls through these lines.
+    |> with_spec_type_fields(spec)
     // As in `project_context`: after every layer that can key a dependency name,
     // and before this package's own inference reads the summaries.
     |> with_dependency_fallback_effects(dep_sources, registry, package_targets)
@@ -3037,7 +3048,6 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
 
   let base_kb =
     kb_base
-    |> with_spec_type_fields(spec)
     |> effects.with_factories(
       qualify_by_module(index, extract.factory_map(
         _,

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -701,6 +701,12 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     |> with_spec_declared_returns(spec, stale_returns_clauses)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
+    // Every layer that can key a dependency name is folded by here — the
+    // catalog, the dependency specs, the module-level assumes, and a spec-less
+    // path dependency's own inference — so a fallback body is walked against
+    // everything a caller of it would resolve against. Before this package's
+    // own inference, whose walks read the summaries this leaves behind.
+    |> with_dependency_fallback_effects(dep_sources, registry, package_targets)
     |> with_committed_spec(spec, stale_externals)
     // Recorded before the inference pass below, so an `@external` resolves to
     // what declares it while this project's own modules are being inferred, not
@@ -1722,17 +1728,22 @@ fn spec_answer(
       // the answer cannot be the declaration alone where the full context says
       // more.
       use <- bool.guard(
-        when: runs_a_fallback_body(parsed, module, name),
+        when: runs_a_fallback_body(parsed.foreign, name),
+        return: Error(Nil),
+      )
+      let dependency_foreign =
+        dependency_foreign_for(directory, project_modules, module, targets)
+      // And a *dependency's* external whose fallback body runs, for the same
+      // reason: the full context walks that body during its dependency pass and
+      // charges the name what it does, so answering from the declaration alone
+      // would quote a charge `check` does not levy.
+      use <- bool.guard(
+        when: runs_a_fallback_body(dependency_foreign, name),
         return: Error(Nil),
       )
       answer_from(
         with_module_facts(spec_knowledge_base(spec, stale, targets), parsed)
-          |> effects.with_dependency_foreign(dependency_foreign_for(
-            directory,
-            project_modules,
-            module,
-            targets,
-          )),
+          |> effects.with_dependency_foreign(dependency_foreign),
         name,
       )
     }
@@ -1778,18 +1789,18 @@ fn spec_knowledge_base(
   |> with_spec_type_fields(spec)
 }
 
-// Whether the queried name is one of this package's `@external`s that falls
-// back to Gleam on some target it is compiled for. The parsed module already
-// says so, so the test costs nothing beyond the file the fast path read anyway.
+// Whether the queried name is an `@external` that falls back to Gleam on some
+// target it is compiled for, according to `foreign` — either scan's map, since
+// the question and its consequence are the same for this package's source and a
+// dependency's. A body runs, and the fast path walks none.
 fn runs_a_fallback_body(
-  parsed: ModuleFacts,
-  module: String,
+  foreign: Dict(QualifiedName, types.ForeignFunction),
   name: String,
 ) -> Bool {
   case annotation.split_function_name(name) {
     Error(Nil) -> False
-    Ok(#(_module, function)) ->
-      case dict.get(parsed.foreign, QualifiedName(module:, function:)) {
+    Ok(#(module, function)) ->
+      case dict.get(foreign, QualifiedName(module:, function:)) {
         Ok(types.ForeignFunction(runs_fallback_body:, ..)) -> runs_fallback_body
         Error(Nil) -> False
       }
@@ -1802,10 +1813,10 @@ fn runs_a_fallback_body(
 // keying one, so nothing over there can change the answer. For a dependency
 // module — which a per-function `assume` line may name — the
 // declaration alone understates an `@external` whose Gleam fallback body runs,
-// because no consumer walks that body and the full context therefore charges
-// the declaration unioned with `[Unknown]`. One module is located and parsed to
-// settle it, so the fast path cannot answer where the full context would say
-// more.
+// because the full context walks that body and unions what it does into the
+// charge. One module is located and parsed to settle it, so the fast path can
+// tell that case and hand it back rather than answer where the full context
+// would say more.
 fn dependency_foreign_for(
   directory: String,
   project_modules: Dict(String, String),
@@ -3016,6 +3027,9 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
     |> with_spec_declared_returns(spec, stale_returns_clauses)
     |> with_builders(index, dep_sources, package_targets)
     |> enrich_with_path_deps(package_root, declared_modules, package_targets)
+    // As in `project_context`: after every layer that can key a dependency name,
+    // and before this package's own inference reads the summaries.
+    |> with_dependency_fallback_effects(dep_sources, registry, package_targets)
     |> effects.with_foreign_functions(project_foreign_functions(
       index,
       package_targets,
@@ -3256,7 +3270,9 @@ fn fold_inferred_module(
 // `@external` is charged the same effects whichever pass ran: the one that
 // reports violations, and the one that writes the spec and cache. A write pass
 // that skipped it would publish a caller as pure over an external whose
-// fallback is not — and publish it for consumers, who have no body to walk.
+// fallback is not — and publish it for consumers, whose own walk of this
+// package's bodies is a separate pass over dependency source
+// (`with_dependency_fallback_effects`) and cannot correct a shipped line.
 //
 // The walk needs only the callees already folded, which topological order
 // guarantees, so it belongs immediately before the module's own inference.
@@ -3269,20 +3285,32 @@ fn with_module_fallback_effects(
   girard_fn_typed: Dict(String, Set(String)),
   package_targets: types.PackageTargets,
 ) -> KnowledgeBase {
+  fold_fallback_summaries(
+    knowledge_base,
+    module_path,
+    checker.fallback_effects(
+      module,
+      module_path,
+      knowledge_base,
+      registry,
+      module_types,
+      girard_fn_typed,
+      package_targets,
+    ),
+  )
+}
+
+// Fold one module's fallback summaries in, qualified by its module path. Both
+// walks — this package's modules and its dependencies' — key their results the
+// same way, so which one produced them leaves no mark on the base.
+fn fold_fallback_summaries(
+  knowledge_base: KnowledgeBase,
+  module_path: String,
+  summaries: Dict(String, #(EffectTerm, List(types.ParamBound))),
+) -> KnowledgeBase {
   effects.with_fallback_summaries(
     knowledge_base,
-    qualify_bare_names(
-      checker.fallback_effects(
-        module,
-        module_path,
-        knowledge_base,
-        registry,
-        module_types,
-        girard_fn_typed,
-        package_targets,
-      ),
-      module_path,
-    ),
+    qualify_bare_names(summaries, module_path),
   )
 }
 
@@ -3534,6 +3562,21 @@ type ScannedModule {
     // own functions are foreign, since a stale line for one is exactly what
     // this map exists to refuse.
     foreign: Dict(types.QualifiedName, types.ForeignFunction),
+    // The file this copy was read from, and the module paths it imports. Kept
+    // for the fallback-body pass, which re-reads and re-parses the modules whose
+    // bodies it walks: the path names *this* copy, the one the build compiles
+    // against, so a duplicate left elsewhere on disk is never the one walked.
+    // The imports order that pass, so a fallback calling another dependency's
+    // fallback is walked after it.
+    //
+    // Two cheap facts of the parse rather than the parsed module itself: an AST
+    // kept on this record would live as long as the context that holds the whole
+    // scan, and the worst case is every module of every dependency at once.
+    // Whether the pass has anything to walk here is not among them — `foreign`
+    // above already answers it, and a second copy of that answer is one more
+    // thing to keep in step with how those entries are selected.
+    source_path: String,
+    imports: List(String),
   )
   // The file would not read or parse. Recorded rather than dropped so it
   // shadows any copy of the path scanned before it, and contributes nothing in
@@ -3578,6 +3621,148 @@ fn dependency_foreign(
     ParsedModule(foreign:, ..) -> dict.merge(acc, foreign)
     UnreadableModule -> acc
   }
+}
+
+// Dependency fallback bodies
+//
+// An `@external` a dependency declares for one target only falls back to its
+// Gleam body on the others, and a consumer compiling those targets runs that
+// body. Walked here, once per command, so the consumer is charged what it does
+// rather than the `[Unknown]` an unwalked body is worth.
+
+// Fold what every dependency `@external`'s running Gleam fallback body does into
+// `knowledge_base`.
+//
+// Run once the spec layers are folded — the catalog, the dependency specs, the
+// module-level assumes and any spec-less path dependency's own inference — and
+// before this package's modules are inferred, so a body reaching a dependency
+// name resolves it against everything that can key it, and every later lookup
+// of a walked external reads the summary rather than the widening.
+//
+// The scan kept a path rather than an AST, so each module is read and parsed
+// again here and dropped before the next: one AST live at a time, as during the
+// scan itself.
+fn with_dependency_fallback_effects(
+  knowledge_base: KnowledgeBase,
+  dep_sources: DependencySources,
+  registry: SignatureRegistry,
+  package_targets: types.PackageTargets,
+) -> KnowledgeBase {
+  let retained = retained_fallback_modules(dep_sources)
+  use <- bool.guard(when: dict.is_empty(retained), return: knowledge_base)
+  use kb, #(module_path, retained) <- list.fold(
+    dependency_walk_order(retained),
+    knowledge_base,
+  )
+  // A re-parse that fails is the `UnreadableModule` case one stage later: the
+  // module is skipped, and its externals keep the `[Unknown]` an unwalked body
+  // carries.
+  case read_and_parse_gleam_or_nil(retained.source_path) {
+    Error(Nil) -> kb
+    Ok(module) ->
+      fold_fallback_summaries(
+        kb,
+        module_path,
+        checker.dependency_fallback_effects(
+          module,
+          module_path,
+          kb,
+          registry,
+          package_targets,
+        ),
+      )
+  }
+}
+
+// One dependency module the fallback-body pass has something to walk in: where
+// its winning copy was read from, and the module paths it imports.
+type RetainedModule {
+  RetainedModule(source_path: String, imports: List(String))
+}
+
+// Those modules, keyed by module path. Which they are is read off `foreign`
+// rather than recorded beside it, so the pass and the scan cannot come to
+// different answers about which `@external`s fall back to a running body.
+fn retained_fallback_modules(
+  sources: DependencySources,
+) -> Dict(String, RetainedModule) {
+  use acc, module_path, scanned <- dict.fold(sources.modules, dict.new())
+  case scanned {
+    UnreadableModule -> acc
+    ParsedModule(foreign:, source_path:, imports:, ..) ->
+      case
+        list.any(dict.values(foreign), fn(entry) { entry.runs_fallback_body })
+      {
+        False -> acc
+        True ->
+          dict.insert(acc, module_path, RetainedModule(source_path:, imports:))
+      }
+  }
+}
+
+// The order the retained modules are walked in: callees before callers, so a
+// fallback body calling another dependency's fallback reads its summary rather
+// than the `[Unknown]` an unwalked one carries.
+//
+// One graph over every retained module, not one per package: a fallback in one
+// package can call a fallback in another, and the scan keys by module path with
+// package ownership merged away, so there is no per-package boundary to sort
+// within. Edges are imports restricted to the retained modules — a retained
+// module reaching another only through an unretained one does not reach its
+// *summary*, since the intermediate's own call is a resolved lookup rather than
+// a walk.
+//
+// Expected acyclic, because the winning copies are the ones the build compiles
+// against and the compiler accepted that set — but not relied on, which is why
+// the components rather than a plain sort: `scc_order` groups a cycle instead of
+// rejecting the whole graph, so the modules that *can* be ordered still are, and
+// only the members of a cycle are dropped. Those keep today's `[Unknown]`, and a
+// module merely downstream of one reads it as an ordinary unwalked name.
+fn dependency_walk_order(
+  retained: Dict(String, RetainedModule),
+) -> List(#(String, RetainedModule)) {
+  let components = topo.scc_order(fallback_import_graph(retained))
+  warn_on_cyclic_modules(components)
+  use component <- list.filter_map(components)
+  // A component of more than one module is a cycle: its members import each
+  // other, so no order settles either against the other's summary.
+  use module_path <- result.try(case component {
+    [only] -> Ok(only)
+    _ -> Error(Nil)
+  })
+  dict.get(retained, module_path)
+  |> result.map(fn(retained) { #(module_path, retained) })
+}
+
+// Name the modules dropped for importing each other, once for the whole graph.
+fn warn_on_cyclic_modules(components: List(List(String))) -> Nil {
+  let cyclic =
+    list.flat_map(components, fn(component) {
+      case component {
+        [_] -> []
+        cycle -> cycle
+      }
+    })
+  use <- bool.guard(when: cyclic == [], return: Nil)
+  io.println_error(
+    "graded: warning: dependency modules import each other in a cycle ("
+    <> string.join(list.sort(cyclic, string.compare), ", ")
+    <> "); their Gleam fallback bodies are not walked, and callers of the "
+    <> "`@external`s they declare are charged [Unknown]",
+  )
+}
+
+// The import graph over the retained modules, with both ends of every edge among
+// them: an import of anything else names no node, and a graph edge to a node it
+// does not hold orders nothing.
+fn fallback_import_graph(
+  retained: Dict(String, RetainedModule),
+) -> Dict(String, Set(String)) {
+  let every = set.from_list(dict.keys(retained))
+  use _module_path, module <- dict.map_values(retained)
+  module.imports
+  |> list.filter(set.contains(every, _))
+  |> set.from_list
 }
 
 // What a dependency's own source says about one name: the three answers the
@@ -3679,7 +3864,7 @@ fn source_dir_sources(
   source_dir: String,
   package_targets: types.PackageTargets,
 ) -> DependencySources {
-  use acc, module_path, parsed <- signatures.fold_source_dir(
+  use acc, module_path, source_path, parsed <- signatures.fold_source_dir(
     source_dir,
     empty_dependency_sources(),
   )
@@ -3698,10 +3883,17 @@ fn source_dir_sources(
           module_path,
           package_targets,
         ),
+        source_path:,
+        imports: module_import_paths(module),
       )
     Error(Nil) -> UnreadableModule
   }
   DependencySources(modules: dict.insert(acc.modules, module_path, scanned))
+}
+
+// The module paths a module imports.
+fn module_import_paths(module: glance.Module) -> List(String) {
+  list.map(module.imports, fn(definition) { definition.definition.module })
 }
 
 // Every function a module defines, public and private alike.

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -6829,8 +6829,7 @@ fn resolve_unproven_field(
           field_call.receiver_span.end,
         )
         |> option.lazy_or(fn() {
-          syntactic_param_type(function, receiver_object)
-          |> option.map(fn(type_name) { #("", type_name) })
+          syntactic_param_type(function, receiver_object, context)
         })
       // Rule 3: a hand-written `type Type.field` line, resolved by the
       // receiver's nominal type.
@@ -7151,7 +7150,8 @@ fn concretize(term: EffectTerm) -> EffectTerm {
 fn syntactic_param_type(
   function: Function,
   object: String,
-) -> option.Option(String) {
+  context: ImportContext,
+) -> option.Option(#(String, String)) {
   case
     list.find(function.parameters, fn(param) {
       case param.name {
@@ -7160,13 +7160,37 @@ fn syntactic_param_type(
       }
     })
   {
-    // Only an unqualified annotation (`r: Runner`) is treated as the current
-    // module's type. A qualified one (`r: ext.Runner`) names an imported type,
-    // whose fields the local registry must not claim, so it yields no type.
     Ok(glance.FunctionParameter(
-      type_: Some(glance.NamedType(name: type_name, module: None, ..)),
+      type_: Some(glance.NamedType(name: type_name, module:, ..)),
       ..,
-    )) -> Some(type_name)
+    )) -> annotated_type_module(type_name, module, context)
     _ -> None
+  }
+}
+
+// The module a parameter's type annotation names, read through the imports of
+// the module the annotation is written in.
+//
+// A qualified annotation (`r: model.Runner`) names the module its alias stands
+// for, and an unresolvable alias names nothing — the local registry must not
+// claim an imported type's fields. An unqualified one is the module's own type,
+// left for the caller to key, unless the module imports a type of that name
+// unqualified (`import dep/model.{type Runner}`), which is the same imported
+// type written shorter.
+fn annotated_type_module(
+  type_name: String,
+  module: option.Option(String),
+  context: ImportContext,
+) -> option.Option(#(String, String)) {
+  case module {
+    Some(alias) ->
+      dict.get(context.aliases, alias)
+      |> option.from_result
+      |> option.map(fn(module_path) { #(module_path, type_name) })
+    None ->
+      case dict.get(context.unqualified_types, type_name) {
+        Ok(imported) -> Some(#(imported.module, imported.function))
+        Error(Nil) -> Some(#("", type_name))
+      }
   }
 }

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -6752,26 +6752,48 @@ fn carries_unknown(term: EffectTerm) -> Bool {
 // construction-inferred nominal entry is never consulted — it holds package-wide
 // evidence keyed by type, not proof for this receiver.
 // The hand-written `type Type.field` line for a receiver's nominal type, with
-// the source that declares it. A construction-inferred entry keyed by the same
-// type does *not* qualify — it is package-wide nominal evidence, which must
-// never resolve an unproven receiver.
+// the source that declares it — the first of `keys` a line is written under. A
+// construction-inferred entry keyed by the same type does *not* qualify — it is
+// package-wide nominal evidence, which must never resolve an unproven receiver.
 fn declared_type_field(
   knowledge_base: KnowledgeBase,
-  receiver_type: option.Option(#(String, String)),
+  keys: List(#(String, String)),
   field: String,
 ) -> option.Option(#(types.TypeFieldEffect, LookupOrigin)) {
-  use #(module, type_name) <- option.then(receiver_type)
-  use field_effect <- option.then(
-    option.from_result(effects.lookup_type_field(
-      knowledge_base,
-      module,
-      type_name,
-      field,
-    )),
+  option.from_result(
+    list.find_map(keys, fn(key) {
+      let #(module, type_name) = key
+      use field_effect <- result.try(effects.lookup_type_field(
+        knowledge_base,
+        module,
+        type_name,
+        field,
+      ))
+      case field_effect.origin {
+        types.Declared(source:) -> Ok(#(field_effect, source))
+        types.Inferred -> Error(Nil)
+      }
+    }),
   )
-  case field_effect.origin {
-    types.Declared(source:) -> Some(#(field_effect, source))
-    types.Inferred -> None
+}
+
+// The keys a receiver's nominal type is looked up under.
+//
+// girard names the type's defining module, which keys a line exactly. The
+// syntactic parameter annotation (`r: Runner`) carries no module — it names a
+// type of the module the walk is in — so it keys both by that module, the form
+// every spec file writes a shipped line in, and bare, the form of a line written
+// without one. Trying only the bare key left a module-qualified line unmatched
+// wherever girard holds no type for the receiver: a dependency's own module,
+// which girard never annotates, or a function girard could not type.
+fn declared_type_field_keys(
+  receiver_type: option.Option(#(String, String)),
+  module_path: String,
+) -> List(#(String, String)) {
+  case receiver_type {
+    None -> []
+    Some(#("", type_name)) -> [#(module_path, type_name), #("", type_name)]
+    Some(qualified) -> [qualified]
   }
 }
 
@@ -6813,7 +6835,11 @@ fn resolve_unproven_field(
       // Rule 3: a hand-written `type Type.field` line, resolved by the
       // receiver's nominal type.
       let declared =
-        declared_type_field(knowledge_base, receiver_type, field_call.label)
+        declared_type_field(
+          knowledge_base,
+          declared_type_field_keys(receiver_type, context.module_path),
+          field_call.label,
+        )
       case declared {
         Some(#(field_effect, source)) -> {
           let #(term, memo) =

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -907,11 +907,70 @@ pub fn fallback_effects(
   // code and which are ordinary Gleam whose body is the only implementation.
   package_targets: types.PackageTargets,
 ) -> dict.Dict(String, #(EffectTerm, List(ParamBound))) {
-  let targets =
+  walk_fallbacks(
     list.filter(module.functions, fn(definition) {
       foreign_definition(definition, package_targets)
       && runs_fallback_body(definition, package_targets)
-    })
+    }),
+    module,
+    module_path,
+    knowledge_base,
+    registry,
+    module_types,
+    girard_fn_typed,
+    package_targets,
+  )
+}
+
+// The same, for a module of a *dependency*, walked on the consumer's targets.
+//
+// One selector apart, and the difference is the whole point of a second entry
+// point: `foreign_definition` asks whether the build compiles the declaration,
+// and an `@external(javascript, …)` read by an Erlang-only consumer fails it.
+// In this package's source that answer is right — nothing foreign is compiled,
+// so the function is ordinary Gleam and the ordinary walk covers its body. A
+// dependency's is not walked as ordinary Gleam by anything, so the question here
+// is only whether a body runs at all: `has_running_fallback`, the same reading
+// `dependency_foreign_functions` records the name under.
+//
+// girard types no consumer holds for a dependency, so the walk takes the
+// syntax-level result — what a module girard cannot type already falls back to.
+pub fn dependency_fallback_effects(
+  module: Module,
+  module_path: String,
+  knowledge_base: KnowledgeBase,
+  registry: SignatureRegistry,
+  package_targets: types.PackageTargets,
+) -> dict.Dict(String, #(EffectTerm, List(ParamBound))) {
+  walk_fallbacks(
+    list.filter(module.functions, fn(definition) {
+      extract.declares_external(definition)
+      && has_running_fallback(definition, package_targets)
+    }),
+    module,
+    module_path,
+    knowledge_base,
+    registry,
+    dict.new(),
+    dict.new(),
+    package_targets,
+  )
+}
+
+// Summarize each of `targets`, which either selector above chose from
+// `module.functions`. The whole module comes along because a fallback body's
+// unqualified calls are resolved against every function beside it — a sibling
+// missing from the map is an unresolved local call, charged `[Unknown]`.
+fn walk_fallbacks(
+  targets: List(Definition(Function)),
+  module: Module,
+  module_path: String,
+  knowledge_base: KnowledgeBase,
+  registry: SignatureRegistry,
+  module_types: dict.Dict(#(Int, Int), girard.Type),
+  girard_fn_typed: dict.Dict(String, Set(String)),
+  package_targets: types.PackageTargets,
+) -> dict.Dict(String, #(EffectTerm, List(ParamBound))) {
   use <- bool.guard(when: targets == [], return: dict.new())
   let function_map = build_function_map(module)
   let ModuleContext(context:, cache:) =
@@ -2626,8 +2685,9 @@ fn recursion_edges(
 // `module_path` and each paired with what a knowledge base records about it.
 // What a knowledge base holds so that every consumer — a caller's resolution,
 // `check`, `why`, `effect` — reads one of these names as only its declaration
-// describes it. Whether the fallback body runs rides along for the consumers
-// that never walk this source, a dependency's away.
+// describes it. Whether the fallback body runs rides along, so a charge assembled
+// before the walk reaches that body says so rather than reading the declaration
+// as the whole story.
 pub fn foreign_functions(
   module: Module,
   module_path: String,
@@ -2658,13 +2718,15 @@ pub fn foreign_functions(
 //
 // The consumer's own modules drop such a declaration, and rightly — no foreign
 // implementation is compiled, so the Gleam body is the sole one and the function
-// is ordinary Gleam whose body graded walks. A dependency's body it never walks.
-// Dropping the entry there left the name keyed by a shipped or catalogued
-// declaration with nothing to say that declaration answers for a target this
-// build does not compile, so `assume dep/ffi.run : [Disk]` over an
-// `@external(javascript, …)` was charged in full to an Erlang-only consumer that
-// reaches only the Gleam body underneath it. Kept, the lookup narrows the
-// declaration out and charges the `[Unknown]` an unwalked body is worth.
+// is ordinary Gleam whose body graded walks. A dependency's body is walked by a
+// pass of its own, and this is what tells that pass which names have one.
+// Dropping the entry left the name keyed by a shipped or catalogued declaration
+// with nothing to say that declaration answers for a target this build does not
+// compile, so `assume dep/ffi.run : [Disk]` over an `@external(javascript, …)`
+// was charged in full to an Erlang-only consumer that reaches only the Gleam body
+// underneath it. Kept, the lookup narrows the declaration out and charges what
+// the body does instead — or the `[Unknown]` an unwalked body is worth, where
+// nothing walked it.
 pub fn dependency_foreign_functions(
   module: Module,
   module_path: String,

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -107,19 +107,22 @@ pub type KnowledgeBase {
     // function missing from a module that *is* here is a name the package does
     // not define, while a module missing entirely is no evidence at all.
     project_functions: Dict(String, Dict(String, types.Visibility)),
-    // What the Gleam fallback body of one of *this package's* `@external`s
-    // does, where that body runs — the targets its declaration leaves
-    // uncovered — paired with the parameter bounds the term is stated over.
-    // Ordinary Gleam that runs, so every caller is charged it on top of
-    // whatever declares the external, exactly as the external's own `check`
-    // line covers both. Held apart from `all_effects` because the declaration
-    // has to stay reportable on its own: the two are unioned when a name is
-    // charged, and told apart when its provenance is explained. The bounds
-    // stay beside the term they bind: which bounds are a fallback's is a
-    // provenance question every reader answers structurally from this one map.
+    // What the Gleam fallback body of an `@external` does, where that body runs
+    // — the targets its declaration leaves uncovered — paired with the
+    // parameter bounds the term is stated over. Ordinary Gleam that runs, so
+    // every caller is charged it on top of whatever declares the external,
+    // exactly as the external's own `check` line covers both. Held apart from
+    // `all_effects` because the declaration has to stay reportable on its own:
+    // the two are unioned when a name is charged, and told apart when its
+    // provenance is explained. The bounds stay beside the term they bind: which
+    // bounds are a fallback's is a provenance question every reader answers
+    // structurally from this one map.
     //
-    // The dependency counterpart is `[Unknown]` (see `with_dependency_fallback`)
-    // — no consumer walks a dependency's bodies. Here the body is in hand.
+    // This package's externals and its dependencies' alike: a dependency module
+    // declaring one is re-parsed and walked before anything of this package is
+    // inferred, so the body a consumer runs is summarized here too. A name here
+    // is one a walk reached, which is what `widens_with_dependency_fallback`
+    // reads to tell a walked dependency body from an unwalked one.
     fallback_summaries: Dict(QualifiedName, #(EffectTerm, List(ParamBound))),
     // The targets the package under analysis is built for, and whether it named
     // them. Every foreign lookup is read on the build's own targets, and a
@@ -427,16 +430,19 @@ pub fn lookup(
   with_dependency_fallback(knowledge_base, name, found)
 }
 
-// Widen a dependency external's answer by the fallback body nobody walks.
+// Widen a dependency external's answer by a fallback body nothing walked.
 //
-// Where the source is walked — this package — a declaration is unioned with a
-// running fallback body's own effects, because that body is ordinary Gleam that
-// runs on the targets the declaration doesn't cover. A consumer never walks a
-// dependency's bodies, so the union has no second operand there and the
-// declaration alone would read as the whole story: `assume dep.run :
-// []` over an `@external(javascript, …)` whose Erlang fallback prints would be
-// believed pure on Erlang. `[Unknown]` is that missing operand — the body ran,
-// and what it did is not knowable from here.
+// A declaration is unioned with its running fallback body's own effects,
+// because that body is ordinary Gleam that runs on the targets the declaration
+// doesn't cover. The dependency pass walks those bodies and records them in
+// `fallback_summaries`, and where it did, the union takes its second operand
+// from there like any of this package's own — nothing is widened here.
+//
+// Where it did not — a module that would not re-parse, one dropped from a
+// cyclic import graph — the declaration alone would read as the whole story:
+// `assume dep.run : []` over an `@external(javascript, …)` whose Erlang
+// fallback prints would be believed pure on Erlang. `[Unknown]` is the missing
+// operand there — the body ran, and what it did is not knowable from here.
 //
 // Which halves the *calling* body reaches decides this the way it decides one of
 // this package's own (see `reachable_halves`), and it is decided here because
@@ -472,19 +478,29 @@ fn with_dependency_fallback(
   }
 }
 
-// Whether a hit for `name` is widened by the fallback body above.
+// Whether a hit for `name` is widened by the fallback body above: a
+// dependency's runs, and nothing walked it.
 //
 // The widening leaves no mark on the answer — the term gains `[Unknown]` and
 // keeps the declaration's source — so a caller that reports provenance asks
 // here to tell the two apart. Without it the widened `[Time, Unknown]` reads as
 // what the dependency's spec said, when the spec said `[Time]` and the
 // `Unknown` is a body nobody walked.
+//
+// The summary is what makes it a body somebody walked, and it has to be weighed
+// here rather than beside the union downstream: `lookup` widens the
+// *declaration* term itself, so an `[Unknown]` let through travels under the
+// declaration's source and nothing after it can subtract it. Both entry points
+// — the widening at `with_dependency_fallback` and the backstop at
+// `running_fallback_term` — ask this one question, so both stand down together.
 pub fn widens_with_dependency_fallback(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
 ) -> Bool {
   case dict.get(knowledge_base.dependency_foreign, name) {
-    Ok(types.ForeignFunction(runs_fallback_body:, ..)) -> runs_fallback_body
+    Ok(types.ForeignFunction(runs_fallback_body:, ..)) ->
+      runs_fallback_body
+      && !dict.has_key(knowledge_base.fallback_summaries, name)
     Error(Nil) -> False
   }
 }
@@ -637,13 +653,13 @@ fn declaration_term(
 // What a running fallback body contributes to `name`'s charge, before the
 // narrowing above weighs whether the walk reaches it.
 //
-// `None` where no fallback runs. One of *this package's* externals contributes
-// what its body does, walked. A dependency's contributes `[Unknown]`: the body
-// runs and no consumer walks it — and so does one of this package's that no walk
-// reached, because the source scan records that a fallback runs before anything
-// walks it. A pass that never reached the walk (an import cycle bails the whole
-// in-memory inference) would otherwise leave the declaration standing alone over
-// a body that prints.
+// `None` where no fallback runs. An external whose body a walk reached — this
+// package's, or a dependency's — contributes what that body does. One no walk
+// reached contributes `[Unknown]`, because both scans record that a fallback
+// runs before anything walks it: this package's where the pass never reached the
+// walk (an import cycle bails the whole in-memory inference), a dependency's
+// where its module would not re-parse. Either would otherwise leave the
+// declaration standing alone over a body that prints.
 fn running_fallback_term(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
@@ -781,8 +797,8 @@ pub fn with_active_targets(
 // never happened rather than a fallback that does nothing.
 //
 // This package's map only: a dependency's running fallback is
-// `widens_with_dependency_fallback`'s, and answers `[Unknown]` by construction
-// rather than by backstop.
+// `widens_with_dependency_fallback`'s, which asks the same question of the other
+// scan's map and of the summary a walk of that dependency's body left behind.
 fn runs_own_fallback_body(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -97,6 +97,11 @@ pub type ImportContext {
     module_path: String,
     aliases: Dict(String, String),
     unqualified: Dict(String, QualifiedName),
+    // Types imported unqualified (`import dep/model.{type Runner}`), by the name
+    // they are written under here -> the module that defines them. A parameter
+    // annotated with one names no module at its use site, and the module is what
+    // a field `assume` for that type is keyed by.
+    unqualified_types: Dict(String, QualifiedName),
     constructors: Dict(String, List(Option(String))),
     // Same-module factory functions (bare name -> signature) and other modules'
     // factories (keyed by `#(defining module, function)`), so a let-bound
@@ -189,41 +194,46 @@ pub fn with_fn_typed_fields(
 
 // Build import context from a parsed module's imports.
 pub fn build_import_context(module: Module) -> ImportContext {
-  let #(aliases, unqualified) =
-    list.fold(module.imports, #(dict.new(), dict.new()), fn(state, definition) {
-      let import_ = definition.definition
-      let module_path = import_.module
-
-      let alias = case import_.alias {
-        Some(glance.Named(name)) -> name
-        Some(glance.Discarded(_)) -> last_segment(module_path)
-        None -> last_segment(module_path)
+  // Both unqualified lists are folded the same way, over the name each import
+  // is written under here — its alias where it has one.
+  let fold_unqualified = fn(
+    into: Dict(String, QualifiedName),
+    imports: List(glance.UnqualifiedImport),
+    module_path: String,
+  ) {
+    list.fold(imports, into, fn(unqualified_map, unqualified_import) {
+      let name = case unqualified_import.alias {
+        Some(alias_name) -> alias_name
+        None -> unqualified_import.name
       }
-
-      let new_aliases = dict.insert(state.0, alias, module_path)
-
-      let new_unqualified =
-        list.fold(
-          import_.unqualified_values,
-          state.1,
-          fn(unqualified_map, unqualified_import) {
-            let name = case unqualified_import.alias {
-              Some(alias_name) -> alias_name
-              None -> unqualified_import.name
-            }
-            dict.insert(
-              unqualified_map,
-              name,
-              QualifiedName(
-                module: module_path,
-                function: unqualified_import.name,
-              ),
-            )
-          },
-        )
-
-      #(new_aliases, new_unqualified)
+      dict.insert(
+        unqualified_map,
+        name,
+        QualifiedName(module: module_path, function: unqualified_import.name),
+      )
     })
+  }
+  let #(aliases, unqualified, unqualified_types) =
+    list.fold(
+      module.imports,
+      #(dict.new(), dict.new(), dict.new()),
+      fn(state, definition) {
+        let import_ = definition.definition
+        let module_path = import_.module
+
+        let alias = case import_.alias {
+          Some(glance.Named(name)) -> name
+          Some(glance.Discarded(_)) -> last_segment(module_path)
+          None -> last_segment(module_path)
+        }
+
+        #(
+          dict.insert(state.0, alias, module_path),
+          fold_unqualified(state.1, import_.unqualified_values, module_path),
+          fold_unqualified(state.2, import_.unqualified_types, module_path),
+        )
+      },
+    )
 
   let constructors = build_constructor_registry(module)
   let functions =
@@ -233,6 +243,7 @@ pub fn build_import_context(module: Module) -> ImportContext {
     module_path: "",
     aliases:,
     unqualified:,
+    unqualified_types:,
     constructors:,
     factories: dict.new(),
     cross_factories: dict.new(),

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -468,10 +468,14 @@ fn is_function_type(t: glance.Type) -> Bool {
 
 // Parse every `.gleam` file under `source_dir` with glance and fold it into
 // `initial`, in walk order. `step` receives the module path the file's location
-// denotes (`<source_dir>/gleam/list.gleam` → `gleam/list`) and the parse of it,
-// or `Error(Nil)` where the file would not read or parse. Folding rather than
-// returning a list keeps one AST live at a time, so a package's whole source
-// never sits in memory at once.
+// denotes (`<source_dir>/gleam/list.gleam` → `gleam/list`), the path of the file
+// itself, and the parse of it, or `Error(Nil)` where the file would not read or
+// parse. Folding rather than returning a list keeps one AST live at a time, so a
+// package's whole source never sits in memory at once.
+//
+// The file path travels alongside because a caller that records the copy of a
+// module path it read may want to read that copy again later, and only the path
+// names *that* copy — a second search for the module could find a different one.
 //
 // A file that will not read or parse (a version mismatch, an FFI-only Erlang
 // package) is handed to `step` rather than skipped: it derives nothing, but it
@@ -483,7 +487,7 @@ fn is_function_type(t: glance.Type) -> Bool {
 pub fn fold_source_dir(
   source_dir: String,
   initial: acc,
-  step: fn(acc, String, Result(Module, Nil)) -> acc,
+  step: fn(acc, String, String, Result(Module, Nil)) -> acc,
 ) -> acc {
   case simplifile.get_files(source_dir) {
     Error(_) -> initial
@@ -498,7 +502,12 @@ pub fn fold_source_dir(
           ))
           result.replace_error(glance.module(source), Nil)
         }
-        step(acc, config.module_path_for_source(gleam_path, source_dir), parsed)
+        step(
+          acc,
+          config.module_path_for_source(gleam_path, source_dir),
+          gleam_path,
+          parsed,
+        )
       })
   }
 }

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -426,8 +426,9 @@ pub type Visibility {
 // What a knowledge base records about one `@external` it has seen the source
 // of: whether its Gleam fallback body is code that runs on some target the
 // function is compiled for. It travels with the name because it decides an
-// answer no other entry can supply — a running fallback widens a declaration
-// downstream, where the body itself is never walked.
+// answer no other entry can supply — a running fallback adds a half to the
+// declaration downstream, and where nothing walked that body the half is
+// `[Unknown]`.
 //
 // The target sets that decided it ride along, because a caller that runs on
 // only some of them needs the same question answered for *its* targets: a body

--- a/test/effect_cli_test.gleam
+++ b/test/effect_cli_test.gleam
@@ -543,12 +543,13 @@ pub fn prose_names_the_body_running_in_a_declarations_place_test() {
   // its place. That body is the whole of what the build reaches, so it is named
   // as the source rather than beside one — no `plus its Gleam fallback body`
   // line, which would read as a half added to a declaration that pays for none
-  // of it.
+  // of it. Walked, and it does nothing, so the answer is the empty set rather
+  // than a guess about a dependency's body.
   out_of_reach_outputs("graded_effect_fallback_in_reach", " {\n  Nil\n}")
   |> should.equal(#(
-    "dep/ffi.run has effects that could not be determined: [Unknown]
+    "dep/ffi.run is pure — no effects ([])
   source: its Gleam fallback body, which is what runs on the targets this build compiles",
-    "effects dep/ffi.run : [Unknown]
+    "effects dep/ffi.run : []
 // its Gleam fallback body, which is what runs on the targets this build compiles",
   ))
 }

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -2036,3 +2036,74 @@ pub fn no_active_targets_charges_both_halves_test() {
     |> effects.with_active_targets(option.None)
   charged(base, name) |> should.equal(Specific(set.from_list(["Disk", "Time"])))
 }
+
+// A dependency external's charge, with and without a walked fallback body
+//
+// `[Unknown]` enters such a charge twice: `lookup` widens the *declaration*
+// term itself, and `running_fallback_term` contributes the fallback half. Only
+// the second reads the summaries, so a walked body that stood down one entry
+// and not the other would leave the `[Unknown]` in place under the
+// declaration's own source, where nothing downstream can subtract it. This pair
+// is the one place both entries are visible without a fixture on disk.
+
+fn dependency_external_base() -> effects.KnowledgeBase {
+  effects.new_knowledge_base()
+  |> effects.with_package_targets(
+    types.NamedTargets(set.from_list(["erlang", "javascript"])),
+  )
+  |> effects.with_externals(
+    [external("dep/ffi", "run", ["Time"])],
+    types.DependencySpec("dep"),
+  )
+  |> effects.with_dependency_foreign(
+    dict.from_list([
+      #(
+        QualifiedName("dep/ffi", "run"),
+        types.ForeignFunction(
+          runs_fallback_body: True,
+          compiled_targets: set.from_list(["erlang", "javascript"]),
+          declared_targets: set.from_list(["javascript"]),
+        ),
+      ),
+    ]),
+  )
+}
+
+pub fn a_walked_dependency_fallback_charges_its_summary_test() {
+  let charge =
+    dependency_external_base()
+    |> effects.with_fallback_summaries(
+      dict.from_list([
+        #(
+          QualifiedName("dep/ffi", "run"),
+          #(
+            effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
+            [],
+          ),
+        ),
+      ]),
+    )
+    |> effects.declared_charge(QualifiedName("dep/ffi", "run"))
+  // The declaration's targets and the body's, each charged once and neither
+  // widened: no `[Unknown]` survives anywhere in the total.
+  charge.term
+  |> effect_term.to_effect_set
+  |> should.equal(Specific(set.from_list(["Time", "Stdout"])))
+  charge.fallback
+  |> option.map(effect_term.to_effect_set)
+  |> should.equal(Some(Specific(set.from_list(["Stdout"]))))
+}
+
+pub fn an_unwalked_dependency_fallback_stays_unknown_test() {
+  // The same base with nothing walked: both entries fire, and the total names
+  // the body graded could not read.
+  let charge =
+    dependency_external_base()
+    |> effects.declared_charge(QualifiedName("dep/ffi", "run"))
+  charge.term
+  |> effect_term.to_effect_set
+  |> should.equal(Specific(set.from_list(["Time", "Unknown"])))
+  charge.fallback
+  |> option.map(effect_term.to_effect_set)
+  |> should.equal(Some(Specific(set.from_list(["Unknown"]))))
+}

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -9022,6 +9022,66 @@ fn hidden() -> Nil
   |> should.be_true
 }
 
+// A fallback body calling a function-typed field on an annotated parameter,
+// against the `assume` line the dependency ships for that field.
+//
+// The line is resolved by the receiver's nominal type, and the only reading of
+// that type here is the parameter's own annotation — girard annotates no
+// dependency's source, so the walk holds no inferred type for `r`. That
+// annotation names no module, and the shipped line qualifies its type by one, so
+// the type is keyed by the module the walk is in as well as bare. Keyed bare
+// alone the line went unmatched, the call stayed polymorphic in `r.run`, and
+// this consumer — constructing the record with a pure function — specialized the
+// declared `[Disk]` away into a passing `check ... : []`.
+pub fn a_dependency_fallbacks_field_call_reads_its_declared_line_test() {
+  let root =
+    support.write_project_with_dependency(
+      directory: "build/dep_fallback_field_line",
+      package: "proj",
+      spec: "check proj.caller : []\n",
+      sources: [
+        #(
+          "proj.gleam",
+          "import dep/store
+
+pub fn quiet() -> Nil {
+  Nil
+}
+
+pub fn caller() -> Nil {
+  store.insert(store.Runner(run: quiet))
+}
+",
+        ),
+      ],
+      dependency: "dep",
+      dependency_spec: "assume dep/store : []
+assume dep/store.Runner.run : [Disk]
+",
+      dependency_sources: [
+        #(
+          "dep/store.gleam",
+          "pub type Runner {
+  Runner(run: fn() -> Nil)
+}
+
+@external(javascript, \"./store.mjs\", \"insert\")
+pub fn insert(r: Runner) -> Nil {
+  r.run()
+}
+",
+        ),
+      ],
+    )
+  let assert Ok(results) = graded.run(root)
+  support.cleanup(root)
+  let assert [violation] =
+    list.flat_map(results, fn(result) { result.violations })
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
 // A fallback body in one dependency package calling one in another. `caller` is
 // the `@external` the consumer calls; the body it falls back to calls `callee`,
 // whose own fallback body reaches the disk. Both module paths are parameters

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -2250,10 +2250,10 @@ pub fn plain_wrapper() -> Nil {
 }
 
 pub fn a_declared_dependency_external_with_a_running_fallback_widens_test() {
-  // The union a consumer cannot compute. On erlang the dependency's fallback
-  // body is what runs, and no consumer walks a dependency's bodies — so the
-  // declaration is widened by the [Unknown] that body stands for, rather than
-  // read as the whole story.
+  // The union, with the fallback half unknowable. On erlang the dependency's
+  // fallback body is what runs; walked, it reaches an external nothing declares,
+  // so the declaration is widened by the `[Unknown]` that body is worth rather
+  // than read as the whole story.
   let root = "build/foreign_values_dep_fallback"
   support.write_fixture(root, [
     #("gleam.toml", support.dual_target_toml("proj")),
@@ -2263,8 +2263,11 @@ pub fn a_declared_dependency_external_with_a_running_fallback_widens_test() {
       "build/packages/dep/src/dep/ffi.gleam",
       "@external(javascript, \"dep_ffi\", \"run\")
 pub fn run() -> Nil {
-  Nil
+  hidden()
 }
+
+@external(erlang, \"dep_ffi\", \"hidden\")
+fn hidden() -> Nil
 ",
     ),
     #(
@@ -2446,20 +2449,27 @@ pub fn wrapper() -> Nil {
 pub fn every_command_reads_a_dependency_external_on_the_same_targets_test() {
   // One name, three surfaces. The dependency's declaration is for JavaScript,
   // this package names Erlang, and what runs there is the dependency's Gleam
-  // body that no consumer walks — so all three answer `[Unknown]`. The walk
-  // narrowed and the query did not, so `check` charged the caller `[Unknown]`
-  // while `effect` answered with the declaration's `[Time]`.
+  // body — walked, and it writes to disk — so all three answer `[Disk]` and none
+  // of them the declaration's `[Time]`. The walk narrowed and the query did not,
+  // so `check` charged the caller the body's effects while `effect` answered
+  // with the declaration.
   let root = "build/dep_external_command_agreement"
   support.write_fixture(root, [
     #("gleam.toml", "name = \"proj\"\ntarget = \"erlang\"\n"),
     #("proj.graded", "check app.wrapper : []\n"),
-    #("build/packages/dep/dep.graded", "assume dep/ffi.run : [Time]\n"),
+    #(
+      "build/packages/dep/dep.graded",
+      "assume dep/ffi.run : [Time]\nassume dep/ffi.scribble : [Disk]\n",
+    ),
     #(
       "build/packages/dep/src/dep/ffi.gleam",
       "@external(javascript, \"dep_ffi\", \"run\")
 pub fn run() -> Nil {
-  Nil
+  scribble()
 }
+
+@external(erlang, \"dep_ffi\", \"scribble\")
+pub fn scribble() -> Nil
 ",
     ),
     #(
@@ -2478,10 +2488,10 @@ pub fn wrapper() -> Nil {
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
   violation.explanation.actual
-  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
 
   let assert Ok(answered) = graded.run_effect(root, "dep/ffi.run")
-  answered |> string.contains("[Unknown]") |> should.be_true()
+  answered |> string.contains("[Disk]") |> should.be_true()
   answered |> string.contains("Time") |> should.be_false()
   // The source line names what the charge came from, in `why`'s words: the body
   // running in the declaration's place. Naming the shipped spec instead pointed
@@ -2501,7 +2511,7 @@ pub fn wrapper() -> Nil {
   )
 
   let assert Ok(why) = graded.run_why(root, "app.wrapper")
-  why |> string.contains("[Unknown]") |> should.be_true()
+  why |> string.contains("[Disk]") |> should.be_true()
   why |> string.contains("Time") |> should.be_false()
   support.cleanup(root)
 }
@@ -4072,18 +4082,19 @@ pub fn w() -> Nil {
   support.cleanup(root)
 }
 
-pub fn a_dependency_declaration_the_build_excludes_is_unknown_test() {
+pub fn a_dependency_declaration_the_build_excludes_is_not_charged_test() {
   // The consumer builds for Erlang alone, and the dependency hands only
   // JavaScript to foreign code -- so what runs here is the dependency's Gleam
-  // body, which no consumer walks. Its declaration was trusted in full: the
-  // scan classified it excluded and dropped it, leaving the shipped
-  // `assume` line keyed by nothing that knew it answers for a target
-  // this build never compiles. That under-reports as readily as it
-  // over-reports, since the body reached instead may do anything at all.
+  // body, and its `[Disk]` declaration describes an implementation this build
+  // never compiles. That declaration was trusted in full: the scan classified it
+  // excluded and dropped it, leaving the shipped `assume` line keyed by nothing
+  // that knew it answers for a target this build never compiles. `check app.w :
+  // []` is the assertion — the body does nothing, and charging the declaration
+  // beside it would fail the line.
   let root = "build/dep_declaration_build_excludes"
   support.write_fixture(root, [
     #("gleam.toml", "name = \"proj\"\ntarget = \"erlang\"\n"),
-    #("proj.graded", "check app.w : [Disk]\n"),
+    #("proj.graded", "check app.w : []\n"),
     #("build/packages/dep/dep.graded", "assume dep/ffi.run : [Disk]\n"),
     #(
       "build/packages/dep/src/dep/ffi.gleam",
@@ -4104,11 +4115,9 @@ pub fn w() -> Nil {
     ),
   ])
   let assert Ok(results) = graded.run(root)
-  let assert Ok(r) =
-    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
-  let assert [violation] = r.violations
-  violation.explanation.actual
-  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
+  let assert Ok(answered) = graded.run_effect(root, "dep/ffi.run")
+  answered |> string.contains("Disk") |> should.be_false()
   support.cleanup(root)
 }
 
@@ -4191,25 +4200,31 @@ pub fn wrapper() -> Nil {
   support.cleanup(root)
 }
 
-pub fn a_dependency_declaration_out_of_reach_answers_unknown_test() {
-  // The other direction, where the widening is *all* there is to say: the
+pub fn a_dependency_declaration_out_of_reach_answers_its_body_test() {
+  // The other direction, where the fallback is *all* there is to say: the
   // dependency's declaration covers JavaScript, this body runs on Erlang, and
-  // what runs there is the dependency's Gleam fallback — which no consumer
-  // walks. The declaration's `[Disk]` describes foreign code this call never
-  // reaches, so keeping it beside the `[Unknown]` charged the caller an effect
-  // of the wrong implementation, under a message already naming the body as
-  // the source.
+  // what runs there is the dependency's Gleam fallback, which reaches the net.
+  // The declaration's `[Disk]` describes foreign code this call never reaches,
+  // so keeping it beside the body's own effects charged the caller an effect of
+  // the wrong implementation, under a message already naming the body as the
+  // source.
   let root = "build/dep_declaration_out_of_reach"
   support.write_fixture(root, [
     #("gleam.toml", support.dual_target_toml("proj")),
     #("proj.graded", "assume app.a : []\ncheck app.a : [Disk]\n"),
-    #("build/packages/dep/dep.graded", "assume dep/ffi.run : [Disk]\n"),
+    #(
+      "build/packages/dep/dep.graded",
+      "assume dep/ffi.run : [Disk]\nassume dep/ffi.reach : [Net]\n",
+    ),
     #(
       "build/packages/dep/src/dep/ffi.gleam",
       "@external(javascript, \"dep_ffi\", \"run\")
 pub fn run() -> Nil {
-  Nil
+  reach()
 }
+
+@external(erlang, \"dep_ffi\", \"reach\")
+pub fn reach() -> Nil
 ",
     ),
     #(
@@ -4228,29 +4243,34 @@ pub fn a() -> Nil {
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
   violation.explanation.actual
-  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+  |> should.equal(types.Specific(set.from_list(["Net"])))
   support.cleanup(root)
 }
 
-pub fn the_effect_fast_path_widens_a_dependency_fallback_test() {
+pub fn the_effect_fast_path_defers_a_dependency_fallback_test() {
   // The spec declares the dependency function, so the fast path could answer
   // from the spec alone — but the dependency's own source says the name is
-  // `@external` with a running fallback, which widens the answer by the
-  // `[Unknown]` no consumer can walk. The query has to say what the callers are
-  // charged, so it reads that one dependency module before answering.
+  // `@external` with a running fallback, and what that body does is added to the
+  // declaration by a walk the fast path performs no part of. The query has to
+  // say what the callers are charged, so it reads that one dependency module,
+  // sees a body runs, and hands the name to the full context.
   let root = "build/effect_fast_path_dep_fallback"
   support.write_fixture(root, [
     #("gleam.toml", support.dual_target_toml("proj")),
     #(
       "proj.graded",
-      "assume dep/ffi.run : [Time]\ncheck app.wrapper : [Time]\n",
+      "assume dep/ffi.run : [Time]\nassume dep/ffi.reach : [Net]\n"
+        <> "check app.wrapper : [Time]\n",
     ),
     #(
       "build/packages/dep/src/dep/ffi.gleam",
       "@external(javascript, \"dep_ffi\", \"run\")
 pub fn run() -> Nil {
-  Nil
+  reach()
 }
+
+@external(erlang, \"dep_ffi\", \"reach\")
+pub fn reach() -> Nil
 ",
     ),
     #(
@@ -4269,10 +4289,15 @@ pub fn wrapper() -> Nil {
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
   violation.explanation.actual
-  |> should.equal(types.Specific(set.from_list(["Time", "Unknown"])))
-  // And what the query answers for the same name.
+  |> should.equal(types.Specific(set.from_list(["Time", "Net"])))
+  // And what the query answers for the same name: the declaration the spec
+  // states, plus the body it says nothing about.
   let assert Ok(answered) = graded.run_effect(root, "dep/ffi.run")
-  answered |> string.contains("Unknown") |> should.be_true()
+  answered |> string.contains("Net") |> should.be_true()
+  answered
+  |> should.equal(
+    graded.run_effect_from_project(root, "dep/ffi.run") |> should.be_ok(),
+  )
   support.cleanup(root)
 }
 
@@ -8883,5 +8908,363 @@ pub fn wrap(f: fn() -> Nil) -> fn() -> Nil {
   violation.function |> should.equal("wrap")
   violation.explanation.actual
   |> should.equal(types.Specific(set.from_list(["Stdout"])))
+  support.cleanup(root)
+}
+
+// A dependency's running Gleam fallback body
+//
+// An `@external` a dependency declares for one target only falls back to its
+// Gleam body on the others. A consumer that compiles those targets runs that
+// body, so it is charged what the body does — walked, the way one of this
+// package's own fallback bodies is, rather than assumed to be anything.
+
+// What a consumer's call into a dependency's `@external` is charged, with that
+// external's fallback body running on a target the consumer compiles.
+fn dependency_fallback_violations(
+  name: String,
+  dependency_spec: String,
+  dependency_source: String,
+) -> List(types.Violation) {
+  let root =
+    support.write_project_with_dependency(
+      directory: "build/" <> name,
+      package: "proj",
+      spec: "check proj.caller : []\n",
+      sources: [
+        #(
+          "proj.gleam",
+          "import dep/store
+
+pub fn caller() -> Nil {
+  store.insert()
+}
+",
+        ),
+      ],
+      dependency: "dep",
+      dependency_spec: dependency_spec,
+      dependency_sources: [#("dep/store.gleam", dependency_source)],
+    )
+  let assert Ok(results) = graded.run(root)
+  let violations = list.flat_map(results, fn(result) { result.violations })
+  // The query agrees with what `check` charged, whichever path answered it.
+  let assert Ok(answered) = graded.run_effect(root, "dep/store.insert")
+  answered
+  |> should.equal(
+    graded.run_effect_from_project(root, "dep/store.insert") |> should.be_ok(),
+  )
+  support.cleanup(root)
+  violations
+}
+
+// The shape the standard library's dicts and sets have: a JavaScript external
+// whose Gleam body calls a private Erlang one beside it. On Erlang the body is
+// what runs, and every name it reaches is declared, so the call costs nothing.
+pub fn a_dependency_fallback_body_is_walked_test() {
+  dependency_fallback_violations(
+    "dep_fallback_walked",
+    "assume dep/store : []\n",
+    "@external(javascript, \"./store.mjs\", \"insert\")
+pub fn insert() -> Nil {
+  do_insert()
+}
+
+@external(erlang, \"dep_ffi\", \"insert\")
+fn do_insert() -> Nil
+",
+  )
+  |> should.equal([])
+}
+
+// Walked, not waved through: what the body reaches is charged, so a fallback
+// that calls a declared effectful name costs that effect and no more. The
+// declaration covers JavaScript, the body covers Erlang, and the consumer
+// compiling both pays the union.
+pub fn a_dependency_fallback_body_charges_what_it_calls_test() {
+  let assert [violation] =
+    dependency_fallback_violations(
+      "dep_fallback_charges",
+      "assume dep/store : []\nassume dep/store.shout : [Stdout]\n",
+      "@external(javascript, \"./store.mjs\", \"insert\")
+pub fn insert() -> Nil {
+  shout()
+}
+
+@external(erlang, \"dep_ffi\", \"shout\")
+pub fn shout() -> Nil
+",
+    )
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Stdout"])))
+}
+
+// The conservative half of the same rule: a body reaching a name nothing
+// declares is still `[Unknown]`. The declaration on the line above states what
+// the foreign implementation does and says nothing about the body beside it.
+pub fn a_dependency_fallback_body_reaching_nothing_stays_unknown_test() {
+  let assert [violation] =
+    dependency_fallback_violations(
+      "dep_fallback_unknown",
+      "assume dep/store.insert : []\n",
+      "@external(javascript, \"./store.mjs\", \"insert\")
+pub fn insert() -> Nil {
+  hidden()
+}
+
+@external(erlang, \"dep_ffi\", \"hidden\")
+fn hidden() -> Nil
+",
+    )
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> types.contains_unknown
+  |> should.be_true
+}
+
+// A fallback body in one dependency package calling one in another. `caller` is
+// the `@external` the consumer calls; the body it falls back to calls `callee`,
+// whose own fallback body reaches the disk. Both module paths are parameters
+// because the walk's order has to hold whichever way they sort: the packages'
+// directories are enumerated in no promised order, and a pass that took the
+// modules as they came would summarize `caller` against an unwalked `callee`
+// half the time.
+fn dependency_fallback_chain_violations(
+  name: String,
+  caller_path: String,
+  callee_path: String,
+) -> List(types.Violation) {
+  let root =
+    support.write_fixture("build/" <> name, [
+      #("gleam.toml", "name = \"proj\"\ntarget = \"erlang\"\n"),
+      #("proj.graded", "check proj.wrap : []\n"),
+      #("proj.gleam", "import " <> caller_path <> "
+
+pub fn wrap() -> Nil {
+  caller.run()
+}
+"),
+      #(
+        "build/packages/upstream/src/" <> caller_path <> ".gleam",
+        "import " <> callee_path <> "
+
+@external(javascript, \"upstream_ffi\", \"run\")
+pub fn run() -> Nil {
+  callee.run()
+}
+",
+      ),
+      #(
+        "build/packages/downstream/downstream.graded",
+        "assume " <> callee_path <> ".scribble : [Disk]\n",
+      ),
+      #(
+        "build/packages/downstream/src/" <> callee_path <> ".gleam",
+        "@external(javascript, \"downstream_ffi\", \"run\")
+pub fn run() -> Nil {
+  scribble()
+}
+
+@external(erlang, \"downstream_ffi\", \"scribble\")
+pub fn scribble() -> Nil
+",
+      ),
+    ])
+  let assert Ok(results) = graded.run(root)
+  let violations = list.flat_map(results, fn(result) { result.violations })
+  support.cleanup(root)
+  violations
+}
+
+// The callee sorts after the caller, so a pass following path order walks the
+// caller first and summarizes it against an unwalked callee.
+pub fn a_dependency_fallback_chain_is_walked_callee_first_test() {
+  let assert [violation] =
+    dependency_fallback_chain_violations(
+      "dep_fallback_chain_forward",
+      "a/caller",
+      "z/callee",
+    )
+  violation.function |> should.equal("wrap")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+// The same chain the other way round, where path order happens to be the walk
+// order. Both arrangements answer the same, which is the point of sorting.
+pub fn a_dependency_fallback_chain_is_walked_in_either_order_test() {
+  let assert [violation] =
+    dependency_fallback_chain_violations(
+      "dep_fallback_chain_reverse",
+      "z/caller",
+      "a/callee",
+    )
+  violation.function |> should.equal("wrap")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+// The within-module half of the same question, which the module ordering above
+// cannot settle: `a`'s fallback calls `b`'s and `b`'s calls `a`'s, so neither is
+// summarized against a settled summary of the other. The walk iterates the
+// component to a fixed point, as it does for one of this package's own.
+pub fn a_dependency_fallback_cycle_settles_to_one_summary_test() {
+  let assert [violation] =
+    dependency_fallback_violations(
+      "dep_fallback_mutual",
+      "assume dep/store : []\nassume dep/store.scribble : [Disk]\n",
+      "@external(javascript, \"store_ffi\", \"insert\")
+pub fn insert() -> Nil {
+  other(1)
+}
+
+@external(javascript, \"store_ffi\", \"a\")
+fn a(n: Int) -> Nil {
+  case n {
+    0 -> scribble()
+    _ -> other(n - 1)
+  }
+}
+
+@external(javascript, \"store_ffi\", \"b\")
+fn other(n: Int) -> Nil {
+  a(n - 1)
+}
+
+@external(erlang, \"store_ffi\", \"scribble\")
+pub fn scribble() -> Nil
+",
+    )
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+// What `infer` writes for a caller of a dependency external whose fallback body
+// runs, and that a second run writes nothing more. The walk happens where both
+// commands fold their layers, so the line `infer` publishes for consumers is the
+// charge `check` levies here.
+pub fn infer_publishes_a_walked_dependency_fallback_test() {
+  let root =
+    support.write_project_with_dependency(
+      directory: "build/dep_fallback_infer",
+      package: "proj",
+      spec: "",
+      sources: [
+        #(
+          "proj.gleam",
+          "import dep/store
+
+pub fn caller() -> Nil {
+  store.insert()
+}
+",
+        ),
+      ],
+      dependency: "dep",
+      dependency_spec: "assume dep/store : []\nassume dep/store.shout : [Stdout]\n",
+      dependency_sources: [
+        #(
+          "dep/store.gleam",
+          "@external(javascript, \"./store.mjs\", \"insert\")
+pub fn insert() -> Nil {
+  shout()
+}
+
+@external(erlang, \"dep_ffi\", \"shout\")
+pub fn shout() -> Nil
+",
+        ),
+      ],
+    )
+  let assert Ok(Nil) = graded.run_infer(root)
+  let assert Ok(written) = simplifile.read(root <> "/proj.graded")
+  written
+  |> string.contains("effects proj.caller : [Stdout]")
+  |> should.be_true()
+  // And the second run has nothing to add: the walk is part of the fold both
+  // runs perform, not state the first one left behind.
+  let assert Ok(preview) = graded.run_infer_dry_run(root)
+  preview |> should.equal("graded: no changes")
+  support.cleanup(root)
+}
+
+// The narrowing the walk does not disturb: a dependency external declaring every
+// target the consumer compiles has no body that runs, so its declaration is the
+// whole charge and nothing is unioned into it.
+pub fn a_dependency_external_covering_every_target_charges_its_declaration_test() {
+  let assert [violation] =
+    dependency_fallback_violations(
+      "dep_fallback_no_body",
+      "assume dep/store.insert : [Disk]\n",
+      "@external(erlang, \"dep_ffi\", \"insert\")
+@external(javascript, \"./store.mjs\", \"insert\")
+pub fn insert() -> Nil {
+  shout()
+}
+
+@external(erlang, \"dep_ffi\", \"shout\")
+pub fn shout() -> Nil
+",
+    )
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+// Two dependency modules importing each other, which the ordering pass cannot
+// sort. Gleam's compiler forbids the shape, so no build produces it — but graded
+// parses dependency source without compiling it, and a walk that trusted the
+// graph to be acyclic would have nothing to fall back on. Both modules are
+// dropped from the walk and keep the `[Unknown]` an unwalked body carries, and
+// the rest of the run carries on.
+pub fn a_cycle_between_dependency_fallbacks_stays_unknown_test() {
+  let root =
+    support.write_project_with_dependency(
+      directory: "build/dep_fallback_cycle",
+      package: "proj",
+      spec: "check proj.caller : []\n",
+      sources: [
+        #(
+          "proj.gleam",
+          "import dep/x
+
+pub fn caller() -> Nil {
+  x.run()
+}
+",
+        ),
+      ],
+      dependency: "dep",
+      dependency_spec: "assume dep/x : []\nassume dep/y : []\n",
+      dependency_sources: [
+        #(
+          "dep/x.gleam",
+          "import dep/y
+
+@external(javascript, \"x_ffi\", \"run\")
+pub fn run() -> Nil {
+  y.helper()
+}
+",
+        ),
+        #(
+          "dep/y.gleam",
+          "import dep/x
+
+@external(javascript, \"y_ffi\", \"helper\")
+pub fn helper() -> Nil {
+  x.run()
+}
+",
+        ),
+      ],
+    )
+  let assert Ok(results) = graded.run(root)
+  let assert [violation] = list.flat_map(results, fn(r) { r.violations })
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> types.contains_unknown
+  |> should.be_true
   support.cleanup(root)
 }

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -9023,22 +9023,23 @@ fn hidden() -> Nil
 }
 
 // A fallback body calling a function-typed field on an annotated parameter,
-// against the `assume` line the dependency ships for that field.
+// against an `assume` line for that field. `field_line` is the line, written
+// into whichever spec the caller of this passes it in — the consumer's or the
+// dependency's, which resolve it by different routes and both have to.
 //
-// The line is resolved by the receiver's nominal type, and the only reading of
-// that type here is the parameter's own annotation — girard annotates no
-// dependency's source, so the walk holds no inferred type for `r`. That
-// annotation names no module, and the shipped line qualifies its type by one, so
-// the type is keyed by the module the walk is in as well as bare. Keyed bare
-// alone the line went unmatched, the call stayed polymorphic in `r.run`, and
-// this consumer — constructing the record with a pure function — specialized the
-// declared `[Disk]` away into a passing `check ... : []`.
-pub fn a_dependency_fallbacks_field_call_reads_its_declared_line_test() {
+// The consumer constructs the record with a pure function, so a summary left
+// polymorphic in `r.run` settles at `[]` here and the `check` passes: the
+// declared effect has to reach the walk to be charged at all.
+fn dependency_fallback_field_violations(
+  name: String,
+  spec: String,
+  dependency_spec: String,
+) -> List(types.Violation) {
   let root =
     support.write_project_with_dependency(
-      directory: "build/dep_fallback_field_line",
+      directory: "build/" <> name,
       package: "proj",
-      spec: "check proj.caller : []\n",
+      spec: spec,
       sources: [
         #(
           "proj.gleam",
@@ -9055,9 +9056,7 @@ pub fn caller() -> Nil {
         ),
       ],
       dependency: "dep",
-      dependency_spec: "assume dep/store : []
-assume dep/store.Runner.run : [Disk]
-",
+      dependency_spec: dependency_spec,
       dependency_sources: [
         #(
           "dep/store.gleam",
@@ -9075,8 +9074,39 @@ pub fn insert(r: Runner) -> Nil {
     )
   let assert Ok(results) = graded.run(root)
   support.cleanup(root)
+  list.flat_map(results, fn(result) { result.violations })
+}
+
+// The line is resolved by the receiver's nominal type, and the only reading of
+// that type here is the parameter's own annotation — girard annotates no
+// dependency's source, so the walk holds no inferred type for `r`. That
+// annotation names no module, and the shipped line qualifies its type by one, so
+// the type is keyed by the module the walk is in as well as bare. Keyed bare
+// alone the line went unmatched and the declared `[Disk]` was specialized away.
+pub fn a_dependency_fallbacks_field_call_reads_its_declared_line_test() {
   let assert [violation] =
-    list.flat_map(results, fn(result) { result.violations })
+    dependency_fallback_field_violations(
+      "dep_fallback_field_line",
+      "check proj.caller : []\n",
+      "assume dep/store : []\nassume dep/store.Runner.run : [Disk]\n",
+    )
+  violation.function |> should.equal("caller")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+// The same line, written by the consumer about a dependency's type — which is
+// where a dependency shipping no spec of its own leaves it. It is charged the
+// same, so the spec's field lines have to be folded into the knowledge base
+// ahead of the walk that reads them, not merely ahead of this package's own
+// inference.
+pub fn a_dependency_fallbacks_field_call_reads_a_consumers_line_test() {
+  let assert [violation] =
+    dependency_fallback_field_violations(
+      "dep_fallback_field_line_consumer",
+      "assume dep/store.Runner.run : [Disk]\ncheck proj.caller : []\n",
+      "assume dep/store : []\n",
+    )
   violation.function |> should.equal("caller")
   violation.explanation.actual
   |> should.equal(types.Specific(set.from_list(["Disk"])))

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -9112,6 +9112,107 @@ pub fn a_dependency_fallbacks_field_call_reads_a_consumers_line_test() {
   |> should.equal(types.Specific(set.from_list(["Disk"])))
 }
 
+// The same, for a fallback body whose parameter is annotated with a type from
+// another module of its own package. `import_line` is how that module is
+// imported and `annotation` how the type is written under that import: three
+// spellings of one type, all of which have to key the one field `assume`.
+//
+// The type's own module qualifies that line, and the annotation is the only
+// reading of the receiver's type in a dependency's body, so the spelling is all
+// the walk has to go on.
+fn dependency_fallback_imported_field_violations(
+  name: String,
+  import_line: String,
+  annotation: String,
+) -> List(types.Violation) {
+  let root =
+    support.write_project_with_dependency(
+      directory: "build/" <> name,
+      package: "proj",
+      spec: "check proj.caller : []\n",
+      sources: [
+        #(
+          "proj.gleam",
+          "import dep/model
+import dep/store
+
+pub fn quiet() -> Nil {
+  Nil
+}
+
+pub fn caller() -> Nil {
+  store.insert(model.Runner(run: quiet))
+}
+",
+        ),
+      ],
+      dependency: "dep",
+      dependency_spec: "assume dep/store : []
+assume dep/model.Runner.run : [Disk]
+",
+      dependency_sources: [
+        #(
+          "dep/model.gleam",
+          "pub type Runner {
+  Runner(run: fn() -> Nil)
+}
+",
+        ),
+        #("dep/store.gleam", import_line <> "
+
+@external(javascript, \"./store.mjs\", \"insert\")
+pub fn insert(r: " <> annotation <> ") -> Nil {
+  r.run()
+}
+"),
+      ],
+    )
+  let assert Ok(results) = graded.run(root)
+  support.cleanup(root)
+  list.flat_map(results, fn(result) { result.violations })
+}
+
+// The declared `[Disk]` is charged for every spelling. A qualified annotation
+// used to name no type at all — the local registry must not claim an imported
+// type's fields — so the call fell to `[Unknown]` and a consumer's accurate
+// `check ... : [Disk]` failed. The alias the annotation is written under names
+// the module instead, which is what the line is keyed by.
+pub fn a_dependency_fallback_reads_an_imported_types_line_test() {
+  let assert [violation] =
+    dependency_fallback_imported_field_violations(
+      "dep_fallback_imported_field",
+      "import dep/model",
+      "model.Runner",
+    )
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+pub fn a_dependency_fallback_reads_an_aliased_imported_types_line_test() {
+  let assert [violation] =
+    dependency_fallback_imported_field_violations(
+      "dep_fallback_aliased_field",
+      "import dep/model as m",
+      "m.Runner",
+    )
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
+// An unqualified import writes the same type with no module beside it, which is
+// the spelling of a type of the module's own. It is the import that tells them
+// apart, so the line keyed by the defining module is still the one read.
+pub fn a_dependency_fallback_reads_an_unqualified_imported_types_line_test() {
+  let assert [violation] =
+    dependency_fallback_imported_field_violations(
+      "dep_fallback_unqualified_field",
+      "import dep/model.{type Runner}",
+      "Runner",
+    )
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk"])))
+}
+
 // A fallback body in one dependency package calling one in another. `caller` is
 // the `@external` the consumer calls; the body it falls back to calls `callee`,
 // whose own fallback body reaches the disk. Both module paths are parameters

--- a/test/signatures_test.gleam
+++ b/test/signatures_test.gleam
@@ -226,7 +226,7 @@ pub fn make() -> foo.Resolver { todo }
 fn registry_from_source_dir(
   source_dir: String,
 ) -> signatures.SignatureRegistry {
-  use acc, module_path, parsed <- signatures.fold_source_dir(
+  use acc, module_path, _source_path, parsed <- signatures.fold_source_dir(
     source_dir,
     signatures.empty(),
   )


### PR DESCRIPTION
## What

A call into a dependency `@external` whose Gleam fallback body runs on a target the build compiles is now charged what that body does, walked, instead of `[Unknown]`. The standard library is the shape this reaches: an `@external(javascript, …)` over a Gleam body that calls a private `@external(erlang, "maps", …)` beside it — every caller of `gleam/dict.insert` and its kin used to inherit an `[Unknown]` from it.

## How it resolves

- The body is read from the dependency's own source under `build/packages`, walked on the build's targets, and unioned with the declaration exactly as one of this package's own fallbacks is. `[Unknown]` remains only where the walk reaches a name nothing declares, or where the module could not be read.
- The pass folds in after every layer that can key a dependency name — catalog, dependency specs, module-level assumes, path dependencies — and before the project's own inference reads the summaries, so a fallback body resolves against everything a caller of it would.
- `graded effect` hands a dependency external with a running fallback off the fast path, so the query and `graded check` quote the same charge.

## Behaviour changes to expect

Charges move, so lines can flip: a `check f : [Unknown]` written to paper over the old answer now fails against the real set the walk produces, and a committed `effects` line for such a caller changes on the next `graded infer`.

Docs updated in `docs/REFERENCE.md`; changelog entry under Unreleased.

## Testing

All four CI gates green locally: `gleam format --check src/ test/`, `gleam build --warnings-as-errors`, `gleam test` (1171 passed), `gleam run -m glinter`.