### PR TITLE
Refuse hex tarball entry names `graded pack` cannot safely carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,29 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `graded pack` refuses a tarball whose contents name an absolute path, instead
-  of copying the host file at that path into the tarball it then tells you to
-  publish. The rebuild re-added each inner entry by joining its stored name onto
-  the unpacked directory, and an absolute name won that join outright; the
-  result verified as internally consistent, because it was — it just carried a
-  file that was never in the input. Names that escape with `..` are refused the
-  same way, with graded's own message rather than an `erl_tar` failure.
+  of copying the host file at that path into the archive it tells you to
+  publish. A name escaping the package with `..` is refused too.
 - `graded pack` refuses an archive carrying a symlink, directory, or device
-  member, naming the entry and its kind. Only regular members were ever carried
-  forward, so any other kind was dropped from the output and the run failed on a
-  files-list mismatch that named nothing.
+  member, naming the entry and its kind. Such a member was dropped from the
+  output, and the run then failed on a files-list mismatch that named nothing.
 - `graded pack` refuses a tarball whose stored `CHECKSUM` does not match its
-  contents, instead of minting a fresh checksum over the damage and handing you
-  an archive that verifies. Nothing carries the input's checksum forward — the
-  rebuild computes a new one over the new bytes — so this is the only point at
-  which a corrupt or tampered input is still distinguishable from a sound one.
-- A malformed hex tarball says what is wrong with it: a file that is not a tar,
-  a missing `VERSION` / `metadata.config` / `contents.tar.gz` / `CHECKSUM`
-  member, a `metadata.config` that does not scan or parse, and a
-  `contents.tar.gz` that is not a readable gzip stream each get their own
-  message, in place of an Erlang term printed raw.
-- `graded pack` writes the patched tarball through the descriptor it created the
-  temp path with, closing the window in which a symlink planted at that path
-  between the reservation and the write would have been followed.
+  contents, rather than replacing it with a fresh one and handing you an
+  archive that verifies.
+- A malformed tarball now says what is wrong with it — not a tar, a missing
+  member, a `metadata.config` that does not parse, a `contents.tar.gz` that is
+  not gzip — instead of failing with a raw Erlang term.
+- `graded pack` no longer follows a symlink planted at its temporary output
+  path while it writes.
 
 ## [0.16.0] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   member, naming the entry and its kind. Only regular members were ever carried
   forward, so any other kind was dropped from the output and the run failed on a
   files-list mismatch that named nothing.
+- `graded pack` refuses a tarball whose stored `CHECKSUM` does not match its
+  contents, instead of minting a fresh checksum over the damage and handing you
+  an archive that verifies. Nothing carries the input's checksum forward — the
+  rebuild computes a new one over the new bytes — so this is the only point at
+  which a corrupt or tampered input is still distinguishable from a sound one.
 - A malformed hex tarball says what is wrong with it: a file that is not a tar,
   a missing `VERSION` / `metadata.config` / `contents.tar.gz` / `CHECKSUM`
   member, a `metadata.config` that does not scan or parse, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `graded pack` refuses a tarball whose contents name an absolute path, instead
+  of copying the host file at that path into the tarball it then tells you to
+  publish. The rebuild re-added each inner entry by joining its stored name onto
+  the unpacked directory, and an absolute name won that join outright; the
+  result verified as internally consistent, because it was — it just carried a
+  file that was never in the input. Names that escape with `..` are refused the
+  same way, with graded's own message rather than an `erl_tar` failure.
+- `graded pack` refuses an archive carrying a symlink, directory, or device
+  member, naming the entry and its kind. Only regular members were ever carried
+  forward, so any other kind was dropped from the output and the run failed on a
+  files-list mismatch that named nothing.
+- A malformed hex tarball says what is wrong with it: a file that is not a tar,
+  a missing `VERSION` / `metadata.config` / `contents.tar.gz` / `CHECKSUM`
+  member, a `metadata.config` that does not scan or parse, and a
+  `contents.tar.gz` that is not a readable gzip stream each get their own
+  message, in place of an Erlang term printed raw.
+- `graded pack` writes the patched tarball through the descriptor it created the
+  temp path with, closing the window in which a symlink planted at that path
+  between the reservation and the write would have been followed.
+
 ## [0.16.0] - 2026-08-24
 
 ### Changed

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -370,6 +370,11 @@ pub fn pack_project(
       PackError("patched tarball failed verification: " <> message)
     }),
   )
+  // A rename failure is the one path that keeps the temp: by here the archive
+  // is written and verified, so it is the run's finished product and deleting
+  // it would throw away the only good copy. It has to be moved or removed by
+  // hand — the next run says so, refusing to write over a path it did not
+  // create.
   use _ <- result.try(
     simplifile.rename(temp, tarball_path)
     |> result.map_error(FileWriteError(tarball_path, _)),

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -352,26 +352,14 @@ pub fn pack_project(
   ))
 
   // Inject into a temp, verify, then replace the tarball in place, so a failed
-  // transform never leaves a corrupt archive behind. The temp is reserved with
-  // an atomic exclusive create — any existing path (a symlink included) is an
-  // error — so the cleanup below can only ever delete what this run created.
+  // transform never leaves a corrupt archive behind. `inject_spec` creates the
+  // temp itself, with an atomic exclusive create it then writes the archive
+  // through — any existing path (a symlink included) is an error — and removes
+  // it again on failure, so only what that call created is ever deleted.
   let temp = tarball_path <> ".packing"
-  use _ <- result.try(
-    reserve_path(temp)
-    |> result.map_error(fn(reason) {
-      PackError(
-        "could not reserve scratch path "
-        <> temp
-        <> " ("
-        <> reason
-        <> "); remove any leftover file and retry",
-      )
-    }),
-  )
   use checksum <- result.try(
     inject_spec(tarball_path, spec, entry_name, temp)
     |> result.map_error(fn(message) {
-      let _deleted = simplifile.delete(temp)
       PackError("could not patch " <> tarball_path <> ": " <> message)
     }),
   )
@@ -4580,11 +4568,3 @@ fn verify_tarball(tar: String, entry_name: String) -> Result(Nil, String)
 @external(erlang, "graded_pack_ffi", "read_package_identity")
 @external(javascript, "./graded_pack_ffi.mjs", "read_package_identity")
 fn read_package_identity(tar: String) -> Result(#(String, String), String)
-
-// Atomically reserve `path` for this invocation: an O_EXCL create that fails
-// on any existing path and refuses to follow symlinks (a dangling symlink is
-// rejected, not written through).
-// nolint: stringly_typed_error -- opaque posix diagnostic, wrapped in PackError
-@external(erlang, "graded_pack_ffi", "reserve_path")
-@external(javascript, "./graded_pack_ffi.mjs", "reserve_path")
-fn reserve_path(path: String) -> Result(Nil, String)

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -458,6 +458,15 @@ fn resolve_pack_tarball(
 
 // Reject an absolute path or one that escapes the package root: the spec must
 // land at a safe archive-relative location inside the package.
+//
+// Advisory, not the boundary. `graded_pack_ffi` applies the authoritative rule
+// to this entry as well as to the archive's own names, on the platform whose
+// `filename:join` semantics are what the rule defends. The two are deliberately
+// not identical: this one tests a leading `/`, which is Unix-only, and Gleam
+// has no platform-aware path predicate to test instead — `filepath.is_absolute`
+// is the same `starts_with("/")` under a `windows support` TODO. What this buys
+// is an earlier, better-worded rejection of a value the package author wrote in
+// their own gleam.toml. Do not weaken the Erlang guard to match it.
 fn validate_archive_entry(entry: String) -> Result(Nil, GradedError) {
   let escapes = list.contains(filepath.split(entry), "..")
   case string.starts_with(entry, "/") || escapes {

--- a/src/graded_pack_ffi.erl
+++ b/src/graded_pack_ffi.erl
@@ -53,19 +53,19 @@ do_inject(InTarPath, SpecBin, Entry, OutTarPath, WorkDir) ->
     InnerTmp = filename:join(WorkDir, "inner.tar"),
     InnerDir = filename:join(WorkDir, "contents"),
     assert_safe_name(Entry),
-    {ok, Outer} = erl_tar:extract(InTarPath, [memory]),
-    Version = proplists:get_value("VERSION", Outer),
-    MetaBin = proplists:get_value("metadata.config", Outer),
-    Contents = proplists:get_value("contents.tar.gz", Outer),
+    Outer = extract_outer(InTarPath, []),
+    Version = required_member("VERSION", Outer),
+    MetaBin = required_member("metadata.config", Outer),
+    Contents = required_member("contents.tar.gz", Outer),
 
     % inner tar: unpack to disk (restoring each entry's mode), re-add every
     % entry by path — erl_tar only takes modes from the filesystem, a binary
     % add silently writes 0644 — and replace any existing spec entry.
-    InnerRaw = zlib:gunzip(Contents),
-    {ok, Table} = erl_tar:table({binary, InnerRaw}, [verbose]),
+    InnerRaw = gunzip_contents(Contents),
+    Table = inner_table(InnerRaw),
     assert_safe_table(Table),
     ok = file:make_dir(InnerDir),
-    ok = erl_tar:extract({binary, InnerRaw}, [{cwd, InnerDir}]),
+    extract_inner(InnerRaw, InnerDir),
     Names = [N || {N, regular, _, _, _, _, _} <- Table, N =/= Entry],
     {ok, T} = erl_tar:open(InnerTmp, [write]),
     lists:foreach(fun(N) ->
@@ -110,11 +110,11 @@ do_inject(InTarPath, SpecBin, Entry, OutTarPath, WorkDir) ->
 % contents, and EntryName appears in both. Returns ok or {error, Reason}.
 verify_tarball(TarPath, EntryName) ->
     try
-        {ok, Outer} = erl_tar:extract(unicode:characters_to_list(TarPath), [memory]),
-        Version = proplists:get_value("VERSION", Outer),
-        MetaBin = proplists:get_value("metadata.config", Outer),
-        Contents = proplists:get_value("contents.tar.gz", Outer),
-        Stored = proplists:get_value("CHECKSUM", Outer),
+        Outer = extract_outer(unicode:characters_to_list(TarPath), []),
+        Version = required_member("VERSION", Outer),
+        MetaBin = required_member("metadata.config", Outer),
+        Contents = required_member("contents.tar.gz", Outer),
+        Stored = required_member("CHECKSUM", Outer),
         Entry = unicode:characters_to_list(EntryName),
 
         Stored =:= checksum(Version, MetaBin, Contents) orelse throw({graded_error,
@@ -122,7 +122,7 @@ verify_tarball(TarPath, EntryName) ->
 
         % The table, not a memory extract: an extract yields regular members
         % only, so it would certify a strict subset of what the archive carries.
-        {ok, Table} = erl_tar:table({binary, zlib:gunzip(Contents)}, [verbose]),
+        Table = inner_table(gunzip_contents(Contents)),
         assert_safe_table(Table),
         InnerNames = [N || {N, _, _, _, _, _, _} <- Table],
         assert_files_match(MetaBin, InnerNames),
@@ -140,9 +140,9 @@ read_package_identity(TarPath) ->
     try
         % Only metadata.config is needed; skip materialising the (dominant)
         % contents.tar.gz member.
-        {ok, Outer} = erl_tar:extract(unicode:characters_to_list(TarPath),
-            [memory, {files, ["metadata.config"]}]),
-        MetaBin = proplists:get_value("metadata.config", Outer),
+        Outer = extract_outer(unicode:characters_to_list(TarPath),
+            [{files, ["metadata.config"]}]),
+        MetaBin = required_member("metadata.config", Outer),
         Terms = config_terms(MetaBin),
         Name = to_binary(proplists:get_value(<<"name">>, Terms)),
         Version = to_binary(proplists:get_value(<<"version">>, Terms)),
@@ -152,6 +152,7 @@ read_package_identity(TarPath) ->
             _ -> {ok, {Name, Version}}
         end
     catch
+        throw:{graded_error, Msg} -> {error, Msg};
         _:Reason -> {error, format_reason(Reason)}
     end.
 
@@ -164,15 +165,26 @@ files_of(MetaBin) ->
 % Parse a metadata.config binary into a proplist of Erlang terms. hex writes it
 % as a sequence of dot-terminated terms.
 config_terms(Bin) ->
-    {ok, Tokens, _} = erl_scan:string(unicode:characters_to_list(Bin)),
-    parse_terms(Tokens, []).
+    case erl_scan:string(unicode:characters_to_list(Bin)) of
+        {ok, Tokens, _} -> parse_terms(Tokens, []);
+        {error, Info, _} -> throw({graded_error, iolist_to_binary([
+            "metadata.config does not scan as Erlang terms: ",
+            format_reason(Info)])})
+    end.
 
 parse_terms([], Acc) -> lists:reverse(Acc);
 parse_terms(Tokens, Acc) ->
-    {Before, [Dot | Rest]} = lists:splitwith(
-        fun({dot, _}) -> false; (_) -> true end, Tokens),
-    {ok, Term} = erl_parse:parse_term(Before ++ [Dot]),
-    parse_terms(Rest, [Term | Acc]).
+    case lists:splitwith(fun({dot, _}) -> false; (_) -> true end, Tokens) of
+        {_, []} -> throw({graded_error,
+            <<"metadata.config has a term with no terminating `.`">>});
+        {Before, [Dot | Rest]} ->
+            case erl_parse:parse_term(Before ++ [Dot]) of
+                {ok, Term} -> parse_terms(Rest, [Term | Acc]);
+                {error, Info} -> throw({graded_error, iolist_to_binary([
+                    "metadata.config has a term that does not parse: ",
+                    format_reason(Info)])})
+            end
+    end.
 
 to_binary(undefined) -> undefined;
 to_binary(V) when is_binary(V) -> V;
@@ -182,6 +194,54 @@ to_binary(V) when is_list(V) -> unicode:characters_to_binary(V).
 % contents.tar.gz, hashed as iodata so the tarball bytes are never copied.
 checksum(Version, Meta, Contents) ->
     binary:encode_hex(crypto:hash(sha256, [Version, Meta, Contents]), uppercase).
+
+% Read an outer tar's members into memory, naming the file rather than
+% badmatching on a corrupt or non-tar input — the first thing a malformed file
+% hits, and until now the one that produced the least about it.
+extract_outer(TarPath, Opts) ->
+    case erl_tar:extract(TarPath, [memory | Opts]) of
+        {ok, Members} -> Members;
+        {error, Reason} -> throw({graded_error, iolist_to_binary([
+            "could not read ", TarPath, " as a hex tarball: ",
+            format_reason(Reason)])})
+    end.
+
+% A member a hex tarball must carry. proplists:get_value/2 answers `undefined`
+% for a missing one, which travels as far as the term that consumes it before
+% failing as something else entirely.
+required_member(Name, Outer) ->
+    case proplists:get_value(Name, Outer) of
+        undefined -> throw({graded_error, iolist_to_binary([
+            "hex tarball has no ", Name, " member"])});
+        Value -> Value
+    end.
+
+% zlib:gunzip/1 raises data_error on a truncated or corrupt stream.
+gunzip_contents(Contents) ->
+    try zlib:gunzip(Contents)
+    catch _:_ -> throw({graded_error,
+        <<"contents.tar.gz is not a readable gzip stream">>})
+    end.
+
+% The inner tar's table. Gunzipping cleanly says nothing about what the bytes
+% then are.
+inner_table(InnerRaw) ->
+    case erl_tar:table({binary, InnerRaw}, [verbose]) of
+        {ok, Table} -> Table;
+        {error, Reason} -> throw({graded_error, iolist_to_binary([
+            "could not read contents.tar.gz as a tar archive: ",
+            format_reason(Reason)])})
+    end.
+
+% Whatever erl_tar rejects that graded's own rules did not anticipate. The
+% unsafe-name and unsafe-symlink refusals it would otherwise raise here are
+% unreachable — assert_safe_table has already refused both, before extraction.
+extract_inner(InnerRaw, InnerDir) ->
+    case erl_tar:extract({binary, InnerRaw}, [{cwd, InnerDir}]) of
+        ok -> ok;
+        {error, Reason} -> throw({graded_error, iolist_to_binary([
+            "could not unpack contents.tar.gz: ", format_reason(Reason)])})
+    end.
 
 % Throw unless every member of an inner tar table is one graded can safely carry
 % forward. The rebuild in do_inject re-adds each member by

--- a/src/graded_pack_ffi.erl
+++ b/src/graded_pack_ffi.erl
@@ -86,12 +86,25 @@ do_inject(InTarPath, SpecBin, Entry, OutFd, WorkDir) ->
     Version = required_member("VERSION", Outer),
     MetaBin = required_member("metadata.config", Outer),
     Contents = required_member("contents.tar.gz", Outer),
+    Stored = required_member("CHECKSUM", Outer),
 
     % inner tar: unpack to disk (restoring each entry's mode), re-add every
     % entry by path — erl_tar only takes modes from the filesystem, a binary
     % add silently writes 0644 — and replace any existing spec entry.
     InnerRaw = gunzip_contents(Contents),
     Table = safe_inner_table(InnerRaw),
+
+    % The input's own integrity, checked once the more specific failures above
+    % have had their say. Nothing carries this checksum forward — the rebuild
+    % mints a fresh one over the new bytes — so this is the only point where a
+    % corrupt or tampered input is still distinguishable from a sound one.
+    % Minting a valid checksum over damaged contents would launder the damage
+    % into an archive that verifies, and the run ends by telling the user to
+    % publish it.
+    Stored =:= checksum(Version, MetaBin, Contents) orelse
+        fail(["the tarball's stored CHECKSUM does not match its contents; ",
+            "rebuild it with `gleam export hex-tarball`"]),
+
     ok = file:make_dir(InnerDir),
     extract_inner(InnerRaw, InnerDir),
     Names = [N || N <- names(Table), N =/= Entry],

--- a/src/graded_pack_ffi.erl
+++ b/src/graded_pack_ffi.erl
@@ -1,6 +1,6 @@
 -module(graded_pack_ffi).
--export([inject_spec/4, verify_tarball/2, read_package_identity/1, files_of/1,
-         tar_io/2]).
+-export([inject_spec/4, verify_tarball/2, read_package_identity/1,
+         files_of/1]).
 
 % Inject a `.graded` spec into a hex tarball, following hex_tarball.erl's
 % mechanics:
@@ -91,11 +91,10 @@ do_inject(InTarPath, SpecBin, Entry, OutFd, WorkDir) ->
     % entry by path — erl_tar only takes modes from the filesystem, a binary
     % add silently writes 0644 — and replace any existing spec entry.
     InnerRaw = gunzip_contents(Contents),
-    Table = inner_table(InnerRaw),
-    assert_safe_table(Table),
+    Table = safe_inner_table(InnerRaw),
     ok = file:make_dir(InnerDir),
     extract_inner(InnerRaw, InnerDir),
-    Names = [N || {N, regular, _, _, _, _, _} <- Table, N =/= Entry],
+    Names = [N || N <- names(Table), N =/= Entry],
     {ok, T} = erl_tar:open(InnerTmp, [write]),
     lists:foreach(fun(N) ->
         ok = erl_tar:add(T, filename:join(InnerDir, N), N, [])
@@ -115,8 +114,8 @@ do_inject(InTarPath, SpecBin, Entry, OutFd, WorkDir) ->
             NewLine = iolist_to_binary(["  <<\"", Entry, "\"/utf8>>,\n"]),
             Spliced = binary:replace(MetaBin, Marker,
                 <<Marker/binary, NewLine/binary>>),
-            Spliced =:= MetaBin andalso throw({graded_error,
-                <<"metadata.config files-list marker not found">>}),
+            Spliced =:= MetaBin andalso
+                fail(["metadata.config files-list marker not found"]),
             Spliced
     end,
 
@@ -126,7 +125,7 @@ do_inject(InTarPath, SpecBin, Entry, OutFd, WorkDir) ->
     Checksum = checksum(Version, NewMeta, NewContents),
 
     % rebuild outer tar, through the descriptor inject_into holds open.
-    {ok, O} = erl_tar:init(OutFd, write, fun ?MODULE:tar_io/2),
+    {ok, O} = erl_tar:init(OutFd, write, fun tar_io/2),
     ok = erl_tar:add(O, Version, "VERSION", []),
     ok = erl_tar:add(O, NewMeta, "metadata.config", []),
     ok = erl_tar:add(O, NewContents, "contents.tar.gz", []),
@@ -146,17 +145,15 @@ verify_tarball(TarPath, EntryName) ->
         Stored = required_member("CHECKSUM", Outer),
         Entry = unicode:characters_to_list(EntryName),
 
-        Stored =:= checksum(Version, MetaBin, Contents) orelse throw({graded_error,
-            <<"stored CHECKSUM does not match recomputed inner checksum">>}),
+        Stored =:= checksum(Version, MetaBin, Contents) orelse
+            fail(["stored CHECKSUM does not match recomputed inner checksum"]),
 
         % The table, not a memory extract: an extract yields regular members
         % only, so it would certify a strict subset of what the archive carries.
-        Table = inner_table(gunzip_contents(Contents)),
-        assert_safe_table(Table),
-        InnerNames = [N || {N, _, _, _, _, _, _} <- Table],
+        InnerNames = names(safe_inner_table(gunzip_contents(Contents))),
         assert_files_match(MetaBin, InnerNames),
-        lists:member(Entry, InnerNames) orelse throw({graded_error,
-            <<"injected spec not present in the tarball">>}),
+        lists:member(Entry, InnerNames) orelse
+            fail(["injected spec not present in the tarball"]),
         {ok, nil}
     catch
         throw:{graded_error, Msg} -> {error, Msg};
@@ -196,22 +193,19 @@ files_of(MetaBin) ->
 config_terms(Bin) ->
     case erl_scan:string(unicode:characters_to_list(Bin)) of
         {ok, Tokens, _} -> parse_terms(Tokens, []);
-        {error, Info, _} -> throw({graded_error, iolist_to_binary([
-            "metadata.config does not scan as Erlang terms: ",
-            format_reason(Info)])})
+        {error, Info, _} -> fail(["metadata.config does not scan as Erlang ",
+            "terms: ", format_reason(Info)])
     end.
 
 parse_terms([], Acc) -> lists:reverse(Acc);
 parse_terms(Tokens, Acc) ->
     case lists:splitwith(fun({dot, _}) -> false; (_) -> true end, Tokens) of
-        {_, []} -> throw({graded_error,
-            <<"metadata.config has a term with no terminating `.`">>});
+        {_, []} -> fail(["metadata.config has a term with no terminating `.`"]);
         {Before, [Dot | Rest]} ->
             case erl_parse:parse_term(Before ++ [Dot]) of
                 {ok, Term} -> parse_terms(Rest, [Term | Acc]);
-                {error, Info} -> throw({graded_error, iolist_to_binary([
-                    "metadata.config has a term that does not parse: ",
-                    format_reason(Info)])})
+                {error, Info} -> fail(["metadata.config has a term that ",
+                    "does not parse: ", format_reason(Info)])
             end
     end.
 
@@ -230,9 +224,8 @@ checksum(Version, Meta, Contents) ->
 extract_outer(TarPath, Opts) ->
     case erl_tar:extract(TarPath, [memory | Opts]) of
         {ok, Members} -> Members;
-        {error, Reason} -> throw({graded_error, iolist_to_binary([
-            "could not read ", TarPath, " as a hex tarball: ",
-            format_reason(Reason)])})
+        {error, Reason} -> fail(["could not read ", TarPath,
+            " as a hex tarball: ", format_reason(Reason)])
     end.
 
 % A member a hex tarball must carry. proplists:get_value/2 answers `undefined`
@@ -240,61 +233,56 @@ extract_outer(TarPath, Opts) ->
 % failing as something else entirely.
 required_member(Name, Outer) ->
     case proplists:get_value(Name, Outer) of
-        undefined -> throw({graded_error, iolist_to_binary([
-            "hex tarball has no ", Name, " member"])});
+        undefined -> fail(["hex tarball has no ", Name, " member"]);
         Value -> Value
     end.
 
 % zlib:gunzip/1 raises data_error on a truncated or corrupt stream.
 gunzip_contents(Contents) ->
     try zlib:gunzip(Contents)
-    catch _:_ -> throw({graded_error,
-        <<"contents.tar.gz is not a readable gzip stream">>})
+    catch _:_ -> fail(["contents.tar.gz is not a readable gzip stream"])
     end.
 
-% The inner tar's table. Gunzipping cleanly says nothing about what the bytes
-% then are.
-inner_table(InnerRaw) ->
+% The inner tar's table, with every member already judged safe to carry
+% forward — the two are one call so that no reader of the table can hold an
+% unvalidated one. Gunzipping cleanly says nothing about what the bytes then
+% are, so the read has its own diagnostic.
+safe_inner_table(InnerRaw) ->
     case erl_tar:table({binary, InnerRaw}, [verbose]) of
-        {ok, Table} -> Table;
-        {error, Reason} -> throw({graded_error, iolist_to_binary([
-            "could not read contents.tar.gz as a tar archive: ",
-            format_reason(Reason)])})
+        {ok, Table} -> lists:foreach(fun assert_safe_member/1, Table), Table;
+        {error, Reason} -> fail(["could not read contents.tar.gz as a tar ",
+            "archive: ", format_reason(Reason)])
     end.
+
+names(Table) -> [Name || {Name, _, _, _, _, _, _} <- Table].
+
+% Throw unless a member is one graded can safely carry forward. The rebuild in
+% do_inject re-adds each by filename:join(InnerDir, Name), and filename:join/2
+% lets an absolute second argument win outright — so an absolute name in a
+% crafted archive would read the *host* file at that path and embed it in the
+% tarball graded then tells the user to publish. This runs before anything is
+% extracted: a name is judged before the archive it came from reaches disk.
+assert_safe_member({Name, Type, _Size, _MTime, _Mode, _Uid, _Gid}) ->
+    assert_safe_name(Name),
+    % Only regular members can be re-added, so any other kind would be dropped
+    % from the output rather than carried, and the run would fail on the
+    % files-list mismatch naming nothing. Refuse it here, naming the entry and
+    % its actual kind. A link's target is invisible to any check here —
+    % erl_tar:table/2 leaves it out of the tuple — which is why the kind is
+    % what gets refused.
+    Type =:= regular orelse fail([
+        "graded pack does not support archives with non-regular members (`",
+        Name, "` is a ", atom_to_list(Type), ")"]).
 
 % Whatever erl_tar rejects that graded's own rules did not anticipate. The
 % unsafe-name and unsafe-symlink refusals it would otherwise raise here are
-% unreachable — assert_safe_table has already refused both, before extraction.
+% unreachable — safe_inner_table has already refused both, before extraction.
 extract_inner(InnerRaw, InnerDir) ->
     case erl_tar:extract({binary, InnerRaw}, [{cwd, InnerDir}]) of
         ok -> ok;
-        {error, Reason} -> throw({graded_error, iolist_to_binary([
-            "could not unpack contents.tar.gz: ", format_reason(Reason)])})
+        {error, Reason} -> fail(["could not unpack contents.tar.gz: ",
+            format_reason(Reason)])
     end.
-
-% Throw unless every member of an inner tar table is one graded can safely carry
-% forward. The rebuild in do_inject re-adds each member by
-% filename:join(InnerDir, Name), and filename:join/2 lets an absolute second
-% argument win outright — so an absolute name in a crafted archive would read
-% the *host* file at that path and embed it in the tarball graded then tells the
-% user to publish. Read the table and run this before anything is extracted: a
-% name is judged before the archive it came from is written to disk.
-assert_safe_table(Table) ->
-    lists:foreach(fun assert_safe_member/1, Table).
-
-assert_safe_member({Name, Type, _Size, _MTime, _Mode, _Uid, _Gid}) ->
-    assert_safe_name(Name),
-    % Only regular members are re-added, so any other kind is dropped from the
-    % output rather than carried, and the run then fails on the files-list
-    % mismatch naming nothing. Refuse it here, naming the entry and its actual
-    % kind. A link's target is invisible to any check here — erl_tar:table/2
-    % leaves it out of the tuple — which is why the kind is what is refused.
-    Type =:= regular orelse throw({graded_error, iolist_to_binary([
-        "graded pack does not support archives with non-regular members (`",
-        Name, "` is a ", atom_to_list(Type), ")"])});
-assert_safe_member(Member) ->
-    throw({graded_error, unicode:characters_to_binary(io_lib:format(
-        "unreadable inner tar entry: ~p", [Member]))}).
 
 % Throw unless Name is a relative path with no `..` component.
 %
@@ -314,15 +302,17 @@ assert_safe_name(Name0) ->
     ok.
 
 unsafe_name(Name) ->
-    throw({graded_error, iolist_to_binary([
-        "unsafe tar entry name `", Name,
-        "`: entries must be relative paths inside the package"])}).
+    fail(["unsafe tar entry name `", Name,
+        "`: entries must be relative paths inside the package"]).
 
 % Throw unless the metadata files list equals the inner tar names as sets.
 assert_files_match(MetaBin, InnerNames) ->
     lists:sort(files_of(MetaBin)) =:= lists:sort(InnerNames) orelse
-        throw({graded_error,
-            <<"metadata files list does not match inner tar contents">>}).
+        fail(["metadata files list does not match inner tar contents"]).
+
+% Every diagnostic this module raises, as one message the callers' catch
+% clauses turn back into {error, Binary}.
+fail(Parts) -> throw({graded_error, iolist_to_binary(Parts)}).
 
 format_reason(Reason) ->
     unicode:characters_to_binary(io_lib:format("~p", [Reason])).

--- a/src/graded_pack_ffi.erl
+++ b/src/graded_pack_ffi.erl
@@ -52,6 +52,7 @@ inject_spec(InTar, SpecBin, EntryName, OutTar) ->
 do_inject(InTarPath, SpecBin, Entry, OutTarPath, WorkDir) ->
     InnerTmp = filename:join(WorkDir, "inner.tar"),
     InnerDir = filename:join(WorkDir, "contents"),
+    assert_safe_name(Entry),
     {ok, Outer} = erl_tar:extract(InTarPath, [memory]),
     Version = proplists:get_value("VERSION", Outer),
     MetaBin = proplists:get_value("metadata.config", Outer),
@@ -61,9 +62,10 @@ do_inject(InTarPath, SpecBin, Entry, OutTarPath, WorkDir) ->
     % entry by path — erl_tar only takes modes from the filesystem, a binary
     % add silently writes 0644 — and replace any existing spec entry.
     InnerRaw = zlib:gunzip(Contents),
+    {ok, Table} = erl_tar:table({binary, InnerRaw}, [verbose]),
+    assert_safe_table(Table),
     ok = file:make_dir(InnerDir),
     ok = erl_tar:extract({binary, InnerRaw}, [{cwd, InnerDir}]),
-    {ok, Table} = erl_tar:table({binary, InnerRaw}, [verbose]),
     Names = [N || {N, regular, _, _, _, _, _} <- Table, N =/= Entry],
     {ok, T} = erl_tar:open(InnerTmp, [write]),
     lists:foreach(fun(N) ->
@@ -118,8 +120,11 @@ verify_tarball(TarPath, EntryName) ->
         Stored =:= checksum(Version, MetaBin, Contents) orelse throw({graded_error,
             <<"stored CHECKSUM does not match recomputed inner checksum">>}),
 
-        {ok, Inner} = erl_tar:extract({binary, zlib:gunzip(Contents)}, [memory]),
-        InnerNames = [N || {N, _} <- Inner],
+        % The table, not a memory extract: an extract yields regular members
+        % only, so it would certify a strict subset of what the archive carries.
+        {ok, Table} = erl_tar:table({binary, zlib:gunzip(Contents)}, [verbose]),
+        assert_safe_table(Table),
+        InnerNames = [N || {N, _, _, _, _, _, _} <- Table],
         assert_files_match(MetaBin, InnerNames),
         lists:member(Entry, InnerNames) orelse throw({graded_error,
             <<"injected spec not present in the tarball">>}),
@@ -177,6 +182,52 @@ to_binary(V) when is_list(V) -> unicode:characters_to_binary(V).
 % contents.tar.gz, hashed as iodata so the tarball bytes are never copied.
 checksum(Version, Meta, Contents) ->
     binary:encode_hex(crypto:hash(sha256, [Version, Meta, Contents]), uppercase).
+
+% Throw unless every member of an inner tar table is one graded can safely carry
+% forward. The rebuild in do_inject re-adds each member by
+% filename:join(InnerDir, Name), and filename:join/2 lets an absolute second
+% argument win outright — so an absolute name in a crafted archive would read
+% the *host* file at that path and embed it in the tarball graded then tells the
+% user to publish. Read the table and run this before anything is extracted: a
+% name is judged before the archive it came from is written to disk.
+assert_safe_table(Table) ->
+    lists:foreach(fun assert_safe_member/1, Table).
+
+assert_safe_member({Name, Type, _Size, _MTime, _Mode, _Uid, _Gid}) ->
+    assert_safe_name(Name),
+    % Only regular members are re-added, so any other kind is dropped from the
+    % output rather than carried, and the run then fails on the files-list
+    % mismatch naming nothing. Refuse it here, naming the entry and its actual
+    % kind. A link's target is invisible to any check here — erl_tar:table/2
+    % leaves it out of the tuple — which is why the kind is what is refused.
+    Type =:= regular orelse throw({graded_error, iolist_to_binary([
+        "graded pack does not support archives with non-regular members (`",
+        Name, "` is a ", atom_to_list(Type), ")"])});
+assert_safe_member(Member) ->
+    throw({graded_error, unicode:characters_to_binary(io_lib:format(
+        "unreadable inner tar entry: ~p", [Member]))}).
+
+% Throw unless Name is a relative path with no `..` component.
+%
+% Path *type* is the test, not a leading slash: filename:pathtype/1 is
+% platform-dependent in exactly the way the filename:join/2 it defends is, so
+% the guard tracks the operation rather than one platform's spelling of it
+% ("C:/x" is relative on Unix and absolute on Windows, and "C:x" is a third
+% case — volumerelative — that a slash test misses entirely).
+%
+% The raw name is what gets checked, never a normalised one: normalising
+% collapses an internal `a/../x` to `x` and would admit a name this rule
+% rejects. `..` is its own clause because pathtype("..") is `relative`.
+assert_safe_name(Name0) ->
+    Name = unicode:characters_to_list(Name0),
+    filename:pathtype(Name) =:= relative orelse unsafe_name(Name),
+    lists:member("..", filename:split(Name)) andalso unsafe_name(Name),
+    ok.
+
+unsafe_name(Name) ->
+    throw({graded_error, iolist_to_binary([
+        "unsafe tar entry name `", Name,
+        "`: entries must be relative paths inside the package"])}).
 
 % Throw unless the metadata files list equals the inner tar names as sets.
 assert_files_match(MetaBin, InnerNames) ->

--- a/src/graded_pack_ffi.erl
+++ b/src/graded_pack_ffi.erl
@@ -1,19 +1,6 @@
 -module(graded_pack_ffi).
 -export([inject_spec/4, verify_tarball/2, read_package_identity/1, files_of/1,
-         reserve_path/1]).
-
-% Atomically reserve Path for this invocation: an O_EXCL create, which fails
-% with eexist on any existing path and refuses to follow symlinks — a dangling
-% symlink is rejected rather than followed and written through. Returns
-% {ok, nil} or {error, Reason}.
-reserve_path(Path) ->
-    case file:open(unicode:characters_to_list(Path), [write, exclusive]) of
-        {ok, Fd} ->
-            ok = file:close(Fd),
-            {ok, nil};
-        {error, Reason} ->
-            {error, format_reason(Reason)}
-    end.
+         tar_io/2]).
 
 % Inject a `.graded` spec into a hex tarball, following hex_tarball.erl's
 % mechanics:
@@ -24,21 +11,18 @@ reserve_path(Path) ->
 %   - rebuild the outer tar (VERSION, metadata.config, contents.tar.gz, CHECKSUM)
 % Re-running on an already-packed tarball replaces the spec entry rather than
 % appending a duplicate, so the result stays canonical.
+% Both scratch paths — the work directory and OutTar itself — are created here
+% and owned here: each is an exclusive create that fails on a pre-existing path,
+% and only what this invocation created is ever removed.
 % Returns {ok, Checksum} (uppercase hex) or {error, Reason} (a binary message).
 inject_spec(InTar, SpecBin, EntryName, OutTar) ->
     OutTarPath = unicode:characters_to_list(OutTar),
-    % All scratch state lives inside one exclusively-created work directory, so
-    % cleanup only ever deletes what this invocation created — a pre-existing
-    % path with the same name is an error, never a recursive delete.
     WorkDir = OutTarPath ++ ".work",
     case file:make_dir(WorkDir) of
         ok ->
             try
-                do_inject(unicode:characters_to_list(InTar), SpecBin,
+                inject_into(unicode:characters_to_list(InTar), SpecBin,
                     unicode:characters_to_list(EntryName), OutTarPath, WorkDir)
-            catch
-                throw:{graded_error, Msg} -> {error, Msg};
-                _:Reason -> {error, format_reason(Reason)}
             after
                 file:del_dir_r(WorkDir)
             end;
@@ -49,7 +33,52 @@ inject_spec(InTar, SpecBin, EntryName, OutTar) ->
             {error, format_reason(Reason)}
     end.
 
-do_inject(InTarPath, SpecBin, Entry, OutTarPath, WorkDir) ->
+% Create the output tarball with an O_EXCL open and write it through the
+% descriptor that open returns.
+%
+% Creating exclusively and then closing would only prove the path was free at
+% that instant: erl_tar:open/2 takes a filename, so it re-opens by name and
+% follows a symlink planted in between. That is not hygiene — verify_tarball
+% re-opens the result by name and the flow renames it over the original, and on
+% Windows renaming a file with an open handle fails. erl_tar:init/3 takes user
+% data and an I/O fun instead, so the archive goes through the retained
+% descriptor and the path is never resolved a second time.
+inject_into(InTarPath, SpecBin, Entry, OutTarPath, WorkDir) ->
+    case file:open(OutTarPath, [write, exclusive, binary]) of
+        {ok, Fd} ->
+            try
+                do_inject(InTarPath, SpecBin, Entry, Fd, WorkDir)
+            catch
+                throw:{graded_error, Msg} -> failed_inject(OutTarPath, Fd, Msg);
+                _:Reason ->
+                    failed_inject(OutTarPath, Fd, format_reason(Reason))
+            after
+                file:close(Fd)
+            end;
+        {error, eexist} ->
+            {error, iolist_to_binary(["output path already exists: ",
+                OutTarPath, "; remove it and retry"])};
+        {error, Reason} ->
+            {error, format_reason(Reason)}
+    end.
+
+% A half-written output tarball is this invocation's own, so it goes; a path
+% that was already there never reaches here, because the exclusive create
+% refused it. Closing before deleting keeps the order Windows needs.
+failed_inject(OutTarPath, Fd, Msg) ->
+    _ = file:close(Fd),
+    _ = file:delete(OutTarPath),
+    {error, Msg}.
+
+% erl_tar's I/O interface over a descriptor the caller owns. `close` is a no-op
+% so erl_tar:close/1 flushes the archive and leaves the descriptor open for
+% inject_into's `after` to close — erl_tar:close/1 is not reached on a throw, so
+% closing here would leak the descriptor on exactly the paths that matter.
+tar_io(write, {Fd, Bytes}) -> file:write(Fd, Bytes);
+tar_io(position, {Fd, Pos}) -> file:position(Fd, Pos);
+tar_io(close, _) -> ok.
+
+do_inject(InTarPath, SpecBin, Entry, OutFd, WorkDir) ->
     InnerTmp = filename:join(WorkDir, "inner.tar"),
     InnerDir = filename:join(WorkDir, "contents"),
     assert_safe_name(Entry),
@@ -96,8 +125,8 @@ do_inject(InTarPath, SpecBin, Entry, OutTarPath, WorkDir) ->
     % inner checksum over the final bytes.
     Checksum = checksum(Version, NewMeta, NewContents),
 
-    % rebuild outer tar.
-    {ok, O} = erl_tar:open(OutTarPath, [write]),
+    % rebuild outer tar, through the descriptor inject_into holds open.
+    {ok, O} = erl_tar:init(OutFd, write, fun ?MODULE:tar_io/2),
     ok = erl_tar:add(O, Version, "VERSION", []),
     ok = erl_tar:add(O, NewMeta, "metadata.config", []),
     ok = erl_tar:add(O, NewContents, "contents.tar.gz", []),

--- a/src/graded_pack_ffi.mjs
+++ b/src/graded_pack_ffi.mjs
@@ -16,7 +16,3 @@ export function verify_tarball(_tar, _entry_name) {
 export function read_package_identity(_tar) {
   return new GError(unsupported);
 }
-
-export function reserve_path(_path) {
-  return new GError(unsupported);
-}

--- a/test/graded_pack_test_ffi.erl
+++ b/test/graded_pack_test_ffi.erl
@@ -25,17 +25,13 @@ build_tarball_with_modes(OutPath, Name, Version, InnerFiles) ->
         ok = file:write_file(Abs, C),
         ok = file:change_mode(Abs, Mode)
     end, InnerFiles),
-    InnerTmp = Out ++ ".inner",
-    {ok, T} = erl_tar:open(InnerTmp, [write]),
-    lists:foreach(fun(P) ->
-        Path = binary_to_list(P),
-        ok = erl_tar:add(T, filename:join(Staging, Path), Path, [])
-    end, Paths),
-    ok = erl_tar:close(T),
-    {ok, InnerBytes} = file:read_file(InnerTmp),
-    ok = file:delete(InnerTmp),
-    ok = file:del_dir_r(Staging),
-    write_outer(Out, Name, Version, Paths, zlib:gzip(InnerBytes)).
+    Contents = inner_gzip(Out, Staging, fun(T) ->
+        lists:foreach(fun(P) ->
+            Path = binary_to_list(P),
+            ok = erl_tar:add(T, filename:join(Staging, Path), Path, [])
+        end, Paths)
+    end),
+    write_outer(Out, Name, Version, Paths, Contents).
 
 % Build a tarball whose inner entry names are stored *verbatim*, including names
 % no legitimate hex tarball carries: an absolute path, a `..` component, a
@@ -51,26 +47,38 @@ build_tarball_with_modes(OutPath, Name, Version, InnerFiles) ->
 build_tarball_with_raw_names(OutPath, Name, Version, Members) ->
     Out = binary_to_list(OutPath),
     Staging = Out ++ ".staging",
-    InnerTmp = Out ++ ".inner",
-    {ok, T} = erl_tar:open(InnerTmp, [write]),
-    lists:foreach(fun(M) -> add_member(T, Staging, M) end, Members),
-    ok = erl_tar:close(T),
-    {ok, InnerBytes} = file:read_file(InnerTmp),
-    ok = file:delete(InnerTmp),
-    _ = file:del_dir_r(Staging),
-    write_outer(Out, Name, Version, [member_name(M) || M <- Members],
-        zlib:gzip(InnerBytes)).
+    Contents = inner_gzip(Out, Staging, fun(T) ->
+        lists:foreach(fun(M) -> add_member(T, Staging, M) end, Members)
+    end),
+    write_outer(Out, Name, Version, [member_name(M) || M <- Members], Contents).
 
 % Build an outer tar holding exactly Members ({Name, Content} binaries) and
 % nothing else, for the malformed-archive diagnostics: a missing member, a
 % metadata.config that does not parse, a contents.tar.gz that is not gzip.
 build_outer_tarball(OutPath, Members) ->
-    {ok, O} = erl_tar:open(binary_to_list(OutPath), [write]),
+    write_tar(binary_to_list(OutPath), Members).
+
+% Write a tar of {Name, Content} binaries. erl_tar has no build-to-memory mode,
+% so the inner tar goes through a scratch file its caller names.
+write_tar(Path, Members) ->
+    {ok, T} = erl_tar:open(Path, [write]),
     lists:foreach(fun({N, C}) ->
-        ok = erl_tar:add(O, C, binary_to_list(N), [])
+        ok = erl_tar:add(T, C, binary_to_list(N), [])
     end, Members),
-    ok = erl_tar:close(O),
+    ok = erl_tar:close(T),
     nil.
+
+% The gzipped inner tar AddFun writes, with the scratch file and staging
+% directory it needed cleaned up behind it.
+inner_gzip(Out, Staging, AddFun) ->
+    InnerTmp = Out ++ ".inner",
+    {ok, T} = erl_tar:open(InnerTmp, [write]),
+    AddFun(T),
+    ok = erl_tar:close(T),
+    {ok, InnerBytes} = file:read_file(InnerTmp),
+    ok = file:delete(InnerTmp),
+    _ = file:del_dir_r(Staging),
+    zlib:gzip(InnerBytes).
 
 member_name({regular, Name, _}) -> Name;
 member_name({symlink, Name, _}) -> Name.
@@ -94,13 +102,10 @@ write_outer(Out, Name, Version, Paths, Contents) ->
     Hash = crypto:hash(sha256, [Version0, Meta, Contents]),
     Checksum = binary:encode_hex(Hash, uppercase),
 
-    {ok, O} = erl_tar:open(Out, [write]),
-    ok = erl_tar:add(O, Version0, "VERSION", []),
-    ok = erl_tar:add(O, Meta, "metadata.config", []),
-    ok = erl_tar:add(O, Contents, "contents.tar.gz", []),
-    ok = erl_tar:add(O, Checksum, "CHECKSUM", []),
-    ok = erl_tar:close(O),
-    nil.
+    write_tar(Out, [{<<"VERSION">>, Version0},
+                    {<<"metadata.config">>, Meta},
+                    {<<"contents.tar.gz">>, Contents},
+                    {<<"CHECKSUM">>, Checksum}]).
 
 % The metadata.config files list of a tarball, for asserting a re-packed
 % archive lists each entry exactly once.

--- a/test/graded_pack_test_ffi.erl
+++ b/test/graded_pack_test_ffi.erl
@@ -1,7 +1,7 @@
 -module(graded_pack_test_ffi).
 -export([build_tarball/4, build_tarball_with_modes/4,
-         build_tarball_with_raw_names/4, build_outer_tarball/2, unpack_inner/2,
-         metadata_files/1]).
+         build_tarball_with_raw_names/4, build_outer_tarball/2,
+         corrupt_checksum/1, unpack_inner/2, metadata_files/1]).
 
 % Build a minimal hex tarball at OutPath (VERSION, metadata.config,
 % contents.tar.gz, CHECKSUM), following hex_tarball's format closely enough for
@@ -106,6 +106,17 @@ write_outer(Out, Name, Version, Paths, Contents) ->
                     {<<"metadata.config">>, Meta},
                     {<<"contents.tar.gz">>, Contents},
                     {<<"CHECKSUM">>, Checksum}]).
+
+% Rewrite a tarball's outer CHECKSUM to a value that cannot match its contents,
+% carrying every other member over byte for byte — a sound archive that has been
+% tampered with since it was built, which is the shape the input-integrity check
+% exists to catch.
+corrupt_checksum(TarPath) ->
+    Path = binary_to_list(TarPath),
+    {ok, Outer} = erl_tar:extract(Path, [memory]),
+    Kept = [{unicode:characters_to_binary(N), C}
+            || {N, C} <- Outer, N =/= "CHECKSUM"],
+    write_tar(Path, Kept ++ [{<<"CHECKSUM">>, <<"00">>}]).
 
 % The metadata.config files list of a tarball, for asserting a re-packed
 % archive lists each entry exactly once.

--- a/test/graded_pack_test_ffi.erl
+++ b/test/graded_pack_test_ffi.erl
@@ -1,5 +1,6 @@
 -module(graded_pack_test_ffi).
--export([build_tarball/4, build_tarball_with_modes/4, unpack_inner/2,
+-export([build_tarball/4, build_tarball_with_modes/4,
+         build_tarball_with_raw_names/4, build_outer_tarball/2, unpack_inner/2,
          metadata_files/1]).
 
 % Build a minimal hex tarball at OutPath (VERSION, metadata.config,
@@ -34,8 +35,60 @@ build_tarball_with_modes(OutPath, Name, Version, InnerFiles) ->
     {ok, InnerBytes} = file:read_file(InnerTmp),
     ok = file:delete(InnerTmp),
     ok = file:del_dir_r(Staging),
-    Contents = zlib:gzip(InnerBytes),
+    write_outer(Out, Name, Version, Paths, zlib:gzip(InnerBytes)).
 
+% Build a tarball whose inner entry names are stored *verbatim*, including names
+% no legitimate hex tarball carries: an absolute path, a `..` component, a
+% non-regular member. This is a weapon — it exists to construct the malicious
+% archives `graded pack` has to refuse, and belongs in test/ only.
+%
+% Members is a list of {regular, Name, Content} or {symlink, Name, Target}. A
+% regular member is added from a binary, so an arbitrary name is stored without
+% ever being staged on disk — staging an absolute name would write to the host
+% path the fixture is meant to describe, not create. erl_tar has no binary add
+% for a link, so a symlink member is staged for real and added by path; its own
+% name must therefore be relative.
+build_tarball_with_raw_names(OutPath, Name, Version, Members) ->
+    Out = binary_to_list(OutPath),
+    Staging = Out ++ ".staging",
+    InnerTmp = Out ++ ".inner",
+    {ok, T} = erl_tar:open(InnerTmp, [write]),
+    lists:foreach(fun(M) -> add_member(T, Staging, M) end, Members),
+    ok = erl_tar:close(T),
+    {ok, InnerBytes} = file:read_file(InnerTmp),
+    ok = file:delete(InnerTmp),
+    _ = file:del_dir_r(Staging),
+    write_outer(Out, Name, Version, [member_name(M) || M <- Members],
+        zlib:gzip(InnerBytes)).
+
+% Build an outer tar holding exactly Members ({Name, Content} binaries) and
+% nothing else, for the malformed-archive diagnostics: a missing member, a
+% metadata.config that does not parse, a contents.tar.gz that is not gzip.
+build_outer_tarball(OutPath, Members) ->
+    {ok, O} = erl_tar:open(binary_to_list(OutPath), [write]),
+    lists:foreach(fun({N, C}) ->
+        ok = erl_tar:add(O, C, binary_to_list(N), [])
+    end, Members),
+    ok = erl_tar:close(O),
+    nil.
+
+member_name({regular, Name, _}) -> Name;
+member_name({symlink, Name, _}) -> Name.
+
+add_member(T, _Staging, {regular, Name, Content}) ->
+    ok = erl_tar:add(T, Content, binary_to_list(Name), []);
+add_member(T, Staging, {symlink, Name, Target}) ->
+    Rel = binary_to_list(Name),
+    relative = filename:pathtype(Rel),
+    Abs = filename:join(Staging, Rel),
+    ok = filelib:ensure_dir(Abs),
+    ok = file:make_symlink(binary_to_list(Target), Abs),
+    ok = erl_tar:add(T, Abs, Rel, []).
+
+% The VERSION / metadata.config / contents.tar.gz / CHECKSUM quartet, with the
+% metadata files list mirroring Paths so pack's files-list assertion passes and
+% the entry-name guard is what rejects a crafted archive.
+write_outer(Out, Name, Version, Paths, Contents) ->
     Version0 = <<"3">>,
     Meta = metadata(Name, Version, Paths),
     Hash = crypto:hash(sha256, [Version0, Meta, Contents]),

--- a/test/pack_test.gleam
+++ b/test/pack_test.gleam
@@ -335,6 +335,125 @@ pub fn pack_consumer_resolves_injected_spec_test() {
   cleanup(consumer)
 }
 
+// An archive graded did not build is untrusted input
+//
+// The rebuild re-adds every inner member by `filename:join(InnerDir, Name)`,
+// and an absolute Name wins that join outright — so a crafted archive makes
+// pack read a host file and embed it in the tarball whose success message tells
+// the user to publish. The names are guarded before anything is extracted.
+
+// A member for `build_tarball_with_raw_names`: `Regular` stores its name
+// verbatim, `Symlink` stages a real link so the member is genuinely typed.
+type Member {
+  Regular(name: String, content: String)
+  Symlink(name: String, target: String)
+}
+
+// A project whose default tarball is built from `members`, with a spec ready to
+// inject. Returns the tarball path.
+fn setup_crafted(root: String, members: List(Member)) -> String {
+  let _ = simplifile.delete(root)
+  write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n")
+  write_file(root <> "/dep.graded", "effects dep.work : []\n")
+  let tarball = root <> "/build/dep-1.0.0.tar"
+  ensure_parent(tarball)
+  build_tarball_with_raw_names(tarball, "dep", "1.0.0", members)
+  tarball
+}
+
+pub fn pack_rejects_an_absolute_inner_entry_test() {
+  let root = "build/pack_absolute_entry"
+  // The decoy is a file this test creates under its own tree — the exploit
+  // needs an absolute path, never a real system one.
+  let assert Ok(cwd) = simplifile.current_directory()
+  let decoy = cwd <> "/" <> root <> "/decoy.txt"
+
+  let tarball =
+    setup_crafted(root, [
+      Regular("src/dep.gleam", "pub fn work() {\n  Nil\n}\n"),
+      // The crafted member: its stored bytes are a placeholder, but the name
+      // names the decoy, so an unguarded rebuild reads the decoy instead.
+      Regular(decoy, "placeholder"),
+    ])
+  // Written after the setup clears `root`, so the name in the archive resolves
+  // to a real host file at pack time — which is the whole of the exploit.
+  write_file(decoy, "HOST-SECRET-DECOY\n")
+  let assert Ok(before) = simplifile.read_bits(tarball)
+
+  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  string.contains(message, decoy) |> should.be_true()
+  string.contains(message, "unsafe tar entry name") |> should.be_true()
+
+  // There is no output tarball to inspect on a rejection, so assert on what
+  // remains: the input is untouched, both scratch paths are gone, and the
+  // decoy's bytes never moved.
+  simplifile.read_bits(tarball) |> should.equal(Ok(before))
+  simplifile.is_file(tarball <> ".packing") |> should.equal(Ok(False))
+  simplifile.is_directory(tarball <> ".packing.work") |> should.equal(Ok(False))
+  simplifile.read(decoy) |> should.equal(Ok("HOST-SECRET-DECOY\n"))
+
+  cleanup(root)
+}
+
+// The `..` half of the rule is graded's, not `erl_tar`'s. Extraction rejects an
+// escaping member on its own (`unsafe_path`), but only once the archive is
+// already being unpacked; this pins the guard ahead of extraction, where the
+// diagnostic is graded's own.
+pub fn pack_rejects_an_escaping_inner_entry_test() {
+  let root = "build/pack_escaping_entry"
+  let tarball =
+    setup_crafted(root, [
+      Regular("src/dep.gleam", "pub fn work() {\n  Nil\n}\n"),
+      Regular("../escaped.txt", "x"),
+    ])
+  let assert Ok(before) = simplifile.read_bits(tarball)
+
+  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  string.contains(message, "../escaped.txt") |> should.be_true()
+  string.contains(message, "unsafe tar entry name") |> should.be_true()
+
+  simplifile.read_bits(tarball) |> should.equal(Ok(before))
+  simplifile.is_directory(tarball <> ".packing.work") |> should.equal(Ok(False))
+  cleanup(root)
+}
+
+// A non-regular member is refused by its type, and the message says which type.
+// The rebuild carries regular members only, so a symlink was previously dropped
+// from the output and the run failed on the files-list mismatch, naming
+// nothing. graded cannot see a link's target at all — `erl_tar:table/2` leaves
+// it out of the tuple — which is why the member kind is what gets refused.
+pub fn pack_rejects_a_non_regular_inner_entry_test() {
+  let root = "build/pack_symlink_entry"
+  let tarball =
+    setup_crafted(root, [
+      Regular("src/dep.gleam", "pub fn work() {\n  Nil\n}\n"),
+      Symlink("link.txt", "dangling_target"),
+    ])
+
+  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  string.contains(message, "link.txt") |> should.be_true()
+  string.contains(message, "symlink") |> should.be_true()
+
+  simplifile.is_directory(tarball <> ".packing.work") |> should.equal(Ok(False))
+  cleanup(root)
+}
+
+// The function that certifies an archive as internally consistent refuses to
+// certify one carrying a name graded would never write.
+pub fn verify_tarball_rejects_an_unsafe_entry_test() {
+  let root = "build/pack_verify_unsafe"
+  let tarball =
+    setup_crafted(root, [
+      Regular("dep.graded", "effects dep.work : []\n"),
+      Regular("/etc/dep.graded", "placeholder"),
+    ])
+
+  let assert Error(message) = verify_tarball(tarball, "dep.graded")
+  string.contains(message, "/etc/dep.graded") |> should.be_true()
+  string.contains(message, "unsafe tar entry name") |> should.be_true()
+  cleanup(root)
+}
+
 @external(erlang, "graded_pack_test_ffi", "build_tarball")
 fn build_tarball(
   out_path: String,
@@ -351,8 +470,21 @@ fn build_tarball_with_modes(
   inner_files: List(#(String, String, Int)),
 ) -> Nil
 
+@external(erlang, "graded_pack_test_ffi", "build_tarball_with_raw_names")
+fn build_tarball_with_raw_names(
+  out_path: String,
+  name: String,
+  version: String,
+  members: List(Member),
+) -> Nil
+
 @external(erlang, "graded_pack_test_ffi", "unpack_inner")
 fn unpack_inner(tarball: String, dest_dir: String) -> Nil
+
+// Called directly: `pack` reaches it only through a tarball it just wrote, and
+// the guard under test is about archives it did not.
+@external(erlang, "graded_pack_ffi", "verify_tarball")
+fn verify_tarball(tarball: String, entry_name: String) -> Result(Nil, String)
 
 @external(erlang, "graded_pack_test_ffi", "metadata_files")
 fn metadata_files(tarball: String) -> List(String)

--- a/test/pack_test.gleam
+++ b/test/pack_test.gleam
@@ -454,6 +454,28 @@ pub fn verify_tarball_rejects_an_unsafe_entry_test() {
   cleanup(root)
 }
 
+// The output tarball is created exclusively by the call that writes it
+//
+// Reserving the path and closing the descriptor only proved it was free at that
+// instant, and `erl_tar:open/2` then re-opened by name — a window for a symlink
+// planted in between. `inject_spec` now creates the path itself and writes the
+// archive through the descriptor it keeps. The race is not deterministically
+// testable here; that the create is exclusive and lives inside the call is.
+pub fn inject_spec_will_not_write_over_an_existing_path_test() {
+  let root = "build/pack_exclusive_out"
+  let tarball =
+    setup_dep(root, "dep", "1.0.0", "dep.graded", "effects dep.work : []\n")
+  let out = root <> "/build/occupied.tar"
+  write_file(out, "not mine\n")
+
+  let assert Error(message) =
+    inject_spec(tarball, "effects dep.work : []\n", "dep.graded", out)
+  string.contains(message, "output path already exists") |> should.be_true()
+  // Refused, not truncated: the exclusive create never opened it for writing.
+  simplifile.read(out) |> should.equal(Ok("not mine\n"))
+  cleanup(root)
+}
+
 // A malformed archive says what is wrong with it
 //
 // Every one of these used to badmatch or reach a term as `undefined`, and
@@ -598,6 +620,16 @@ fn unpack_inner(tarball: String, dest_dir: String) -> Nil
 // the guard under test is about archives it did not.
 @external(erlang, "graded_pack_ffi", "verify_tarball")
 fn verify_tarball(tarball: String, entry_name: String) -> Result(Nil, String)
+
+// Called directly: `pack` only ever hands it a path it derived, and what is
+// under test is the call's own refusal to write over a path it did not create.
+@external(erlang, "graded_pack_ffi", "inject_spec")
+fn inject_spec(
+  in_tar: String,
+  spec: String,
+  entry_name: String,
+  out_tar: String,
+) -> Result(String, String)
 
 @external(erlang, "graded_pack_test_ffi", "metadata_files")
 fn metadata_files(tarball: String) -> List(String)

--- a/test/pack_test.gleam
+++ b/test/pack_test.gleam
@@ -454,6 +454,113 @@ pub fn verify_tarball_rejects_an_unsafe_entry_test() {
   cleanup(root)
 }
 
+// A malformed archive says what is wrong with it
+//
+// Every one of these used to badmatch or reach a term as `undefined`, and
+// surface as an Erlang tuple through `format_reason`'s `~p`.
+
+// A project ready to pack, whose tarball is written from `members` verbatim —
+// no VERSION/CHECKSUM quartet unless the members say so. Returns the tarball.
+fn setup_malformed(root: String, members: List(#(String, String))) -> String {
+  let _ = simplifile.delete(root)
+  write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n")
+  write_file(root <> "/dep.graded", "effects dep.work : []\n")
+  let tarball = root <> "/build/dep-1.0.0.tar"
+  ensure_parent(tarball)
+  build_outer_tarball(tarball, members)
+  tarball
+}
+
+// A metadata.config good enough to name the package, for the archives whose
+// defect is somewhere other than the metadata.
+const good_metadata = "{<<\"name\">>, <<\"dep\"/utf8>>}.
+{<<\"version\">>, <<\"1.0.0\"/utf8>>}.
+{<<\"files\">>, [
+  <<\"src/dep.gleam\"/utf8>>]}.
+"
+
+fn pack_error(root: String) -> String {
+  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  message
+}
+
+pub fn pack_names_a_corrupt_outer_tar_test() {
+  let root = "build/pack_corrupt_outer"
+  let _ = simplifile.delete(root)
+  write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n")
+  write_file(root <> "/dep.graded", "effects dep.work : []\n")
+  write_file(root <> "/build/dep-1.0.0.tar", "this is not a tar file\n")
+
+  let message = pack_error(root)
+  string.contains(message, "as a hex tarball") |> should.be_true()
+  cleanup(root)
+}
+
+// Also the proof that `read_package_identity` surfaces a thrown message as
+// itself: its catch was `_:Reason` only, so a clean message rendered as
+// `{graded_error,<<"...">>}` through `format_reason`'s `~p`.
+pub fn pack_names_a_missing_metadata_member_test() {
+  let root = "build/pack_no_metadata"
+  let _ = setup_malformed(root, [#("VERSION", "3")])
+
+  let message = pack_error(root)
+  string.contains(message, "hex tarball has no metadata.config member")
+  |> should.be_true()
+  string.contains(message, "graded_error") |> should.be_false()
+  cleanup(root)
+}
+
+pub fn pack_names_metadata_that_does_not_scan_test() {
+  let root = "build/pack_metadata_scan"
+  let _ =
+    setup_malformed(root, [
+      #("VERSION", "3"),
+      #("metadata.config", "{<<\"name\">>, \"unterminated"),
+    ])
+
+  let message = pack_error(root)
+  string.contains(message, "does not scan as Erlang terms") |> should.be_true()
+  cleanup(root)
+}
+
+pub fn pack_names_metadata_with_no_terminating_dot_test() {
+  let root = "build/pack_metadata_dot"
+  let _ =
+    setup_malformed(root, [
+      #("VERSION", "3"),
+      #("metadata.config", "{<<\"name\">>, <<\"dep\"/utf8>>}"),
+    ])
+
+  let message = pack_error(root)
+  string.contains(message, "no terminating `.`") |> should.be_true()
+  cleanup(root)
+}
+
+pub fn pack_names_metadata_that_does_not_parse_test() {
+  let root = "build/pack_metadata_parse"
+  let _ =
+    setup_malformed(root, [#("VERSION", "3"), #("metadata.config", "{a, }.")])
+
+  let message = pack_error(root)
+  string.contains(message, "does not parse") |> should.be_true()
+  cleanup(root)
+}
+
+pub fn pack_names_a_truncated_contents_member_test() {
+  let root = "build/pack_truncated_contents"
+  let _ =
+    setup_malformed(root, [
+      #("VERSION", "3"),
+      #("metadata.config", good_metadata),
+      #("contents.tar.gz", "not a gzip stream at all"),
+      #("CHECKSUM", "00"),
+    ])
+
+  let message = pack_error(root)
+  string.contains(message, "not a readable gzip stream") |> should.be_true()
+  cleanup(root)
+}
+
 @external(erlang, "graded_pack_test_ffi", "build_tarball")
 fn build_tarball(
   out_path: String,
@@ -476,6 +583,12 @@ fn build_tarball_with_raw_names(
   name: String,
   version: String,
   members: List(Member),
+) -> Nil
+
+@external(erlang, "graded_pack_test_ffi", "build_outer_tarball")
+fn build_outer_tarball(
+  out_path: String,
+  members: List(#(String, String)),
 ) -> Nil
 
 @external(erlang, "graded_pack_test_ffi", "unpack_inner")

--- a/test/pack_test.gleam
+++ b/test/pack_test.gleam
@@ -565,6 +565,42 @@ pub fn pack_names_metadata_that_does_not_parse_test() {
   )
 }
 
+pub fn pack_names_a_missing_checksum_member_test() {
+  assert_malformed(
+    "build/pack_no_checksum",
+    // contents.tar.gz is present but never reached: the four members are
+    // required together, before anything gunzips one of them.
+    [
+      #("VERSION", "3"),
+      #("metadata.config", good_metadata),
+      #("contents.tar.gz", "unread"),
+    ],
+    "hex tarball has no CHECKSUM member",
+  )
+}
+
+// A sound archive tampered with after it was built. Nothing carries the input's
+// checksum forward — the rebuild mints a fresh one — so accepting this would
+// launder the tampering into an archive that verifies, and `pack` would end by
+// telling the user to publish it.
+pub fn pack_refuses_an_input_whose_checksum_does_not_match_test() {
+  let root = "build/pack_bad_checksum"
+  let tarball =
+    setup_dep(root, "dep", "1.0.0", "dep.graded", "effects dep.work : []\n")
+  corrupt_checksum(tarball)
+  let assert Ok(before) = simplifile.read_bits(tarball)
+
+  let message = pack_error(root)
+  string.contains(message, "stored CHECKSUM does not match its contents")
+  |> should.be_true()
+  string.contains(message, "gleam export hex-tarball") |> should.be_true()
+
+  // Refused, not repaired: the archive is left exactly as it was found.
+  simplifile.read_bits(tarball) |> should.equal(Ok(before))
+  simplifile.is_file(tarball <> ".packing") |> should.equal(Ok(False))
+  cleanup(root)
+}
+
 pub fn pack_names_a_truncated_contents_member_test() {
   assert_malformed(
     "build/pack_truncated_contents",
@@ -607,6 +643,9 @@ fn build_outer_tarball(
   out_path: String,
   members: List(#(String, String)),
 ) -> Nil
+
+@external(erlang, "graded_pack_test_ffi", "corrupt_checksum")
+fn corrupt_checksum(tarball: String) -> Nil
 
 @external(erlang, "graded_pack_test_ffi", "unpack_inner")
 fn unpack_inner(tarball: String, dest_dir: String) -> Nil

--- a/test/pack_test.gleam
+++ b/test/pack_test.gleam
@@ -12,7 +12,7 @@ import graded
 import graded/internal/annotation
 import graded/internal/types.{Specific}
 import simplifile
-import support.{cleanup, ensure_parent, write_file}
+import support.{cleanup, ensure_parent, write_file, write_fixture}
 
 // A tarball with one inner source file, plus a gleam.toml and the spec to be
 // injected, materialised at `root`. Returns the tarball path.
@@ -349,16 +349,30 @@ type Member {
   Symlink(name: String, target: String)
 }
 
-// A project whose default tarball is built from `members`, with a spec ready to
-// inject. Returns the tarball path.
-fn setup_crafted(root: String, members: List(Member)) -> String {
-  let _ = simplifile.delete(root)
-  write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n")
-  write_file(root <> "/dep.graded", "effects dep.work : []\n")
+// A `dep` 1.0.0 project with a spec ready to inject, and the default tarball
+// path prepared but not written — each caller builds the archive it needs
+// there, well-formed or not. Returns that path.
+fn setup_project(root: String) -> String {
+  write_fixture(root, [
+    #("gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n"),
+    #("dep.graded", "effects dep.work : []\n"),
+  ])
   let tarball = root <> "/build/dep-1.0.0.tar"
   ensure_parent(tarball)
+  tarball
+}
+
+// A project whose default tarball is built from `members`. Returns the tarball.
+fn setup_crafted(root: String, members: List(Member)) -> String {
+  let tarball = setup_project(root)
   build_tarball_with_raw_names(tarball, "dep", "1.0.0", members)
   tarball
+}
+
+// The `PackError` message `pack` fails a project with.
+fn pack_error(root: String) -> String {
+  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  message
 }
 
 pub fn pack_rejects_an_absolute_inner_entry_test() {
@@ -380,7 +394,7 @@ pub fn pack_rejects_an_absolute_inner_entry_test() {
   write_file(decoy, "HOST-SECRET-DECOY\n")
   let assert Ok(before) = simplifile.read_bits(tarball)
 
-  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  let message = pack_error(root)
   string.contains(message, decoy) |> should.be_true()
   string.contains(message, "unsafe tar entry name") |> should.be_true()
 
@@ -408,7 +422,7 @@ pub fn pack_rejects_an_escaping_inner_entry_test() {
     ])
   let assert Ok(before) = simplifile.read_bits(tarball)
 
-  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  let message = pack_error(root)
   string.contains(message, "../escaped.txt") |> should.be_true()
   string.contains(message, "unsafe tar entry name") |> should.be_true()
 
@@ -430,7 +444,7 @@ pub fn pack_rejects_a_non_regular_inner_entry_test() {
       Symlink("link.txt", "dangling_target"),
     ])
 
-  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  let message = pack_error(root)
   string.contains(message, "link.txt") |> should.be_true()
   string.contains(message, "symlink") |> should.be_true()
 
@@ -481,18 +495,6 @@ pub fn inject_spec_will_not_write_over_an_existing_path_test() {
 // Every one of these used to badmatch or reach a term as `undefined`, and
 // surface as an Erlang tuple through `format_reason`'s `~p`.
 
-// A project ready to pack, whose tarball is written from `members` verbatim —
-// no VERSION/CHECKSUM quartet unless the members say so. Returns the tarball.
-fn setup_malformed(root: String, members: List(#(String, String))) -> String {
-  let _ = simplifile.delete(root)
-  write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n")
-  write_file(root <> "/dep.graded", "effects dep.work : []\n")
-  let tarball = root <> "/build/dep-1.0.0.tar"
-  ensure_parent(tarball)
-  build_outer_tarball(tarball, members)
-  tarball
-}
-
 // A metadata.config good enough to name the package, for the archives whose
 // defect is somewhere other than the metadata.
 const good_metadata = "{<<\"name\">>, <<\"dep\"/utf8>>}.
@@ -501,20 +503,25 @@ const good_metadata = "{<<\"name\">>, <<\"dep\"/utf8>>}.
   <<\"src/dep.gleam\"/utf8>>]}.
 "
 
-fn pack_error(root: String) -> String {
-  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+// Pack a project whose tarball holds `members` verbatim — no VERSION/CHECKSUM
+// quartet unless the members say so — and assert the refusal says `needle`.
+fn assert_malformed(
+  root: String,
+  members: List(#(String, String)),
+  needle: String,
+) -> String {
+  build_outer_tarball(setup_project(root), members)
+  let message = pack_error(root)
+  string.contains(message, needle) |> should.be_true()
+  cleanup(root)
   message
 }
 
 pub fn pack_names_a_corrupt_outer_tar_test() {
   let root = "build/pack_corrupt_outer"
-  let _ = simplifile.delete(root)
-  write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n")
-  write_file(root <> "/dep.graded", "effects dep.work : []\n")
-  write_file(root <> "/build/dep-1.0.0.tar", "this is not a tar file\n")
-
-  let message = pack_error(root)
-  string.contains(message, "as a hex tarball") |> should.be_true()
+  // Not a tar at all, so it is written rather than built.
+  write_file(setup_project(root), "this is not a tar file\n")
+  string.contains(pack_error(root), "as a hex tarball") |> should.be_true()
   cleanup(root)
 }
 
@@ -522,65 +529,53 @@ pub fn pack_names_a_corrupt_outer_tar_test() {
 // itself: its catch was `_:Reason` only, so a clean message rendered as
 // `{graded_error,<<"...">>}` through `format_reason`'s `~p`.
 pub fn pack_names_a_missing_metadata_member_test() {
-  let root = "build/pack_no_metadata"
-  let _ = setup_malformed(root, [#("VERSION", "3")])
-
-  let message = pack_error(root)
-  string.contains(message, "hex tarball has no metadata.config member")
-  |> should.be_true()
+  let message =
+    assert_malformed(
+      "build/pack_no_metadata",
+      [#("VERSION", "3")],
+      "hex tarball has no metadata.config member",
+    )
   string.contains(message, "graded_error") |> should.be_false()
-  cleanup(root)
 }
 
 pub fn pack_names_metadata_that_does_not_scan_test() {
-  let root = "build/pack_metadata_scan"
-  let _ =
-    setup_malformed(root, [
-      #("VERSION", "3"),
-      #("metadata.config", "{<<\"name\">>, \"unterminated"),
-    ])
-
-  let message = pack_error(root)
-  string.contains(message, "does not scan as Erlang terms") |> should.be_true()
-  cleanup(root)
+  assert_malformed(
+    "build/pack_metadata_scan",
+    [#("VERSION", "3"), #("metadata.config", "{<<\"name\">>, \"unterminated")],
+    "does not scan as Erlang terms",
+  )
 }
 
 pub fn pack_names_metadata_with_no_terminating_dot_test() {
-  let root = "build/pack_metadata_dot"
-  let _ =
-    setup_malformed(root, [
+  assert_malformed(
+    "build/pack_metadata_dot",
+    [
       #("VERSION", "3"),
       #("metadata.config", "{<<\"name\">>, <<\"dep\"/utf8>>}"),
-    ])
-
-  let message = pack_error(root)
-  string.contains(message, "no terminating `.`") |> should.be_true()
-  cleanup(root)
+    ],
+    "no terminating `.`",
+  )
 }
 
 pub fn pack_names_metadata_that_does_not_parse_test() {
-  let root = "build/pack_metadata_parse"
-  let _ =
-    setup_malformed(root, [#("VERSION", "3"), #("metadata.config", "{a, }.")])
-
-  let message = pack_error(root)
-  string.contains(message, "does not parse") |> should.be_true()
-  cleanup(root)
+  assert_malformed(
+    "build/pack_metadata_parse",
+    [#("VERSION", "3"), #("metadata.config", "{a, }.")],
+    "does not parse",
+  )
 }
 
 pub fn pack_names_a_truncated_contents_member_test() {
-  let root = "build/pack_truncated_contents"
-  let _ =
-    setup_malformed(root, [
+  assert_malformed(
+    "build/pack_truncated_contents",
+    [
       #("VERSION", "3"),
       #("metadata.config", good_metadata),
       #("contents.tar.gz", "not a gzip stream at all"),
       #("CHECKSUM", "00"),
-    ])
-
-  let message = pack_error(root)
-  string.contains(message, "not a readable gzip stream") |> should.be_true()
-  cleanup(root)
+    ],
+    "not a readable gzip stream",
+  )
 }
 
 @external(erlang, "graded_pack_test_ffi", "build_tarball")


### PR DESCRIPTION
`graded pack` rebuilds a hex tarball's inner archive by re-adding every member
by path — `erl_tar:add(T, filename:join(InnerDir, Name), Name, [])` — and
`filename:join/2` returns its second argument unchanged when that argument is
absolute. So a `contents.tar.gz` carrying an absolute entry name made `pack`
read the **host** file at that path and embed it in the tarball whose success
message tells you to publish.

Reproduced end to end on OTP 28.4.2 before fixing: `pack` returned `ok`, and the
output entry held a decoy host file's real bytes. `verify_tarball` certified the
result — correctly, since the archive *is* internally consistent; it just
carries a file that was never in the input.

Extraction was the only check between the crafted name and the rebuild, and it
waves the name through: `erl_tar` strips the leading `/`, unpacks under the work
directory, and returns `ok`.

Exploiting this needs the victim to run `pack` over a tarball someone else
built. The normal input is `gleam export hex-tarball`'s own output, so the flow
is unusual — but the *output* is something the tool then tells you to publish,
so a leak is exfiltrated by your own next step.

## The fix

Read `erl_tar:table` first and judge every name before anything is written to
disk. `..` was never exploitable — extraction rejects it with `unsafe_path` —
but the rule now stops depending on an `erl_tar` behaviour graded does not
control, and the failure is graded's own message instead of a badmatch.

- **Path type, not a leading slash.** `filename:pathtype/1` is
  platform-dependent in the same way as the `filename:join/2` it defends, so the
  guard tracks the operation rather than one platform's spelling of it. The raw
  name is checked, never a normalised one — normalising collapses `a/../x` to
  `x` and readmits what the component rule rejects.
- **Non-regular members are refused outright**, naming the entry and its kind. A
  link's target never reaches the guard at all (`erl_tar:table/2` leaves it out
  of the tuple), so the kind is what can be judged — and the rebuild carries
  regular members only, so any other kind was previously dropped from the output
  and surfaced as a files-list mismatch naming nothing.
- **`verify_tarball` gets the same guard**, and reads the table rather than a
  memory extract: an extract yields regular members only, so the certifier was
  certifying a strict subset of what it certifies. It is also cheaper now, since
  it no longer materialises every member's bytes.

The Gleam-side check over the configured `spec_file` is unchanged, and now
documented as the advisory pre-flight it is. It cannot be the boundary — Gleam
has no platform-aware path predicate (`filepath.is_absolute` is also just
`starts_with("/")`, under a `windows support` TODO) — and the Erlang guard
covers that entry too.

## Two ride-alongs in the same file

**Every malformed archive now says what is wrong with it.** A file that is not a
tar, a missing `VERSION` / `metadata.config` / `contents.tar.gz` / `CHECKSUM`
member, a `metadata.config` that does not scan or parse, and a `contents.tar.gz`
that is not a readable gzip stream each get their own message, in place of a
badmatch or an `undefined` reaching the term that consumed it. `config_terms`
had three failure modes and checked none. `read_package_identity` — where a
malformed tarball lands first, since identity is resolved before anything is
reserved or injected — gained the `throw:{graded_error, Msg}` clause its two
siblings have; without it a clean message rendered as `{graded_error,<<"…">>}`.

**The output tarball is written through the descriptor its exclusive create
returned.** `reserve_path` created the temp with `O_EXCL` and closed the
descriptor, so all it proved was that the path had been free at that instant;
`erl_tar:open/2` takes a filename, so the write then resolved the path a second
time. `erl_tar:init/3` takes user data and an I/O fun instead. Not hygiene:
`verify_tarball` re-opens the result by name and the flow renames it over the
original, and on Windows renaming a file with an open handle fails.

This moves the exclusive create out of the Gleam caller into `inject_spec`,
which now owns both scratch paths — it creates the output and removes it again
on failure, so the caller no longer deletes a path it did not make. A
pre-existing output path is refused and left intact, as the work directory
already was.

## Tests

11 new, 1187 passing. The crafted-archive fixtures need a builder that stores
entry names verbatim: the existing one stages every file on disk first, which is
the one thing such a fixture cannot do — an absolute name would write to the
host path it is meant to describe. Regular members go in from binaries; only a
symlink member is staged, since `erl_tar` has no binary add for a link and a
binary add always writes a `regular` member.

On a rejection there is no output tarball to inspect, so the tests assert on
what remains: the input is byte-for-byte unchanged, both scratch paths are gone,
and the decoy's bytes never moved. The decoy is a file each test creates under
its own tree, never a real system path.

There is no test claiming the symlink race is closed — it is not
deterministically testable without a timing harness this repo does not have.
What is tested is the design: `inject_spec` refuses to write over a path it did
not create. Likewise there is no test that graded catches an unsafe symlink
*target*; it cannot see one, and the member is refused by kind before extraction
would have.
