### PR TITLE
Carry a where returns clause's scoping bounds on its summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not gzip — instead of failing with a raw Erlang term.
 - `graded pack` no longer follows a symlink planted at its temporary output
   path while it writes.
+- A `where returns` clause on a path dependency that vendors a catalogued
+  package now resolves the returned function at the call site, instead of
+  charging it `[Unknown]`.
+- A clause variable its own line does not scope no longer binds to a call
+  argument. Such a clause resolves to `[Unknown]`, and `graded check` reports it
+  as open.
 
 ## [0.16.0] - 2026-08-24
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -958,9 +958,9 @@ fn check_one_file(
 // dead or silently ignored, so surface it as a warning.
 // Every input is a field of the context the run already assembled, so it
 // travels whole: a lint needing one more piece of it adds no parameter. The
-// `registry`/`knowledge_base` pair is the oracle a `where returns` clause's
-// variables are weighed against — the same one the gate that binds them reads,
-// so lint and gate agree by construction.
+// `registry` and the linted line's own bound list are the oracle a
+// `where returns` clause's variables are weighed against — the same one the gate
+// that binds them reads, so lint and gate agree by construction.
 fn validate_spec_annotations(context: ProjectContext) -> List(Warning) {
   let ProjectContext(
     sources: ProjectSources(spec:, index:, package_root:, ..),
@@ -969,7 +969,6 @@ fn validate_spec_annotations(context: ProjectContext) -> List(Warning) {
     catalog:,
     dependencies:,
     registry:,
-    knowledge_base:,
     ..,
   ) = context
   let known_functions = known_function_names(index)
@@ -1065,7 +1064,7 @@ fn validate_spec_annotations(context: ProjectContext) -> List(Warning) {
   // bug. Reported all the same: the gate drops it silently.
   let clause_warnings =
     annotation.extract_effects(spec)
-    |> list.filter_map(unclosed_clause_warning(_, registry, knowledge_base))
+    |> list.filter_map(unclosed_clause_warning(_, registry))
 
   list.flatten([
     check_warnings,
@@ -1078,10 +1077,13 @@ fn validate_spec_annotations(context: ProjectContext) -> List(Warning) {
 
 // The warning for one `effects` line's `where returns` clause, or `Error(Nil)`
 // where it carries none, names nothing, or is closed.
+//
+// The line's own bound list is what scopes the clause, and the line is right
+// here, so the lint weighs the clause against exactly what the gate weighs it
+// against without consulting the knowledge base at all.
 fn unclosed_clause_warning(
   annotation_line: EffectAnnotation,
   registry: SignatureRegistry,
-  knowledge_base: KnowledgeBase,
 ) -> Result(Warning, Nil) {
   use operator <- result.try(option.to_result(annotation_line.returns, Nil))
   use #(module, function) <- result.try(annotation.split_function_name(
@@ -1091,7 +1093,7 @@ fn unclosed_clause_warning(
     checker.unclosed_clause_variables(
       operator,
       QualifiedName(module, function),
-      knowledge_base,
+      annotation_line.params,
       registry,
     )
   {
@@ -4328,11 +4330,6 @@ fn with_spec_type_fields(
 // would pair with freshly inferred bounds, whose variable names need not match
 // it.
 //
-// One exception, below: a line kept under a module declaration for the sake of
-// its `where returns` clause keeps its bounds without its term. They are not
-// that term's pairing — they are the clause's scoping list, and the clause has
-// none of its own.
-//
 // Lines for a module-level-external module are dropped from both, so they can't
 // reshadow the declaration (which lives in `module_effects`, consulted only when
 // `all_effects` misses). `graded infer` no longer writes such lines; this guards
@@ -4358,11 +4355,6 @@ fn with_committed_spec(
   // drop are a property of that spec, and a caller passing any other set folds
   // in the very lines this function exists to drop.
   let declared_modules = annotation.module_external_modules(spec)
-  // The names whose committed `effects` line is kept only for its
-  // `where returns` clause: their bounds are that clause's scoping list, so the
-  // module drop leaves them where it takes the term beside them.
-  let clause_scopes =
-    effects.load_spec_returns_from_file(spec) |> dict.keys |> set.from_list
   knowledge_base
   |> effects.with_inferred(
     effects.load_spec_effects_from_file(spec)
@@ -4372,7 +4364,7 @@ fn with_committed_spec(
   )
   |> effects.with_inferred_params(
     effects.load_spec_params_from_file(spec)
-    |> drop_declared_modules_keeping(declared_modules, clause_scopes)
+    |> drop_declared_modules(declared_modules)
     |> drop_stale_names(stale_externals),
   )
 }
@@ -4396,24 +4388,8 @@ fn drop_declared_modules(
   entries: Dict(QualifiedName, a),
   modules: Set(String),
 ) -> Dict(QualifiedName, a) {
-  drop_declared_modules_keeping(entries, modules, set.new())
-}
-
-// The same, minus the names `keep` names. The bounds channel keeps the entries
-// scoping a clause on a line the declaration otherwise covers: the clause has no
-// bound list of its own, so that line's is the only thing its variables are
-// scoped by, and dropping it resolves the returned function to `[Unknown]`. Such
-// an entry pairs with the declaration's term rather than the one it was written
-// beside — the one exception to the pairing rule this file states above.
-fn drop_declared_modules_keeping(
-  entries: Dict(QualifiedName, a),
-  modules: Set(String),
-  keep: Set(QualifiedName),
-) -> Dict(QualifiedName, a) {
   use <- bool.guard(set.is_empty(modules), entries)
-  dict.filter(entries, fn(name, _value) {
-    !set.contains(modules, name.module) || set.contains(keep, name)
-  })
+  dict.filter(entries, fn(name, _value) { !set.contains(modules, name.module) })
 }
 
 // CLI plumbing

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -3347,7 +3347,7 @@ fn qualify_bare_names(
 // A module the consumer declared with a module-level external (in
 // `declared_modules`) has its inferred *call effect* dropped so lookup falls
 // through to the declared set — the project-module counterpart of the path-dep
-// `drop_declared_modules` in `infer_path_dep_module`. Returned-operator and
+// `drop_module_declared` in `infer_path_dep_module`. Returned-operator and
 // parameter-bound metadata describe what a function returns and how it consumes
 // operator arguments, not its call effect, so they are kept.
 fn thread_inferred_into_kb(
@@ -3359,7 +3359,8 @@ fn thread_inferred_into_kb(
 ) -> KnowledgeBase {
   let #(effects_dict, params_dict, returns_dict) =
     qualified_inferred(inferred, returned_operators, module_path)
-  let effects_dict = drop_declared_modules(effects_dict, declared_modules)
+  let effects_dict =
+    effects.drop_module_declared(effects_dict, declared_modules)
   // Main project topo loop + the in-memory pre-pass: results inferred this run,
   // originating in this project's own inference.
   fold_inferred_into_kb(
@@ -4249,7 +4250,8 @@ fn infer_path_dep_module(
       // returns and how it consumes operator arguments, not its call effect, so
       // they are kept; a sibling wrapper doing `let f = mod.make(); f()` still
       // resolves `f` instead of falling to `[Unknown]`.
-      let inferred_effs = drop_declared_modules(inferred_effs, consumer_modules)
+      let inferred_effs =
+        effects.drop_module_declared(inferred_effs, consumer_modules)
       let inferred_provenance = qualify_bare_names(provenance, module_path)
       let new_kb =
         fold_inferred_into_kb(
@@ -4358,13 +4360,13 @@ fn with_committed_spec(
   knowledge_base
   |> effects.with_inferred(
     effects.load_spec_effects_from_file(spec)
-      |> drop_declared_modules(declared_modules)
+      |> effects.drop_module_declared(declared_modules)
       |> drop_stale_names(stale_externals),
     types.CommittedSpec,
   )
   |> effects.with_inferred_params(
     effects.load_spec_params_from_file(spec)
-    |> drop_declared_modules(declared_modules)
+    |> effects.drop_module_declared(declared_modules)
     |> drop_stale_names(stale_externals),
   )
 }
@@ -4378,18 +4380,6 @@ fn drop_stale_names(
   dict.filter(entries, fn(name, _value) {
     !set.contains(stale_externals, types.dotted_name(name))
   })
-}
-
-// Drop every `QualifiedName`-keyed entry whose module the consumer declared
-// with a module-level external. Keyed off the consumer's declared modules, not
-// the whole knowledge base, so a catalog pure-module entry never suppresses a
-// same-named path-dependency module.
-fn drop_declared_modules(
-  entries: Dict(QualifiedName, a),
-  modules: Set(String),
-) -> Dict(QualifiedName, a) {
-  use <- bool.guard(set.is_empty(modules), entries)
-  dict.filter(entries, fn(name, _value) { !set.contains(modules, name.module) })
 }
 
 // CLI plumbing

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -5139,17 +5139,23 @@ fn unresolved_producer_reason(
 }
 
 // The knowledge base's summary for `name`, in the shape the trust match reads:
-// the operator, how it was produced, and the source that wrote it.
+// the operator, how it was produced, the source that wrote it, and the bounds
+// scoping the operator's variables.
 fn knowledge_base_operator(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
 ) -> Result(
-  #(EffectTerm, effects.SummaryOrigin, option.Option(LookupOrigin)),
+  #(
+    EffectTerm,
+    effects.SummaryOrigin,
+    option.Option(LookupOrigin),
+    List(ParamBound),
+  ),
   Nil,
 ) {
   effects.lookup_returned_operator(knowledge_base, name)
   |> result.map(fn(found) {
-    #(found.operator, found.summary, Some(found.source))
+    #(found.operator, found.summary, Some(found.source), found.bounds)
   })
 }
 
@@ -5174,9 +5180,10 @@ fn resolve_returned_operator(
   cache: LocalCache,
   memo: Memo,
 ) -> #(Result(#(EffectTerm, option.Option(LookupOrigin)), Nil), Memo) {
-  // A same-module (`""`) summary is computed on demand now, hence Fresh and
-  // sourced by nothing but this run's analysis; a cross-module one is read from
-  // the KB with its recorded origin (Fix E) and the source that wrote it.
+  // A same-module (`""`) summary is computed on demand now, hence Fresh, sourced
+  // by nothing but this run's analysis and scoped by no line of its own; a
+  // cross-module one is read from the KB with its recorded origin (Fix E), the
+  // source that wrote it and the bounds its line scopes it with.
   let #(lookup, memo) = case callee.module {
     "" ->
       case
@@ -5196,7 +5203,7 @@ fn resolve_returned_operator(
               cache,
               memo,
             )
-          #(result.map(result, fn(op) { #(op, effects.Fresh, None) }), memo)
+          #(result.map(result, fn(op) { #(op, effects.Fresh, None, []) }), memo)
         }
         // A recursive producer call — the producer is already on the analysis
         // stack, so this branch contributes the neutral operator (pure over the
@@ -5206,7 +5213,7 @@ fn resolve_returned_operator(
         // type, stay conservative.
         True, NativeDefinition(definition) -> #(
           neutral_returned_operator(definition.definition, cache.fn_alias_types)
-            |> result.map(fn(op) { #(op, effects.Fresh, None) }),
+            |> result.map(fn(op) { #(op, effects.Fresh, None, []) }),
           memo,
         )
         // A same-module `@external`: there is no body to compute a summary
@@ -5229,7 +5236,7 @@ fn resolve_returned_operator(
   }
   case lookup {
     Error(Nil) -> #(Error(Nil), memo)
-    Ok(#(operator, summary, source)) ->
+    Ok(#(operator, summary, source, clause_bounds)) ->
       case effect_term.is_ground(operator), summary {
         // Ground operator (no free vars): trusted regardless of origin. A Fresh
         // one is sanitized by this run (callback binders can't have captured a
@@ -5246,8 +5253,8 @@ fn resolve_returned_operator(
         //   - **Closed**: a clause read back from a spec, whose variables are
         //     checked against the producer's real callback parameters here,
         //     where the substitution happens; one naming anything else degrades
-        //     to [Unknown] rather than binding against a parameter that isn't
-        //     there.
+        //     to [Unknown] rather than binding against a parameter the clause
+        //     never scoped.
         //   - **Declared**: a declaration is tagged only after the non-ground
         //     operators are dropped, so nothing reaches here. An edit that
         //     changed that must degrade to [Unknown] rather than substitute over
@@ -5256,10 +5263,20 @@ fn resolve_returned_operator(
           let admitted = case summary {
             effects.Fresh -> True
             effects.Closed ->
-              clause_is_closed(operator, callee, knowledge_base, registry)
+              clause_is_closed(operator, callee, clause_bounds, registry)
             effects.Declared -> False
           }
           use <- bool.guard(when: !admitted, return: #(Error(Nil), memo))
+          // What scopes the operator's variables, per summary kind. A **Closed**
+          // clause is scoped by the bound list on its own line, carried here
+          // with it. A **Fresh** one has no line: its bounds are the ones this
+          // run recorded on the params channel, which carry the girard-typed
+          // callbacks no syntactic signature shows.
+          let scoping = case summary {
+            effects.Closed -> clause_bounds
+            effects.Fresh | effects.Declared ->
+              effects.lookup_param_bounds(knowledge_base, callee)
+          }
           let #(bound, memo) =
             bind_producer_params(
               operator,
@@ -5272,6 +5289,7 @@ fn resolve_returned_operator(
               registry,
               module_types,
               caller_param_bounds,
+              scoping,
               cache,
               memo,
             )
@@ -5302,6 +5320,11 @@ fn bind_producer_params(
   // the nested bind resolves it to the sentinel — keeping it distinct from any
   // residual of the same name. `[]` for a top-level producer resolution.
   caller_param_bounds: List(ParamBound),
+  // What scopes the operator's variables, chosen by the caller per summary kind:
+  // a `Closed` clause's own bound list, or the params channel's entry for a
+  // `Fresh` summary. Read on the cross-module path only — a same-module callee's
+  // bounds come from its glance signature below.
+  scoping: List(ParamBound),
   cache: LocalCache,
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
@@ -5331,7 +5354,7 @@ fn bind_producer_params(
         Error(Nil) -> #([], registry)
       }
     _ -> {
-      // Cross-module completion (Fix B/C-B/E): the KB's param bounds omit params
+      // Cross-module completion (Fix B/C-B/E): the scoping bounds omit params
       // that are polymorphic only through the returned closure (inference derives
       // bounds from the *direct* effect, which trims the closure). Synthesize a
       // self-referential bound for each of the summary's own free vars not already
@@ -5341,14 +5364,13 @@ fn bind_producer_params(
       // just re-checked against the producer's real callback parameters. The real
       // `registry` supplies each param's position. Field-path (dotted) vars are
       // excluded (they round-trip as field bounds, not producer params).
-      let kb_bounds = effects.lookup_param_bounds(knowledge_base, callee)
-      let have = bound_name_set(kb_bounds)
+      let have = bound_name_set(scoping)
       let synth =
         effect_term.free_vars(operator)
         |> set.filter(fn(v) { !is_field_path_var(v) && !set.contains(have, v) })
         |> set.to_list()
         |> list.map(self_referential_bound)
-      #(list.append(kb_bounds, synth), registry)
+      #(list.append(scoping, synth), registry)
     }
   }
   let lift =
@@ -5895,21 +5917,21 @@ fn ordered_callback_param_names(
 // Whether every free variable of a `where returns` clause is a real callback
 // parameter of the producer the clause sits on.
 //
-// The oracle is the signature registry's fn-typed parameters together with the
-// knowledge base's recorded bound names for the function — the same pair
-// `ordered_callback_param_names` reads, so a girard-typed callback no syntactic
-// signature shows is admitted through its recorded bound rather than
-// spuriously rejected. Committed bounds win over this run's inference, so the
-// recorded set can be stale-empty but never stale-wrong: staleness makes this
-// stricter, never looser. Field-path (dotted) variables round-trip as field
-// bounds rather than as producer parameters, so they are not weighed here.
+// The oracle is the signature registry's fn-typed parameters together with
+// `bounds` — the clause's own scoping list, read off the line the clause sits
+// on. A callback that girard typed and no syntactic signature shows is admitted
+// through that list rather than spuriously rejected, and a variable the line
+// never scoped is rejected however the knowledge base happens to key the name:
+// the list is the only thing consulted, so a bound another line records for the
+// same function cannot widen it. Field-path (dotted) variables round-trip as
+// field bounds rather than as producer parameters, so they are not weighed here.
 fn clause_is_closed(
   operator: EffectTerm,
   callee: QualifiedName,
-  knowledge_base: KnowledgeBase,
+  bounds: List(ParamBound),
   registry: SignatureRegistry,
 ) -> Bool {
-  unclosed_clause_variables(operator, callee, knowledge_base, registry) == []
+  unclosed_clause_variables(operator, callee, bounds, registry) == []
 }
 
 // The clause's free variables that name no callback parameter, sorted. Empty
@@ -5918,13 +5940,13 @@ fn clause_is_closed(
 pub fn unclosed_clause_variables(
   operator: EffectTerm,
   callee: QualifiedName,
-  knowledge_base: KnowledgeBase,
+  bounds: List(ParamBound),
   registry: SignatureRegistry,
 ) -> List(String) {
   let callbacks =
     set.union(
       signatures.fn_typed_param_names(registry, callee),
-      recorded_bound_names(knowledge_base, callee),
+      bound_name_set(bounds),
     )
   effect_term.free_vars(operator)
   |> set.filter(fn(variable) {
@@ -5934,9 +5956,9 @@ pub fn unclosed_clause_variables(
   |> list.sort(string.compare)
 }
 
-// The parameter names `name`'s recorded bounds state effects over. For one of
-// this package's running fallbacks these carry the girard-typed callbacks no
-// syntactic signature shows.
+// The parameter names `name`'s recorded bounds state effects over, for the
+// binders a lifted operator abstracts over. For one of this package's running
+// fallbacks these carry the girard-typed callbacks no syntactic signature shows.
 fn recorded_bound_names(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -5139,23 +5139,18 @@ fn unresolved_producer_reason(
 }
 
 // The knowledge base's summary for `name`, in the shape the trust match reads:
-// the operator, how it was produced, the source that wrote it, and the bounds
-// scoping the operator's variables.
+// the operator, how it was produced — a `Closed` summary carrying the bounds
+// that scope it — and the source that wrote it.
 fn knowledge_base_operator(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
 ) -> Result(
-  #(
-    EffectTerm,
-    effects.SummaryOrigin,
-    option.Option(LookupOrigin),
-    List(ParamBound),
-  ),
+  #(EffectTerm, effects.SummaryOrigin, option.Option(LookupOrigin)),
   Nil,
 ) {
   effects.lookup_returned_operator(knowledge_base, name)
   |> result.map(fn(found) {
-    #(found.operator, found.summary, Some(found.source), found.bounds)
+    #(found.operator, found.summary, Some(found.source))
   })
 }
 
@@ -5180,10 +5175,9 @@ fn resolve_returned_operator(
   cache: LocalCache,
   memo: Memo,
 ) -> #(Result(#(EffectTerm, option.Option(LookupOrigin)), Nil), Memo) {
-  // A same-module (`""`) summary is computed on demand now, hence Fresh, sourced
-  // by nothing but this run's analysis and scoped by no line of its own; a
-  // cross-module one is read from the KB with its recorded origin (Fix E), the
-  // source that wrote it and the bounds its line scopes it with.
+  // A same-module (`""`) summary is computed on demand now, hence Fresh and
+  // sourced by nothing but this run's analysis; a cross-module one is read from
+  // the KB with its recorded origin (Fix E) and the source that wrote it.
   let #(lookup, memo) = case callee.module {
     "" ->
       case
@@ -5203,7 +5197,7 @@ fn resolve_returned_operator(
               cache,
               memo,
             )
-          #(result.map(result, fn(op) { #(op, effects.Fresh, None, []) }), memo)
+          #(result.map(result, fn(op) { #(op, effects.Fresh, None) }), memo)
         }
         // A recursive producer call — the producer is already on the analysis
         // stack, so this branch contributes the neutral operator (pure over the
@@ -5213,7 +5207,7 @@ fn resolve_returned_operator(
         // type, stay conservative.
         True, NativeDefinition(definition) -> #(
           neutral_returned_operator(definition.definition, cache.fn_alias_types)
-            |> result.map(fn(op) { #(op, effects.Fresh, None, []) }),
+            |> result.map(fn(op) { #(op, effects.Fresh, None) }),
           memo,
         )
         // A same-module `@external`: there is no body to compute a summary
@@ -5236,7 +5230,7 @@ fn resolve_returned_operator(
   }
   case lookup {
     Error(Nil) -> #(Error(Nil), memo)
-    Ok(#(operator, summary, source, clause_bounds)) ->
+    Ok(#(operator, summary, source)) ->
       case effect_term.is_ground(operator), summary {
         // Ground operator (no free vars): trusted regardless of origin. A Fresh
         // one is sanitized by this run (callback binders can't have captured a
@@ -5262,21 +5256,11 @@ fn resolve_returned_operator(
         False, summary -> {
           let admitted = case summary {
             effects.Fresh -> True
-            effects.Closed ->
-              clause_is_closed(operator, callee, clause_bounds, registry)
+            effects.Closed(bounds:) ->
+              clause_is_closed(operator, callee, bounds, registry)
             effects.Declared -> False
           }
           use <- bool.guard(when: !admitted, return: #(Error(Nil), memo))
-          // What scopes the operator's variables, per summary kind. A **Closed**
-          // clause is scoped by the bound list on its own line, carried here
-          // with it. A **Fresh** one has no line: its bounds are the ones this
-          // run recorded on the params channel, which carry the girard-typed
-          // callbacks no syntactic signature shows.
-          let scoping = case summary {
-            effects.Closed -> clause_bounds
-            effects.Fresh | effects.Declared ->
-              effects.lookup_param_bounds(knowledge_base, callee)
-          }
           let #(bound, memo) =
             bind_producer_params(
               operator,
@@ -5289,7 +5273,7 @@ fn resolve_returned_operator(
               registry,
               module_types,
               caller_param_bounds,
-              scoping,
+              summary,
               cache,
               memo,
             )
@@ -5302,8 +5286,9 @@ fn resolve_returned_operator(
 // Bind a polymorphic returned operator's free producer-parameter variables to
 // the producer call's arguments, reusing the call-site substitution machinery.
 // The producer's parameter bounds + a registry that knows its operator params
-// come from the KB/project registry (cross-module) or its glance signature
-// (same-module, keyed by the `""` module so the synthetic callee name matches).
+// come from the summary and the KB/project registry (cross-module) or from its
+// glance signature (same-module, keyed by the `""` module so the synthetic
+// callee name matches).
 fn bind_producer_params(
   operator: EffectTerm,
   callee: types.QualifiedName,
@@ -5320,11 +5305,9 @@ fn bind_producer_params(
   // the nested bind resolves it to the sentinel — keeping it distinct from any
   // residual of the same name. `[]` for a top-level producer resolution.
   caller_param_bounds: List(ParamBound),
-  // What scopes the operator's variables, chosen by the caller per summary kind:
-  // a `Closed` clause's own bound list, or the params channel's entry for a
-  // `Fresh` summary. Read on the cross-module path only — a same-module callee's
-  // bounds come from its glance signature below.
-  scoping: List(ParamBound),
+  // How the operator was produced, which is what says where its scoping bounds
+  // come from on the cross-module path below.
+  summary: effects.SummaryOrigin,
   cache: LocalCache,
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
@@ -5354,6 +5337,15 @@ fn bind_producer_params(
         Error(Nil) -> #([], registry)
       }
     _ -> {
+      // A **Closed** clause is scoped by the bound list on its own line, which
+      // it carries; every other summary by the params channel's entry for the
+      // name, which for a **Fresh** one holds the girard-typed callbacks no
+      // syntactic signature shows.
+      let scoping = case summary {
+        effects.Closed(bounds:) -> bounds
+        effects.Fresh | effects.Declared ->
+          effects.lookup_param_bounds(knowledge_base, callee)
+      }
       // Cross-module completion (Fix B/C-B/E): the scoping bounds omit params
       // that are polymorphic only through the returned closure (inference derives
       // bounds from the *direct* effect, which trims the closure). Synthesize a

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1179,15 +1179,29 @@ pub type SummaryOrigin {
 }
 
 // A function's returned-operator summary as the knowledge base holds it: the
-// operator, whether this run produced it, and the source that wrote it. The
-// three are one value, so a lookup can report the summary it used and where it
-// came from together.
+// operator, whether this run produced it, the source that wrote it, and the
+// bound list scoping the operator's variables. The four are one value, so a
+// lookup can report the summary it used, where it came from, and what its
+// variables answer to together.
+//
+// `bounds` is empty wherever the operator binds no parameter of its own: a
+// `Declared` summary is ground by rule, and a `Fresh` one is scoped by the
+// bounds the params channel records for the same name.
 pub type ReturnedOperator {
   ReturnedOperator(
     operator: EffectTerm,
     summary: SummaryOrigin,
     source: LookupOrigin,
+    bounds: List(ParamBound),
   )
+}
+
+// A `where returns` clause as the annotation carries it: the operator and the
+// bound list on the same line, which is what scopes the operator's variables.
+// The two are read off one line and travel as one value, so no tier has to copy
+// the bounds by a rule of its own.
+pub type ScopedClause {
+  ScopedClause(operator: EffectTerm, bounds: List(ParamBound))
 }
 
 // Pair every term of a bare effect map with the source that wrote it, giving
@@ -1199,8 +1213,8 @@ fn with_origin(
   dict.map_values(entries, fn(_name, term) { #(term, origin) })
 }
 
-// Pair every summary in a bare `name -> operator` map with how it was produced
-// and the source that wrote it, giving the shape `returned_operators` holds.
+// Pair every clause in a `name -> clause` map with how it was produced and the
+// source that wrote it, giving the shape `returned_operators` holds.
 //
 // Guard: never reach here with `Closed` for a map of clauses on `assume` lines.
 // A declaration is written for a value-opaque name, and a Closed-tagged summary
@@ -1208,12 +1222,28 @@ fn with_origin(
 // deferred catalog tier is the one waiting to) silently no-ops instead of
 // answering. `declared_returns` is the entry point for those.
 fn tag_returns(
-  returns: Dict(QualifiedName, EffectTerm),
+  returns: Dict(QualifiedName, ScopedClause),
   summary: SummaryOrigin,
   source: LookupOrigin,
 ) -> Dict(QualifiedName, ReturnedOperator) {
-  dict.map_values(returns, fn(_, operator) {
-    ReturnedOperator(operator:, summary:, source:)
+  dict.map_values(returns, fn(_, clause) {
+    ReturnedOperator(
+      operator: clause.operator,
+      summary:,
+      source:,
+      bounds: clause.bounds,
+    )
+  })
+}
+
+// Read a bare `name -> operator` map as clauses that scope nothing: the shape
+// the two summary kinds written without a bound list of their own are tagged
+// from — `Declared` (ground by rule) and `Fresh` (scoped by the params channel).
+fn unscoped(
+  operators: Dict(QualifiedName, EffectTerm),
+) -> Dict(QualifiedName, ScopedClause) {
+  dict.map_values(operators, fn(_name, operator) {
+    ScopedClause(operator:, bounds: [])
   })
 }
 
@@ -1228,7 +1258,7 @@ fn tag_returns(
 // `with_declared_returned_operators`.
 pub fn with_closed_returned_operators(
   knowledge_base: KnowledgeBase,
-  clauses: Dict(QualifiedName, EffectTerm),
+  clauses: Dict(QualifiedName, ScopedClause),
   source: LookupOrigin,
 ) -> KnowledgeBase {
   let merged =
@@ -1329,6 +1359,7 @@ fn declared_returns(
   source: LookupOrigin,
 ) -> Dict(QualifiedName, ReturnedOperator) {
   dict.filter(declared, fn(_name, operator) { effect_term.is_ground(operator) })
+  |> unscoped
   |> tag_returns(Declared, source)
 }
 
@@ -1351,7 +1382,7 @@ pub fn with_fresh_returned_operators(
   let merged =
     merge_returns(
       knowledge_base.returned_operators,
-      tag_returns(inferred, Fresh, source),
+      tag_returns(unscoped(inferred), Fresh, source),
     )
   KnowledgeBase(..knowledge_base, returned_operators: merged)
 }
@@ -1643,15 +1674,6 @@ pub fn load_spec_effects_from_file(
 //   entry: the external term wins in `all_effects` and is ground by
 //   construction, so any bounds pairing with it come from another source.
 //
-//   Unless the declared function's `effects` line carries a `where returns`
-//   clause. Such a line survives the declaration for the clause's sake, and the
-//   clause's variables are scoped by that line's own bound list — the clause has
-//   none of its own. So the line's bounds are recorded, and they are the one
-//   entry on this channel that does not pair with the term beside them: the
-//   declaration answers the effects channel, these bounds scope the returned
-//   operator. Dropping them leaves a clause nothing can bind and the returned
-//   function resolves to `[Unknown]`.
-//
 // Entries for a name a *stale* per-function external also names are the
 // project-spec caller's to drop, with the same filter it applies to the
 // effects map beside this one.
@@ -1670,8 +1692,7 @@ pub fn load_spec_params_from_file(
   list.fold(annotation.extract_annotations(file), from_externals, fn(acc, ann) {
     use <- bool.guard(when: ann.kind == Check, return: acc)
     use <- bool.guard(
-      when: set.contains(external_functions, ann.function)
-        && option.is_none(ann.returns),
+      when: set.contains(external_functions, ann.function),
       return: acc,
     )
     case annotation.split_function_name(ann.function) {
@@ -1700,8 +1721,9 @@ pub type DepSpec {
   DepSpec(
     effects: Dict(QualifiedName, EffectTerm),
     params: Dict(QualifiedName, List(ParamBound)),
-    // `where returns` clauses on the spec's `effects` lines.
-    returns: Dict(QualifiedName, EffectTerm),
+    // `where returns` clauses on the spec's `effects` lines, each with the
+    // bound list scoping it.
+    returns: Dict(QualifiedName, ScopedClause),
     declared_returns: Dict(QualifiedName, EffectTerm),
     type_fields: List(TypeFieldAnnotation),
     externals: List(ExternalAnnotation),
@@ -1740,11 +1762,6 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
       DepSpec(dict.new(), dict.new(), dict.new(), dict.new(), [], [], set.new())
     }
     Ok(file) -> {
-      let returns = load_spec_returns_from_file(file)
-      // The names whose `effects` line is kept only for its `where returns`
-      // clause. That line's bound list is what scopes the clause's variables, so
-      // it survives the module drop below alongside it.
-      let clause_scopes = returns |> dict.keys |> set.from_list
       // Loaded through the same two readers a package uses for its *own* spec,
       // so a dependency's `check` budgets and externally-declared functions are
       // scoped identically one package boundary away: a `check` line's bounds
@@ -1757,21 +1774,18 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
         // left to outrank the declaration per-function-beats-module-level. Only
         // that channel: `infer` keeps such a line when it carries a
         // `where returns` clause, which is the clause's only home, and the
-        // clause is read from `returns` below.
+        // clause is read from `returns` below, carrying its own scoping bounds.
         effects: load_spec_effects_from_file(file)
-          |> drop_module_assumed(file, set.new()),
+          |> drop_module_assumed(file),
         // A dependency's per-function external is never stale by this rule: its
         // own body is the documented case for the line.
         //
-        // Bounds travel with their term, so dropping one without the other pairs
-        // a surviving term with bounds from another annotation — except for the
-        // names `clause_scopes` holds, where the bounds are deliberately kept
-        // without the term they were written beside. There they scope the
-        // clause on the returns channel; the effects channel answers from the
-        // declaration, whose ground term binds nothing.
+        // Bounds travel with their term, so both channels drop the same names:
+        // a surviving term paired with bounds from another annotation is a
+        // pairing no annotation wrote.
         params: load_spec_params_from_file(file)
-          |> drop_module_assumed(file, clause_scopes),
-        returns:,
+          |> drop_module_assumed(file),
+        returns: load_spec_returns_from_file(file),
         declared_returns: load_spec_external_returns_from_file(file),
         type_fields: annotation.extract_type_fields(file),
         externals: annotation.extract_externals(file),
@@ -1782,24 +1796,16 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
 }
 
 // Drop every entry whose module the same spec declares with a module-level
-// `assume <module> : [...]`, minus the names `keep` names. The consumer-side
-// counterpart of the drop a package's own context applies to its own spec, so a
-// declaration means the same thing read from either side of the package
-// boundary.
-//
-// `keep` is empty on the effects channel — the declaration is the whole answer
-// there. On the bounds channel it holds the names whose line was kept for its
-// clause, whose variables those bounds scope.
+// `assume <module> : [...]`. The consumer-side counterpart of the drop a
+// package's own context applies to its own spec, so a declaration means the
+// same thing read from either side of the package boundary.
 fn drop_module_assumed(
   entries: Dict(QualifiedName, a),
   file: types.GradedFile,
-  keep: Set(QualifiedName),
 ) -> Dict(QualifiedName, a) {
   let modules = annotation.module_external_modules(file)
   use <- bool.guard(when: set.is_empty(modules), return: entries)
-  dict.filter(entries, fn(name, _value) {
-    !set.contains(modules, name.module) || set.contains(keep, name)
-  })
+  dict.filter(entries, fn(name, _value) { !set.contains(modules, name.module) })
 }
 
 // The module paths a package ships, read off its `src/` tree.
@@ -1840,9 +1846,7 @@ fn package_modules(dep_root: String) -> Set(String) {
 // A term and its bounds are dropped together. `load_knowledge_base` merges terms
 // and bounds in two independent passes, so a term dropped without its bounds
 // would revive the catalog's term paired with the dependency's bounds — the
-// pairing `load_spec_params_from_file` documents, broken. (Its one stated
-// exception is elsewhere: bounds kept without their term to scope a
-// `where returns` clause, which this filter neither makes nor unmakes.)
+// pairing `load_spec_params_from_file` documents, broken.
 fn sanitize_dep_spec(
   dep: DepSpec,
   foreign: Dict(QualifiedName, types.ForeignFunction),
@@ -1890,11 +1894,10 @@ fn sanitize_dep_spec(
 // A function's `assume` line wins over an `effects` line for the same
 // name. `graded infer` writes no `effects` line for an externally-declared
 // function unless the line carries a `where returns` clause, so a spec carrying
-// both without one has a stale line, and only the external's ground term pairs
-// with the empty bounds `load_spec_params_from_file` records for it. With a
-// clause the pair is deliberately mixed: the declaration's ground term answers
-// here, and the bounds recorded beside it scope the clause on the returns
-// channel instead.
+// both without one has a stale line, and either way only the external's ground
+// term pairs with the empty bounds `load_spec_params_from_file` records for it:
+// where the line is kept for a clause, that clause carries its own scoping
+// bounds on the returns channel.
 fn decided_entries(dep: DepSpec, origin: LookupOrigin) -> ExternalTiers {
   let #(function_externals, module_externals) =
     split_externals(dep.externals, origin)
@@ -1921,17 +1924,6 @@ fn decided_entries(dep: DepSpec, origin: LookupOrigin) -> ExternalTiers {
 // `returns` lines, so a name both key resolves to the declaration. Both merges
 // gap-fill: this tier reads below the installed dependencies', so a name an
 // installed dep's spec already answered keeps that answer, declaration or not.
-//
-// The two returns channels differ in whether a summary needs bounds beside it.
-// A **declared** operator is ground by rule, so it binds no parameter and pairs
-// with nothing. A **closed** one — a clause on an `effects` line — is scoped by
-// that line's own bound list, and travels with it or is not readable at all:
-// without those bounds the closed gate calls the clause open and the caller
-// resolves the returned function to `[Unknown]`. So the bounds are copied for
-// the clauses this fold lands, on top of the ones copied for the terms it
-// decides. The two sets are not the same: a module declaration takes the name's
-// effects entry out of `winning` while leaving its clause to answer, which is
-// precisely when the term-keyed copy alone drops the list.
 pub fn with_path_dep_spec(
   knowledge_base: KnowledgeBase,
   dep: DepSpec,
@@ -1943,44 +1935,23 @@ pub fn with_path_dep_spec(
   let dep = sanitize_dep_spec(dep, knowledge_base.dependency_foreign)
   let #(decided, module_externals) = decided_entries(dep, origin)
   let winning = over_catalog(knowledge_base.all_effects, decided)
-  let folded =
-    KnowledgeBase(
-      ..knowledge_base,
-      all_effects: dict.merge(knowledge_base.all_effects, winning),
-      param_bounds: dict.merge(
-        knowledge_base.param_bounds,
-        dict.map_values(winning, fn(name, _entry) {
-          dict.get(dep.params, name) |> result.unwrap([])
-        }),
-      ),
-      module_effects: dict.merge(
-        knowledge_base.module_effects,
-        over_catalog(knowledge_base.module_effects, module_externals),
-      ),
-    )
-    |> gap_filling_declared_returns(dep.declared_returns, origin)
-    |> with_closed_returned_operators(dep.returns, origin)
-    |> with_type_fields(dep.type_fields, origin)
-
-  // The bound lists scoping the clauses this fold landed, read off the outcome
-  // rather than recomputed from the merge rules: an entry is this fold's clause
-  // exactly when the channel answers the name with a `Closed` summary from this
-  // origin. A name an earlier tier answered, or this spec's own declaration
-  // did, is not one — that answer's own tier supplies whatever scopes it.
-  let scoping =
-    dict.filter(dep.params, fn(name, _bounds) {
-      case dict.get(folded.returned_operators, name) {
-        Ok(entry) -> entry.summary == Closed && entry.source == origin
-        Error(Nil) -> False
-      }
-    })
   KnowledgeBase(
-    ..folded,
-    // Gap-filling, like the operator they scope: a bounds entry already there
-    // belongs to whichever tier answered first, including the term-keyed copy
-    // above.
-    param_bounds: dict.merge(scoping, folded.param_bounds),
+    ..knowledge_base,
+    all_effects: dict.merge(knowledge_base.all_effects, winning),
+    param_bounds: dict.merge(
+      knowledge_base.param_bounds,
+      dict.map_values(winning, fn(name, _entry) {
+        dict.get(dep.params, name) |> result.unwrap([])
+      }),
+    ),
+    module_effects: dict.merge(
+      knowledge_base.module_effects,
+      over_catalog(knowledge_base.module_effects, module_externals),
+    ),
   )
+  |> gap_filling_declared_returns(dep.declared_returns, origin)
+  |> with_closed_returned_operators(dep.returns, origin)
+  |> with_type_fields(dep.type_fields, origin)
 }
 
 // The incoming entries a path dependency's spec may write over a knowledge-base
@@ -2053,19 +2024,25 @@ fn read_spec_file(
   annotation.parse_file(content) |> result.map_error(SpecMalformed)
 }
 
-// Build a returned-operator map (qualified name → operator) from the
-// `where returns` clauses on a parsed spec's `effects` lines, and those only.
-// A `check` line's clause keys nothing — it asserts what a function returns
-// rather than declaring it — and an `assume` line's goes through
+// Build a clause map (qualified name → operator and the bounds scoping it) from
+// the `where returns` clauses on a parsed spec's `effects` lines, and those
+// only. A `check` line's clause keys nothing — it asserts what a function
+// returns rather than declaring it — and an `assume` line's goes through
 // `load_spec_external_returns_from_file` instead.
+//
+// The line's own bound list travels with the clause it scopes: the clause has
+// no bound list of its own, and read apart from that list its variables answer
+// to nothing.
 pub fn load_spec_returns_from_file(
   file: types.GradedFile,
-) -> Dict(QualifiedName, EffectTerm) {
+) -> Dict(QualifiedName, ScopedClause) {
   annotation.extract_effects(file)
   |> list.filter_map(fn(ann) {
     ann.returns
     |> option.to_result(Nil)
-    |> result.map(fn(op) { #(ann.function, op) })
+    |> result.map(fn(op) {
+      #(ann.function, ScopedClause(operator: op, bounds: ann.params))
+    })
   })
   |> fold_named_returns()
 }
@@ -2087,16 +2064,16 @@ pub fn load_spec_external_returns_from_file(
   |> dict.from_list()
 }
 
-// Key a list of `#(spec name, operator)` pairs by qualified name, dropping the
+// Key a list of `#(spec name, clause)` pairs by qualified name, dropping the
 // names that don't split into a module and a function.
 fn fold_named_returns(
-  entries: List(#(String, EffectTerm)),
-) -> Dict(QualifiedName, EffectTerm) {
+  entries: List(#(String, ScopedClause)),
+) -> Dict(QualifiedName, ScopedClause) {
   list.fold(entries, dict.new(), fn(acc, entry) {
-    let #(name, operator) = entry
+    let #(name, clause) = entry
     case annotation.split_function_name(name) {
       Ok(#(module, function)) ->
-        dict.insert(acc, QualifiedName(module:, function:), operator)
+        dict.insert(acc, QualifiedName(module:, function:), clause)
       Error(_) -> acc
     }
   })

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -1164,11 +1164,14 @@ pub type SummaryOrigin {
   // Produced by this run's `compute_returned_operator` — Fix-D-sanitized, so its
   // free vars ⊆ the producer's fn-typed params; safe to synthesize/bind.
   Fresh
-  // Read from a `where returns` clause on an `effects` line. The gate checks
-  // its free variables against the producer's real callback parameters before
-  // binding, so an open clause degrades to `[Unknown]` rather than binding
-  // against variables the producer has no parameter for.
-  Closed
+  // Read from a `where returns` clause on an `effects` line, carrying that
+  // line's own bound list — what scopes the clause's variables, since the clause
+  // has no bound list of its own. The gate checks its free variables against
+  // those bounds and the producer's real callback parameters before binding, so
+  // an open clause degrades to `[Unknown]` rather than binding against variables
+  // the producer has no parameter for. This is the only summary a bound list
+  // means anything for, so it is the only one that carries one.
+  Closed(bounds: List(ParamBound))
   // Written by hand as a `where returns` clause: what a foreign producer
   // hands back, declared rather than inferred. It answers for a name every
   // other summary is refused for — that is the whole point of the line — so
@@ -1179,20 +1182,15 @@ pub type SummaryOrigin {
 }
 
 // A function's returned-operator summary as the knowledge base holds it: the
-// operator, whether this run produced it, the source that wrote it, and the
-// bound list scoping the operator's variables. The four are one value, so a
-// lookup can report the summary it used, where it came from, and what its
-// variables answer to together.
-//
-// `bounds` is empty wherever the operator binds no parameter of its own: a
-// `Declared` summary is ground by rule, and a `Fresh` one is scoped by the
-// bounds the params channel records for the same name.
+// operator, how it was produced — with, for a clause, the bounds scoping its
+// variables — and the source that wrote it. The three are one value, so a lookup
+// can report the summary it used, what its variables answer to, and where it
+// came from together.
 pub type ReturnedOperator {
   ReturnedOperator(
     operator: EffectTerm,
     summary: SummaryOrigin,
     source: LookupOrigin,
-    bounds: List(ParamBound),
   )
 }
 
@@ -1213,37 +1211,37 @@ fn with_origin(
   dict.map_values(entries, fn(_name, term) { #(term, origin) })
 }
 
-// Pair every clause in a `name -> clause` map with how it was produced and the
-// source that wrote it, giving the shape `returned_operators` holds.
+// Pair every clause in a `name -> clause` map with the source that wrote it,
+// tagging each `Closed` over the bounds it was read beside, and giving the shape
+// `returned_operators` holds.
 //
-// Guard: never reach here with `Closed` for a map of clauses on `assume` lines.
-// A declaration is written for a value-opaque name, and a Closed-tagged summary
+// Guard: never fold a map of clauses on `assume` lines through here. A
+// declaration is written for a value-opaque name, and a Closed-tagged summary
 // over one is refused at lookup — a new tier folding declarations this way (the
 // deferred catalog tier is the one waiting to) silently no-ops instead of
 // answering. `declared_returns` is the entry point for those.
-fn tag_returns(
-  returns: Dict(QualifiedName, ScopedClause),
-  summary: SummaryOrigin,
+fn tag_closed_returns(
+  clauses: Dict(QualifiedName, ScopedClause),
   source: LookupOrigin,
 ) -> Dict(QualifiedName, ReturnedOperator) {
-  dict.map_values(returns, fn(_, clause) {
+  dict.map_values(clauses, fn(_name, clause) {
     ReturnedOperator(
       operator: clause.operator,
-      summary:,
+      summary: Closed(bounds: clause.bounds),
       source:,
-      bounds: clause.bounds,
     )
   })
 }
 
-// Read a bare `name -> operator` map as clauses that scope nothing: the shape
-// the two summary kinds written without a bound list of their own are tagged
-// from — `Declared` (ground by rule) and `Fresh` (scoped by the params channel).
-fn unscoped(
-  operators: Dict(QualifiedName, EffectTerm),
-) -> Dict(QualifiedName, ScopedClause) {
-  dict.map_values(operators, fn(_name, operator) {
-    ScopedClause(operator:, bounds: [])
+// The same for the two summaries no bound list scopes: `Declared` (ground by
+// rule) and `Fresh` (scoped by the params channel's entry for the name).
+fn tag_returns(
+  returns: Dict(QualifiedName, EffectTerm),
+  summary: SummaryOrigin,
+  source: LookupOrigin,
+) -> Dict(QualifiedName, ReturnedOperator) {
+  dict.map_values(returns, fn(_name, operator) {
+    ReturnedOperator(operator:, summary:, source:)
   })
 }
 
@@ -1263,7 +1261,7 @@ pub fn with_closed_returned_operators(
 ) -> KnowledgeBase {
   let merged =
     dict.merge(
-      tag_returns(clauses, Closed, source),
+      tag_closed_returns(clauses, source),
       knowledge_base.returned_operators,
     )
   KnowledgeBase(..knowledge_base, returned_operators: merged)
@@ -1332,11 +1330,11 @@ fn merge_returns(
     dict.filter(incoming, fn(name, entry) {
       case entry.summary {
         Declared -> True
-        Fresh | Closed ->
+        Fresh | Closed(..) ->
           case dict.get(existing, name) {
             Ok(ReturnedOperator(summary: Declared, ..)) -> False
             Ok(ReturnedOperator(summary: Fresh, ..))
-            | Ok(ReturnedOperator(summary: Closed, ..))
+            | Ok(ReturnedOperator(summary: Closed(..), ..))
             | Error(Nil) -> True
           }
       }
@@ -1359,7 +1357,6 @@ fn declared_returns(
   source: LookupOrigin,
 ) -> Dict(QualifiedName, ReturnedOperator) {
   dict.filter(declared, fn(_name, operator) { effect_term.is_ground(operator) })
-  |> unscoped
   |> tag_returns(Declared, source)
 }
 
@@ -1382,7 +1379,7 @@ pub fn with_fresh_returned_operators(
   let merged =
     merge_returns(
       knowledge_base.returned_operators,
-      tag_returns(unscoped(inferred), Fresh, source),
+      tag_returns(inferred, Fresh, source),
     )
   KnowledgeBase(..knowledge_base, returned_operators: merged)
 }
@@ -1447,7 +1444,7 @@ pub fn lookup_returned_operator(
         DeclaredReturnUnbuilt | DeclaredReturnFallbackRuns | NoDeclaredReturn ->
           Error(Nil)
       }
-    Fresh | Closed ->
+    Fresh | Closed(..) ->
       case is_value_opaque(knowledge_base, name) {
         True -> Error(Nil)
         False -> Ok(found)
@@ -1491,7 +1488,7 @@ pub fn declared_return_standing(
   case dict.get(knowledge_base.returned_operators, name) {
     Error(Nil) -> NoDeclaredReturn
     Ok(ReturnedOperator(summary: Fresh, ..))
-    | Ok(ReturnedOperator(summary: Closed, ..)) -> NoDeclaredReturn
+    | Ok(ReturnedOperator(summary: Closed(..), ..)) -> NoDeclaredReturn
     Ok(ReturnedOperator(summary: Declared, ..)) ->
       charged_standing(knowledge_base, name)
   }
@@ -1762,6 +1759,7 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
       DepSpec(dict.new(), dict.new(), dict.new(), dict.new(), [], [], set.new())
     }
     Ok(file) -> {
+      let declared_modules = annotation.module_external_modules(file)
       // Loaded through the same two readers a package uses for its *own* spec,
       // so a dependency's `check` budgets and externally-declared functions are
       // scoped identically one package boundary away: a `check` line's bounds
@@ -1776,7 +1774,7 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
         // `where returns` clause, which is the clause's only home, and the
         // clause is read from `returns` below, carrying its own scoping bounds.
         effects: load_spec_effects_from_file(file)
-          |> drop_module_assumed(file),
+          |> drop_module_declared(declared_modules),
         // A dependency's per-function external is never stale by this rule: its
         // own body is the documented case for the line.
         //
@@ -1784,7 +1782,7 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
         // a surviving term paired with bounds from another annotation is a
         // pairing no annotation wrote.
         params: load_spec_params_from_file(file)
-          |> drop_module_assumed(file),
+          |> drop_module_declared(declared_modules),
         returns: load_spec_returns_from_file(file),
         declared_returns: load_spec_external_returns_from_file(file),
         type_fields: annotation.extract_type_fields(file),
@@ -1795,15 +1793,16 @@ pub fn load_dep_spec(dep_root: String, package_name: String) -> DepSpec {
   }
 }
 
-// Drop every entry whose module the same spec declares with a module-level
-// `assume <module> : [...]`. The consumer-side counterpart of the drop a
-// package's own context applies to its own spec, so a declaration means the
-// same thing read from either side of the package boundary.
-fn drop_module_assumed(
+// Drop every `QualifiedName`-keyed entry whose module a module-level
+// `assume <module> : [...]` declares. Read by both sides of the package
+// boundary — a dependency's spec as it loads here, and a consumer's own spec and
+// inference in `graded.gleam` — so a declaration means the same thing wherever
+// it is read. The caller supplies the declared modules, since only it knows
+// whose declarations the entries are being weighed against.
+pub fn drop_module_declared(
   entries: Dict(QualifiedName, a),
-  file: types.GradedFile,
+  modules: Set(String),
 ) -> Dict(QualifiedName, a) {
-  let modules = annotation.module_external_modules(file)
   use <- bool.guard(when: set.is_empty(modules), return: entries)
   dict.filter(entries, fn(name, _value) { !set.contains(modules, name.module) })
 }
@@ -1878,7 +1877,7 @@ fn sanitize_dep_spec(
     params: dict.filter(dep.params, fn(name, _bounds) {
       !inferred_over_foreign(name)
     }),
-    returns: dict.filter(dep.returns, fn(name, _operator) {
+    returns: dict.filter(dep.returns, fn(name, _clause) {
       !dict.has_key(foreign, name) && !about_other_code(name)
     }),
     declared_returns: dict.filter(dep.declared_returns, fn(name, _operator) {
@@ -2127,7 +2126,7 @@ fn load_dependencies(
           // specs, the same rule keeps one package's stray `returns` line from
           // burying another's declaration for the same name.
           merge_returns(
-            tag_returns(dep.returns, Closed, origin),
+            tag_closed_returns(dep.returns, origin),
             declared_returns(dep.declared_returns, origin),
           ),
         ),

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -4143,7 +4143,7 @@ pub fn caller() -> Nil {
       ]),
       types.ProjectInferred,
     )
-    |> effects.with_fresh_returned_operators(
+    |> effects.with_closed_returned_operators(
       effects.load_spec_returns_from_file(spec),
       types.CommittedSpec,
     )
@@ -4264,7 +4264,7 @@ pub fn caller() -> Nil {
       ]),
       types.ProjectInferred,
     )
-    |> effects.with_fresh_returned_operators(
+    |> effects.with_closed_returned_operators(
       effects.load_spec_returns_from_file(spec),
       types.CommittedSpec,
     )

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -482,7 +482,14 @@ pub fn returned_operators_round_trip_test() {
     )
   effects.lookup_returned_operator(enriched, QualifiedName("mylib/foo", "pick"))
   |> should.equal(
-    Ok(effects.ReturnedOperator(operator, effects.Fresh, types.ProjectInferred)),
+    Ok(
+      effects.ReturnedOperator(
+        operator,
+        effects.Fresh,
+        types.ProjectInferred,
+        [],
+      ),
+    ),
   )
   effects.lookup_returned_operator(
     enriched,
@@ -1795,11 +1802,12 @@ pub fn a_module_assume_does_not_bury_a_clause_on_the_same_module_test() {
   )
 }
 
-// A line kept for its clause keeps the bounds that scope it
+// A line kept for its clause carries the bounds that scope it
 //
 // The clause's variables are scoped by its own line's bound list, so the two
-// travel together or the clause is not readable at all. An assumption
-// suppresses the effects half of such a line — never its bounds.
+// travel together or the clause is not readable at all. They travel on the
+// clause itself: an assumption suppresses the line's effects half and the
+// params channel with it, and neither is what the clause is read against.
 
 const wrap_clause = "effects dep/wrap.wrap(f: [f]) : [] where returns : [f]\n"
 
@@ -1817,11 +1825,14 @@ pub fn a_function_assume_keeps_a_kept_clauses_bounds_test() {
       "dep",
       "assume dep/wrap.wrap : []\n" <> wrap_clause,
     )
-  effects.lookup_param_bounds(kb, QualifiedName("dep/wrap", "wrap"))
-  |> should.equal([ParamBound("f", types.TVar("f"))])
   let assert Ok(found) =
     effects.lookup_returned_operator(kb, QualifiedName("dep/wrap", "wrap"))
   found.operator |> should.equal(types.TVar("f"))
+  found.bounds |> should.equal([ParamBound("f", types.TVar("f"))])
+  // And on the clause alone: the declaration answers the effects channel, so
+  // the bounds beside it pair with a ground term that binds nothing.
+  effects.lookup_param_bounds(kb, QualifiedName("dep/wrap", "wrap"))
+  |> should.equal([])
 }
 
 pub fn a_module_assume_keeps_a_kept_clauses_bounds_test() {
@@ -1831,17 +1842,18 @@ pub fn a_module_assume_keeps_a_kept_clauses_bounds_test() {
       "dep",
       "assume dep/wrap : []\n" <> wrap_clause,
     )
-  effects.lookup_param_bounds(kb, QualifiedName("dep/wrap", "wrap"))
-  |> should.equal([ParamBound("f", types.TVar("f"))])
   let assert Ok(found) =
     effects.lookup_returned_operator(kb, QualifiedName("dep/wrap", "wrap"))
   found.operator |> should.equal(types.TVar("f"))
+  found.bounds |> should.equal([ParamBound("f", types.TVar("f"))])
+  effects.lookup_param_bounds(kb, QualifiedName("dep/wrap", "wrap"))
+  |> should.equal([])
 }
 
 pub fn a_clause_less_line_under_an_assume_keeps_no_bounds_test() {
-  // The non-goal. Nothing scopes anything on such a line: the declaration is
-  // the whole answer for the name, and its bounds stay out of the way of the
-  // ground term that wins.
+  // The same reading with no clause to scope: the declaration is the whole
+  // answer for the name, and its bounds stay out of the way of the ground term
+  // that wins.
   wrap_bounds(
     "build/eff_fn_assume_no_clause_bounds",
     "assume dep/wrap.wrap : []\neffects dep/wrap.wrap(f: [f]) : []\n",

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -482,14 +482,7 @@ pub fn returned_operators_round_trip_test() {
     )
   effects.lookup_returned_operator(enriched, QualifiedName("mylib/foo", "pick"))
   |> should.equal(
-    Ok(
-      effects.ReturnedOperator(
-        operator,
-        effects.Fresh,
-        types.ProjectInferred,
-        [],
-      ),
-    ),
+    Ok(effects.ReturnedOperator(operator, effects.Fresh, types.ProjectInferred)),
   )
   effects.lookup_returned_operator(
     enriched,
@@ -1753,7 +1746,7 @@ pub fn a_clause_on_an_effects_line_loads_as_closed_test() {
     )
   let assert Ok(found) =
     effects.lookup_returned_operator(kb, QualifiedName("dep", "make"))
-  found.summary |> should.equal(effects.Closed)
+  found.summary |> should.equal(effects.Closed(bounds: []))
   found.operator
   |> should.equal(
     effect_term.from_effect_set(Specific(set.from_list(["Stdout"]))),
@@ -1818,36 +1811,42 @@ fn wrap_bounds(root: String, spec: String) -> List(ParamBound) {
   )
 }
 
-pub fn a_function_assume_keeps_a_kept_clauses_bounds_test() {
-  let kb =
-    installed_dep(
-      "build/eff_fn_assume_clause_bounds",
-      "dep",
-      "assume dep/wrap.wrap : []\n" <> wrap_clause,
-    )
+// The clause `spec` states for `dep/wrap.wrap`, and the bounds the params
+// channel records for that name beside it.
+fn wrap_clause_and_bounds(
+  root: String,
+  spec: String,
+) -> #(effects.ReturnedOperator, List(ParamBound)) {
+  let kb = installed_dep(root, "dep", spec)
   let assert Ok(found) =
     effects.lookup_returned_operator(kb, QualifiedName("dep/wrap", "wrap"))
+  #(found, effects.lookup_param_bounds(kb, QualifiedName("dep/wrap", "wrap")))
+}
+
+pub fn a_function_assume_keeps_a_kept_clauses_bounds_test() {
+  let #(found, params_channel) =
+    wrap_clause_and_bounds(
+      "build/eff_fn_assume_clause_bounds",
+      "assume dep/wrap.wrap : []\n" <> wrap_clause,
+    )
   found.operator |> should.equal(types.TVar("f"))
-  found.bounds |> should.equal([ParamBound("f", types.TVar("f"))])
+  found.summary
+  |> should.equal(effects.Closed(bounds: [ParamBound("f", types.TVar("f"))]))
   // And on the clause alone: the declaration answers the effects channel, so
   // the bounds beside it pair with a ground term that binds nothing.
-  effects.lookup_param_bounds(kb, QualifiedName("dep/wrap", "wrap"))
-  |> should.equal([])
+  params_channel |> should.equal([])
 }
 
 pub fn a_module_assume_keeps_a_kept_clauses_bounds_test() {
-  let kb =
-    installed_dep(
+  let #(found, params_channel) =
+    wrap_clause_and_bounds(
       "build/eff_module_assume_clause_bounds",
-      "dep",
       "assume dep/wrap : []\n" <> wrap_clause,
     )
-  let assert Ok(found) =
-    effects.lookup_returned_operator(kb, QualifiedName("dep/wrap", "wrap"))
   found.operator |> should.equal(types.TVar("f"))
-  found.bounds |> should.equal([ParamBound("f", types.TVar("f"))])
-  effects.lookup_param_bounds(kb, QualifiedName("dep/wrap", "wrap"))
-  |> should.equal([])
+  found.summary
+  |> should.equal(effects.Closed(bounds: [ParamBound("f", types.TVar("f"))]))
+  params_channel |> should.equal([])
 }
 
 pub fn a_clause_less_line_under_an_assume_keeps_no_bounds_test() {

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -8639,9 +8639,9 @@ pub fn a_clause_over_a_recorded_bound_binds_test() {
 
 pub fn an_assume_kept_clause_still_binds_over_its_bounds_test() {
   // The line survives an assumption for the sake of its clause; the bounds that
-  // scope the clause survive with it. Over `unannotated_wrap` nothing else can
-  // prove `f` is a callback, so the recorded bound is the whole of what admits
-  // the clause — a dropped one resolves the returned closure to [Unknown].
+  // scope the clause travel on the clause itself. Over `unannotated_wrap`
+  // nothing else can prove `f` is a callback, so those bounds are the whole of
+  // what admits the clause — dropped, the returned closure is [Unknown].
   cross_package_clause_effects_over(
     "clause_fn_assume_bounds",
     "assume dep/wrap.wrap : []\n"
@@ -8661,40 +8661,63 @@ pub fn an_assume_kept_clause_still_binds_over_its_bounds_test() {
 
 // The same shape one tier over: `dep` is a *path* dependency the consumer
 // declares in `gleam.toml`, so its committed spec folds through
-// `with_path_dep_spec` rather than the installed-package scan — a merge that
-// pairs bounds with entries by its own rule.
+// `with_path_dep_spec` rather than the installed-package scan.
 fn path_dep_clause_effects_over(
   name: String,
   dependency_spec: String,
   dep_source: String,
 ) -> types.EffectSet {
+  path_dep_clause_effects_in(name, "dep/wrap", "wrap", dependency_spec, [
+    #("dep/src/dep/wrap.gleam", dep_source),
+  ])
+}
+
+// The same, over a path dependency shipping `module` — whose last segment
+// qualifies the producer call — plus whatever files the dependency needs. The
+// consumer writes a `manifest.toml`: the catalog is selected per *installed*
+// package, so a fixture without one loads no catalog at all and a collision
+// with a catalogued module cannot arise.
+fn path_dep_clause_effects_in(
+  name: String,
+  module: String,
+  producer: String,
+  dependency_spec: String,
+  dep_files: List(#(String, String)),
+) -> types.EffectSet {
+  let assert Ok(qualifier) = list.last(string.split(module, "/"))
   let root = "build/" <> name
-  support.write_fixture(root, [
-    #(
-      "proj/gleam.toml",
-      "name = \"proj\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n",
-    ),
-    #(
-      "proj/proj.graded",
-      "check proj.caller : []\nassume proj.shout : [Stdout]\n",
-    ),
-    #(
-      "proj/proj.gleam",
-      "import dep/wrap
+  support.write_fixture(
+    root,
+    list.append(
+      [
+        #(
+          "proj/gleam.toml",
+          "name = \"proj\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n",
+        ),
+        #(
+          "proj/manifest.toml",
+          "packages = [\n  { name = \"envoy\", version = \"1.0.0\" },\n]\n",
+        ),
+        #(
+          "proj/proj.graded",
+          "check proj.caller : []\nassume proj.shout : [Stdout]\n",
+        ),
+        #("proj/proj.gleam", "import " <> module <> "
 
 @external(erlang, \"proj_ffi\", \"shout\")
 pub fn shout() -> Nil
 
 pub fn caller() -> Nil {
-  let h = wrap.wrap(shout)
+  let h = " <> qualifier <> "." <> producer <> "(shout)
   h()
 }
-",
+"),
+        #("dep/gleam.toml", "name = \"dep\"\n"),
+        #("dep/dep.graded", dependency_spec),
+      ],
+      dep_files,
     ),
-    #("dep/gleam.toml", "name = \"dep\"\n"),
-    #("dep/dep.graded", dependency_spec),
-    #("dep/src/dep/wrap.gleam", dep_source),
-  ])
+  )
   let assert Ok(results) = graded.run(root <> "/proj")
   let assert Ok(violation) =
     results
@@ -8708,9 +8731,9 @@ pub fn caller() -> Nil {
 
 pub fn a_path_deps_assume_kept_clause_binds_over_its_bounds_test() {
   // The path-dependency tier of the same rule. Over `unannotated_wrap` the
-  // bounds the dep's kept line records are the only thing that proves `f` is a
-  // callback, and this merge copies them by a rule of its own — one keyed to
-  // the effects entry, which a module declaration is exactly what takes away.
+  // bounds on the dep's kept line are the only thing that proves `f` is a
+  // callback, and they reach this tier on the clause, so no merge here has to
+  // pair them with anything.
   path_dep_clause_effects_over(
     "clause_path_dep_module_assume",
     "assume dep/wrap : []\n"
@@ -8726,6 +8749,86 @@ pub fn a_path_deps_assume_kept_clause_binds_over_its_bounds_test() {
     unannotated_wrap,
   )
   |> should.equal(types.Specific(set.from_list(["Stdout"])))
+}
+
+pub fn a_vendored_forks_clause_binds_over_the_catalogued_name_test() {
+  // A path dependency shipping a module the bundled catalog also covers — a
+  // vendored fork of a catalogued package. The catalog's per-function `assume`
+  // lines key the same names the fork's clause does, and the clause is read
+  // against its own line either way.
+  path_dep_clause_effects_in(
+    "clause_path_dep_catalog_collision",
+    "envoy",
+    "get",
+    "assume envoy : []\n"
+      <> "effects envoy.get(f: [f]) : [] where returns : [f]\n",
+    [#("dep/src/envoy.gleam", unannotated_get)],
+  )
+  |> should.equal(types.Specific(set.from_list(["Stdout"])))
+}
+
+// `unannotated_wrap` under the name the catalog's `envoy` entry keys.
+const unannotated_get = "pub fn get(f) {
+  fn() { f() }
+}
+"
+
+// A clause is weighed against its own line, not against the params channel
+//
+// The params channel is hand-editable and keyed by function name, so a bound
+// recorded for `wrap` by one line says nothing about what a clause on another
+// line of the same name scopes. Two `effects` lines for one name are what a
+// hand edit leaves behind: the later one decides the bounds, the earlier one
+// carries the clause.
+
+const ghost_lines = "effects dep/wrap.wrap : [] where returns : [ghost]\n"
+  <> "effects dep/wrap.wrap(ghost: [ghost]) : []\n"
+
+// `ghost` is a real parameter of `wrap`, and a first-order one: passing it a
+// function is what an argument matcher would bind, and being no callback is
+// what the clause may not scope over.
+const generic_wrap = "pub fn wrap(ghost: a) -> fn() -> Nil {
+  fn() { Nil }
+}
+"
+
+pub fn a_clause_over_a_bound_from_another_line_degrades_test() {
+  cross_package_clause_effects_over(
+    "clause_foreign_bound",
+    ghost_lines,
+    generic_wrap,
+  )
+  |> should.equal(types.Specific(set.from_list(["Unknown"])))
+}
+
+pub fn an_open_clause_beside_a_bound_from_another_line_is_reported_test() {
+  // The lint's half of the same reading. It weighs the clause against the line
+  // it sits on, so the bound the second line records leaves it unmoved.
+  let root = "build/clause_lint_foreign_bound"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "effects proj.wrap : [] where returns : [ghost]\n"
+        <> "effects proj.wrap(ghost: [ghost]) : []\n",
+    ),
+    #(
+      "proj.gleam",
+      "pub fn wrap(ghost: a) -> fn() -> Nil {
+  fn() { Nil }
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  results
+  |> list.flat_map(fn(r) { r.warnings })
+  |> should.equal([
+    types.UnclosedReturnsClauseWarning(function: "proj.wrap", free_vars: [
+      "ghost",
+    ]),
+  ])
+  support.cleanup(root)
 }
 
 pub fn a_clause_applying_an_unannotated_callback_degrades_test() {

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -8667,42 +8667,41 @@ fn path_dep_clause_effects_over(
   dependency_spec: String,
   dep_source: String,
 ) -> types.EffectSet {
-  path_dep_clause_effects_in(name, "dep/wrap", "wrap", dependency_spec, [
-    #("dep/src/dep/wrap.gleam", dep_source),
-  ])
+  path_dep_clause_effects_in(
+    name,
+    "dep/wrap",
+    "wrap",
+    no_installed_packages,
+    dependency_spec,
+    dep_source,
+  )
 }
 
 // The same, over a path dependency shipping `module` — whose last segment
-// qualifies the producer call — plus whatever files the dependency needs. The
-// consumer writes a `manifest.toml`: the catalog is selected per *installed*
-// package, so a fixture without one loads no catalog at all and a collision
-// with a catalogued module cannot arise.
+// qualifies the producer call. `manifest` is the consumer's `manifest.toml`:
+// the catalog is selected per *installed* package, so it is what decides
+// whether a catalogued module is in play at all.
 fn path_dep_clause_effects_in(
   name: String,
   module: String,
   producer: String,
+  manifest: String,
   dependency_spec: String,
-  dep_files: List(#(String, String)),
+  dep_source: String,
 ) -> types.EffectSet {
   let assert Ok(qualifier) = list.last(string.split(module, "/"))
   let root = "build/" <> name
-  support.write_fixture(
-    root,
-    list.append(
-      [
-        #(
-          "proj/gleam.toml",
-          "name = \"proj\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n",
-        ),
-        #(
-          "proj/manifest.toml",
-          "packages = [\n  { name = \"envoy\", version = \"1.0.0\" },\n]\n",
-        ),
-        #(
-          "proj/proj.graded",
-          "check proj.caller : []\nassume proj.shout : [Stdout]\n",
-        ),
-        #("proj/proj.gleam", "import " <> module <> "
+  support.write_fixture(root, [
+    #(
+      "proj/gleam.toml",
+      "name = \"proj\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n",
+    ),
+    #("proj/manifest.toml", manifest),
+    #(
+      "proj/proj.graded",
+      "check proj.caller : []\nassume proj.shout : [Stdout]\n",
+    ),
+    #("proj/proj.gleam", "import " <> module <> "
 
 @external(erlang, \"proj_ffi\", \"shout\")
 pub fn shout() -> Nil
@@ -8712,12 +8711,10 @@ pub fn caller() -> Nil {
   h()
 }
 "),
-        #("dep/gleam.toml", "name = \"dep\"\n"),
-        #("dep/dep.graded", dependency_spec),
-      ],
-      dep_files,
-    ),
-  )
+    #("dep/gleam.toml", "name = \"dep\"\n"),
+    #("dep/dep.graded", dependency_spec),
+    #("dep/src/" <> module <> ".gleam", dep_source),
+  ])
   let assert Ok(results) = graded.run(root <> "/proj")
   let assert Ok(violation) =
     results
@@ -8760,12 +8757,21 @@ pub fn a_vendored_forks_clause_binds_over_the_catalogued_name_test() {
     "clause_path_dep_catalog_collision",
     "envoy",
     "get",
+    envoy_installed,
     "assume envoy : []\n"
       <> "effects envoy.get(f: [f]) : [] where returns : [f]\n",
-    [#("dep/src/envoy.gleam", unannotated_get)],
+    unannotated_get,
   )
   |> should.equal(types.Specific(set.from_list(["Stdout"])))
 }
+
+// A manifest naming a package the bundled catalog covers, and one naming none.
+const envoy_installed = "packages = [
+  { name = \"envoy\", version = \"1.0.0\" },
+]
+"
+
+const no_installed_packages = "packages = []\n"
 
 // `unannotated_wrap` under the name the catalog's `envoy` entry keys.
 const unannotated_get = "pub fn get(f) {
@@ -8799,36 +8805,6 @@ pub fn a_clause_over_a_bound_from_another_line_degrades_test() {
     generic_wrap,
   )
   |> should.equal(types.Specific(set.from_list(["Unknown"])))
-}
-
-pub fn an_open_clause_beside_a_bound_from_another_line_is_reported_test() {
-  // The lint's half of the same reading. It weighs the clause against the line
-  // it sits on, so the bound the second line records leaves it unmoved.
-  let root = "build/clause_lint_foreign_bound"
-  support.write_fixture(root, [
-    #("gleam.toml", "name = \"proj\"\n"),
-    #(
-      "proj.graded",
-      "effects proj.wrap : [] where returns : [ghost]\n"
-        <> "effects proj.wrap(ghost: [ghost]) : []\n",
-    ),
-    #(
-      "proj.gleam",
-      "pub fn wrap(ghost: a) -> fn() -> Nil {
-  fn() { Nil }
-}
-",
-    ),
-  ])
-  let assert Ok(results) = graded.run(root)
-  results
-  |> list.flat_map(fn(r) { r.warnings })
-  |> should.equal([
-    types.UnclosedReturnsClauseWarning(function: "proj.wrap", free_vars: [
-      "ghost",
-    ]),
-  ])
-  support.cleanup(root)
 }
 
 pub fn a_clause_applying_an_unannotated_callback_degrades_test() {
@@ -8925,48 +8901,70 @@ pub fn run() -> Nil {
 // The lint reports an open clause against the oracle the gate binds by, so what
 // it names is exactly what degrades to `[Unknown]`.
 
+// The warnings a one-module project whose spec is `spec` and whose source is
+// `source` collects.
+fn clause_lint_warnings(
+  name: String,
+  spec: String,
+  source: String,
+) -> List(types.Warning) {
+  let root = "build/" <> name
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #("proj.graded", spec),
+    #("proj.gleam", source),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let warnings = list.flat_map(results, fn(r) { r.warnings })
+  support.cleanup(root)
+  warnings
+}
+
+// A producer whose callback parameter every syntactic reader can see.
+const annotated_wrap = "pub fn wrap(f: fn() -> Nil) -> fn() -> Nil {
+  fn() { f() }
+}
+"
+
 pub fn an_open_clause_on_an_effects_line_is_reported_test() {
   // Hand-edited: `infer` writes a bound for every variable its clause mentions,
   // so an `effects` clause is closed by construction.
-  let root = "build/clause_lint_open"
-  support.write_fixture(root, [
-    #("gleam.toml", "name = \"proj\"\n"),
-    #("proj.graded", "effects proj.wrap(f: [f]) : [] where returns : [ghost]\n"),
-    #(
-      "proj.gleam",
-      "pub fn wrap(f: fn() -> Nil) -> fn() -> Nil {
-  fn() { f() }
-}
-",
-    ),
-  ])
-  let assert Ok(results) = graded.run(root)
-  results
-  |> list.flat_map(fn(r) { r.warnings })
+  clause_lint_warnings(
+    "clause_lint_open",
+    "effects proj.wrap(f: [f]) : [] where returns : [ghost]\n",
+    annotated_wrap,
+  )
   |> should.equal([
     types.UnclosedReturnsClauseWarning(function: "proj.wrap", free_vars: [
       "ghost",
     ]),
   ])
-  support.cleanup(root)
 }
 
 pub fn a_closed_clause_on_an_effects_line_is_not_reported_test() {
-  let root = "build/clause_lint_closed"
-  support.write_fixture(root, [
-    #("gleam.toml", "name = \"proj\"\n"),
-    #("proj.graded", "effects proj.wrap(f: [f]) : [] where returns : [f]\n"),
-    #(
-      "proj.gleam",
-      "pub fn wrap(f: fn() -> Nil) -> fn() -> Nil {
-  fn() { f() }
+  clause_lint_warnings(
+    "clause_lint_closed",
+    "effects proj.wrap(f: [f]) : [] where returns : [f]\n",
+    annotated_wrap,
+  )
+  |> should.equal([])
 }
-",
-    ),
+
+pub fn an_open_clause_beside_a_bound_from_another_line_is_reported_test() {
+  // The lint's half of what `a_clause_over_a_bound_from_another_line_degrades_test`
+  // asserts through resolution. It weighs the clause against the line it sits
+  // on, so the bound the second line records leaves it unmoved.
+  clause_lint_warnings(
+    "clause_lint_foreign_bound",
+    "effects proj.wrap : [] where returns : [ghost]\n"
+      <> "effects proj.wrap(ghost: [ghost]) : []\n",
+    generic_wrap,
+  )
+  |> should.equal([
+    types.UnclosedReturnsClauseWarning(function: "proj.wrap", free_vars: [
+      "ghost",
+    ]),
   ])
-  let assert Ok(results) = graded.run(root)
-  results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
-  support.cleanup(root)
 }
 
 pub fn a_check_clause_is_unverified_while_its_budget_still_is_test() {


### PR DESCRIPTION
A `where returns` clause has no bound list of its own — the line it sits on
supplies one, and that list is what scopes the clause's variables. Until now
the list travelled on the params channel, keyed by function name, while the
clause travelled on the returns channel. The two channels can be decided by
different tiers, and where they diverge the pairing breaks.

Two observable defects follow, both fixed here by carrying the bounds on the
summary itself (`SummaryOrigin.Closed(bounds:)`), read off the same line the
clause was read from:

- A clause on a **path dependency whose module the bundled catalog also
  covers** — a vendored fork of a catalogued package — resolved its returned
  function to `[Unknown]`. The catalog records an empty bounds entry for every
  catalogued function, the dep's module-level `assume` takes the name's effects
  entry out of the merge that would have copied the real list, and the
  catalog's empty entry shadowed what was left. The clause was judged open.
- A clause variable that the clause's own bound list does **not** scope, and
  that is no callback-typed parameter, bound anyway when some other line
  recorded a bound of that name for the same function. That is the loose
  direction: a clause judged closed that isn't, substituted over a parameter it
  never scoped. Note this was never "a parameter that does not exist" — that
  case never bound, because the argument matcher refuses it.

## Shape

`SummaryOrigin.Closed` carries the bound list, so a `Fresh` or `Declared`
summary with bounds is unconstructible rather than documented-empty.
`load_spec_returns_from_file` reads clause and bounds together into a
`ScopedClause`, which travels through `DepSpec.returns` and `tag_closed_returns`
to every tier — installed dependency, path dependency and committed spec alike.
No tier copies a bound list by a rule of its own any more.

`checker.unclosed_clause_variables` takes the scoping list as an argument and no
longer takes a knowledge base at all, so nothing keyed by function name can
widen what a clause may scope. The spec lint passes the linted line's own
`params`; resolution passes the bounds off the `Closed` summary it just matched
on. A `Fresh` summary still reads the params channel — those bounds carry the
girard-typed callbacks no syntactic signature shows — and `bind_producer_params`
resolves that lookup on the cross-module path only, where it is read.

With the exception gone, the params channel is back to its unbroken "bounds pair
with their term" rule: the `option.is_none(ann.returns)` carve-out in
`load_spec_params_from_file`, the `keep` sets on both module-declaration drops,
and the post-fold `scoping` recomputation in `with_path_dep_spec` are all
deleted, along with the prose that explained them at six sites. The two
module-declaration filters had become identical, so there is one now —
`effects.drop_module_declared`, read from both sides of the package boundary.

## Tests

Three new tests, each replayed against the branch base to confirm it fails
there with the pre-fix value:

- a path dep shipping `envoy` (a catalogued module) with a manifest naming it,
  a module-level assume and a polymorphic clause: `[Stdout]`, was `[Unknown]`
- a clause over a bound recorded by a different line for the same function:
  `[Unknown]`, was `[Stdout]`
- the same shape through the lint: reports the open clause, was silent

The three kept-clause tiers (installed dep, path dep, own spec) stay green
unchanged. Two `effects_test` cases that asserted the old mechanism now assert
the bounds on the summary and `lookup_param_bounds == []`, converging with the
clause-less case beside them. Two `checker_test` cases were feeding committed
clauses into `with_fresh_returned_operators`, which bypasses the gate entirely;
they now go through `with_closed_returned_operators` and pass under the real
gate.

Release-wise this changes what a committed spec resolves to in the trigger case,
so an `effects` line can change on the next `graded infer` — a minor, not a
patch.

All four gates green: `gleam format --check`, `gleam build --warnings-as-errors`,
`gleam test` (1192 passing), `gleam run -m glinter`.