### PR TITLE
Charge a bodyless external's callbacks on the value channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   module-level assumptions keep the union.
 - A written `assume … where returns` clause on such an external is now
   trusted, where it was previously refused whole.
-- A boundless `assume` over a higher-order external still charges each
-  callback argument's actual effects, on every call shape.
+- A boundless `assume` over a higher-order external charges each callback
+  argument's actual effects on every channel — called directly, passed to a
+  helper, wired into a record field, or referenced by a sibling — and
+  `[Unknown]` at any call shape graded cannot trace. An external with no Gleam
+  fallback body, and one a catalog or a dependency's spec declares, are covered
+  too; previously only a direct call to them charged the callback, so checks
+  that passed because such an external was handed around as a value may now
+  fail. A line with its own bound list answers for its callbacks as written.
+- A Gleam function a catalog entry or a module-level `assume` declares — such
+  as `gleam/list.map` — charges its callback argument's effects when it is
+  passed as a value or wired into a record field. Its direct calls are
+  unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   too; previously only a direct call to them charged the callback, so checks
   that passed because such an external was handed around as a value may now
   fail. A line with its own bound list answers for its callbacks as written.
-- A Gleam function a catalog entry or a module-level `assume` declares — such
-  as `gleam/list.map` — charges its callback argument's effects when it is
-  passed as a value or wired into a record field. Its direct calls are
-  unchanged.
+- A module-level `assume` states what its functions' own bodies cost and
+  nothing about the callbacks they are handed, matching a boundless
+  per-function line. `assume myapp/util : []` over a higher-order
+  `util.each(cb)` now charges each caller the callback it passes, whether it
+  calls `each` directly, hands it to a helper, or does either from inside the
+  declared module. Previously such a callback was charged to nobody, so an
+  effectful function passed to a module-assumed helper passed a pure check.
+- A Gleam function a catalog entry declares — such as `gleam/list.map` —
+  charges its callback argument's effects when it is passed as a value or
+  wired into a record field. Its direct calls are unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,24 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   module-level assumptions keep the union.
 - A written `assume … where returns` clause on such an external is now
   trusted, where it was previously refused whole.
-- A boundless `assume` over a higher-order external charges each callback
-  argument's actual effects on every channel — called directly, passed to a
-  helper, wired into a record field, or referenced by a sibling — and
-  `[Unknown]` at any call shape graded cannot trace. An external with no Gleam
-  fallback body, and one a catalog or a dependency's spec declares, are covered
-  too; previously only a direct call to them charged the callback, so checks
-  that passed because such an external was handed around as a value may now
-  fail. A line with its own bound list answers for its callbacks as written.
-- A module-level `assume` states what its functions' own bodies cost and
-  nothing about the callbacks they are handed, matching a boundless
-  per-function line. `assume myapp/util : []` over a higher-order
-  `util.each(cb)` now charges each caller the callback it passes, whether it
-  calls `each` directly, hands it to a helper, or does either from inside the
-  declared module. Previously such a callback was charged to nobody, so an
-  effectful function passed to a module-assumed helper passed a pure check.
-- A Gleam function a catalog entry declares — such as `gleam/list.map` —
-  charges its callback argument's effects when it is passed as a value or
-  wired into a record field. Its direct calls are unchanged.
+- A boundless `assume` over a higher-order external now charges its callback
+  argument however the external is reached — called, passed to a helper, wired
+  into a field, referenced by a sibling — where only a direct call charged it
+  before. Checks that passed because the external was handed around as a value
+  may now fail; a line with its own bound list is unaffected.
+- A module-level `assume` says nothing about the callbacks its functions are
+  handed, so `assume myapp/util : []` over `util.each(cb)` now charges each
+  caller the callback it passes. Previously that callback was charged to
+  nobody.
+- A Gleam function a catalog entry declares — `gleam/list.map` and kin —
+  charges its callback when passed as a value or wired into a field. Direct
+  calls are unchanged.
 
 ### Fixed
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -693,6 +693,11 @@ fn project_context(sources: ProjectSources) -> ProjectContext {
     // Before anything is looked up: every foreign lookup is read on the targets
     // this build compiles, and every command reads them the same way.
     |> effects.with_package_targets(cfg.targets)
+    // Which parameters of a declared name are callbacks, from the one registry
+    // this run builds. Ahead of the path-dependency and fallback-body walks
+    // below: a body walked there charges a declared name the same conservative
+    // callback share a body walked at check time does.
+    |> effects.with_callback_params(signatures.callback_param_names(registry))
     // Consumer externals are applied before path-dep inference so a module-level
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.
@@ -1889,19 +1894,24 @@ fn spec_answer(
         when: runs_a_fallback_body(parsed.foreign, name),
         return: Error(Nil),
       )
-      let dependency_foreign =
-        dependency_foreign_for(directory, project_modules, module, targets)
+      let dependency =
+        dependency_facts_for(directory, project_modules, module, targets)
       // And a *dependency's* external whose fallback body runs, for the same
       // reason: the full context walks that body during its dependency pass and
       // charges the name what it does, so answering from the declaration alone
       // would quote a charge `check` does not levy.
       use <- bool.guard(
-        when: runs_a_fallback_body(dependency_foreign, name),
+        when: runs_a_fallback_body(dependency.foreign, name),
         return: Error(Nil),
       )
       answer_from(
         with_module_facts(spec_knowledge_base(spec, stale, targets), parsed)
-          |> effects.with_dependency_foreign(dependency_foreign),
+          |> effects.with_dependency_foreign(dependency.foreign)
+          // The dependency module's own callback parameters, from the parse
+          // above: a boundless declaration over one of its higher-order
+          // externals charges a variable per callback, and an answer without
+          // them quotes the declared term the full context widened.
+          |> effects.with_callback_params(dependency.callbacks),
         name,
       )
     }
@@ -1965,34 +1975,51 @@ fn runs_a_fallback_body(
   }
 }
 
-// What a *dependency's* source says is `@external` in the queried module.
+// What a *dependency's* source says about the queried module: which of its
+// functions are `@external`, and which parameters of each are callbacks. Both
+// come off one parse, because both answer the same question about the same
+// module and a second parse could read a different copy of it.
+type DependencyModuleFacts {
+  DependencyModuleFacts(
+    foreign: Dict(QualifiedName, types.ForeignFunction),
+    callbacks: Dict(QualifiedName, List(String)),
+  )
+}
+
+// What a *dependency's* source says about the queried module.
 //
 // Empty for one of this package's own modules: Gleam forbids a dependency from
 // keying one, so nothing over there can change the answer. For a dependency
 // module — which a per-function `assume` line may name — the
 // declaration alone understates an `@external` whose Gleam fallback body runs,
 // because the full context walks that body and unions what it does into the
-// charge. One module is located and parsed to settle it, so the fast path can
-// tell that case and hand it back rather than answer where the full context
-// would say more.
-fn dependency_foreign_for(
+// charge. It also understates a boundless declaration over a higher-order one,
+// whose callbacks the full context charges off this same signature. One module
+// is located and parsed to settle both, so the fast path can tell the first
+// case and hand it back, and answer the second as the full context does.
+fn dependency_facts_for(
   directory: String,
   project_modules: Dict(String, String),
   module: String,
   package_targets: types.PackageTargets,
-) -> Dict(QualifiedName, types.ForeignFunction) {
-  use <- bool.guard(
-    when: dict.has_key(project_modules, module),
-    return: dict.new(),
-  )
+) -> DependencyModuleFacts {
+  let none = DependencyModuleFacts(foreign: dict.new(), callbacks: dict.new())
+  use <- bool.guard(when: dict.has_key(project_modules, module), return: none)
   let files = dependency_module_files(resolve_package_root(directory))
   // A dependency graded cannot locate or parse is one the full context cannot
   // read either, so both answer from the declaration alone.
-  use <- bool.guard(when: !dict.has_key(files, module), return: dict.new())
+  use <- bool.guard(when: !dict.has_key(files, module), return: none)
   case dict.get(files, module) |> result.try(read_and_parse_gleam_or_nil) {
     Ok(parsed) ->
-      checker.dependency_foreign_functions(parsed, module, package_targets)
-    Error(Nil) -> dict.new()
+      DependencyModuleFacts(
+        foreign: checker.dependency_foreign_functions(
+          parsed,
+          module,
+          package_targets,
+        ),
+        callbacks: module_callback_params(module, parsed),
+      )
+    Error(Nil) -> none
   }
 }
 
@@ -2024,6 +2051,12 @@ type ModuleFacts {
     foreign: Dict(QualifiedName, types.ForeignFunction),
     visibility: Dict(String, Dict(String, types.Visibility)),
     native: Set(String),
+    // Which parameters of each of its functions are callbacks — what the full
+    // context reads off the whole-package registry, taken here from the one
+    // module this path parses. A boundless declaration over a higher-order
+    // `@external` charges a variable per callback, so an answer without them
+    // quotes a narrower term than `check` levies.
+    callbacks: Dict(QualifiedName, List(String)),
   )
 }
 
@@ -2048,6 +2081,7 @@ fn module_source_facts(
         foreign: dict.new(),
         visibility: dict.new(),
         native: set.new(),
+        callbacks: dict.new(),
       ))
     Ok(path) -> {
       use module <- result.map(
@@ -2059,12 +2093,27 @@ fn module_source_facts(
           #(module_path, checker.function_visibility(module)),
         ]),
         native: checker.native_function_names(module, package_targets),
+        callbacks: module_callback_params(module_path, module),
       )
     }
   }
 }
 
-// Fold one module's source facts into a knowledge base, in the same two calls
+// The callback parameters of one parsed module's functions — what the full
+// context reads off the whole-package registry, derived here from the single
+// module a fast-path answer parses. Both fast-path halves take it from here, so
+// neither can read a module's signatures differently from the other.
+fn module_callback_params(
+  module_path: String,
+  module: glance.Module,
+) -> Dict(QualifiedName, List(String)) {
+  signatures.callback_param_names(signatures.from_glance_module(
+    module_path,
+    module,
+  ))
+}
+
+// Fold one module's source facts into a knowledge base, in the same three calls
 // the full context makes over the whole package.
 fn with_module_facts(
   knowledge_base: KnowledgeBase,
@@ -2073,6 +2122,7 @@ fn with_module_facts(
   knowledge_base
   |> effects.with_foreign_functions(facts.foreign)
   |> effects.with_project_functions(facts.visibility)
+  |> effects.with_callback_params(facts.callbacks)
 }
 
 // Render `name` as an `effects` line, or `Error(Nil)` when it isn't a known
@@ -2163,7 +2213,12 @@ fn function_effect(
       Ok(answer.FunctionAnswer(
         name:,
         module:,
-        bounds: fallback_bounds,
+        // The full pairing, as the function-entry answer below takes: a
+        // module-level `assume` states no bounds of its own, and where the
+        // charge synthesized a callback variable for one of the module's
+        // higher-order externals, the bound that scopes it is in this list and
+        // in no other.
+        bounds: effects.lookup_param_bounds(knowledge_base, qualified),
         term:,
         source: answer.Entry(types.ModuleExternalEntry(origin:), fallback:),
       ))
@@ -3176,6 +3231,9 @@ fn compute_infer(directory: String) -> Result(InferOutcome, GradedError) {
       dependency_foreign(dep_sources),
     )
     |> effects.with_package_targets(cfg.targets)
+    // As in `project_context`: the callback parameters of every parsed
+    // signature, in reach of the walks below.
+    |> effects.with_callback_params(signatures.callback_param_names(registry))
     // Consumer externals are applied before path-dep inference so a module-level
     // external governs a path dependency's module during that dep's own
     // inference, not only at the final lookup.

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -3945,14 +3945,19 @@ fn substitute_local_call_effects(
   case dict.get(function_map, local_call.function) {
     Error(Nil) -> #(recursive, memo)
     Ok(local_definition) -> {
-      // A foreign sibling was collected as the knowledge base's charge under
-      // its qualified name. Substitute it exactly as a qualified call is —
-      // auto-detected callback bounds included — so both call shapes pay the
-      // same set. A *native* sibling under a module-level declaration keeps
-      // the declaration's set alone; the reference it is handed surfaces as
-      // an untracked-effect warning, not a charge.
+      // A sibling a declaration answers for was collected as the knowledge
+      // base's charge under its qualified name. Substitute it exactly as a
+      // qualified call is — auto-detected callback bounds included — so both
+      // call shapes pay the same set.
+      //
+      // A *native* sibling under a module-level `assume` comes through here
+      // too. That line states the function's own effects and says nothing
+      // about what it does with a callback it is handed, exactly as a
+      // boundless per-function line does; keeping the declaration's set alone
+      // charged its callback to nobody, and let a same-module caller pass an
+      // effectful function to a module-assumed helper for free.
       use <- bool.lazy_guard(
-        when: foreign_definition(local_definition, context.package_targets),
+        when: declares_for_callers(local_definition, context, knowledge_base),
         return: fn() {
           let #(memo, calls) =
             list.map_fold(recursive, memo, fn(memo, one) {

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -5063,7 +5063,7 @@ fn operator_term_for_argument(
         signatures.fn_typed_param_names_ordered(
           registry,
           name,
-          recorded_bound_names(knowledge_base, name),
+          value_channel_bound_names(knowledge_base, name),
         )
         |> list.fold_right(body, fn(acc, param) { types.TAbs(param, acc) })
       #(operator, memo)
@@ -6124,6 +6124,19 @@ fn recorded_bound_names(
   effects.bound_name_set(effects.lookup_param_bounds(knowledge_base, name))
 }
 
+// The same for the value channels, whose term may carry a callback variable
+// the recorded bounds do not name — a declared Gleam function's synthesized
+// share. The binder has to be the variable the term holds free: where the
+// callback is labeled, `fn_typed_param_names_ordered` prefers the label unless
+// a bound names the parameter, and a binder named after the label leaves the
+// term's variable free, the application stuck, and the result `[Unknown]`.
+fn value_channel_bound_names(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> Set(String) {
+  effects.bound_name_set(effects.value_channel_bounds(knowledge_base, name))
+}
+
 // Argument matching
 //
 // Locate the call argument bound to a named callee parameter — by label, then
@@ -6540,7 +6553,11 @@ fn value_field_effect(
     // an `@external` wired into a field is charged the same `[Unknown]` a call
     // to it is, and `local_function_field_effect` declines to walk its body.
     Some(name) ->
-      case effects.lookup_declared(knowledge_base, name) {
+      // Read as the value channel it is: a declaration silent about the wired
+      // function's callbacks says nothing about what calling the field does
+      // with them, so the term carries a variable for each. A no-op for a
+      // foreign name, whose charge carries the same share already.
+      case effects.lookup_value_channel(knowledge_base, name) {
         effects.Known(effect, source) -> #(
           known_field_effect(effect, knowledge_base, name),
           Some(effects.origin_of(source)),
@@ -6636,6 +6653,11 @@ fn value_field_effect(
 // The field effect of a wired function as the knowledge base reports it: a
 // concrete effect carries no bounds or source; an effect-polymorphic one keeps
 // the wired function's bounds and identity for substitution at the field call.
+//
+// The bounds are the value channel's, which pair with the term this channel
+// reads: a callback variable synthesized into that term binds through a bound
+// of the same name, and without it the field call resolves the argument it was
+// handed to nothing.
 fn known_field_effect(
   field_effects: EffectTerm,
   knowledge_base: KnowledgeBase,
@@ -6646,7 +6668,7 @@ fn known_field_effect(
     True ->
       types.TypeFieldEffect(
         field_effects,
-        effects.lookup_param_bounds(knowledge_base, name),
+        effects.value_channel_bounds(knowledge_base, name),
         Some(name),
         types.Inferred,
       )

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -5932,25 +5932,36 @@ fn lift_local_function(
 ) -> #(EffectTerm, Memo) {
   let function = definition.definition
   let fn_param_names = ordered_fn_typed_param_names(function)
-  // An `@external` has no body to lift. It is charged what declares the foreign
-  // code — the rule a direct same-module call into it already follows —
-  // abstracted over its own callback parameters so an application of the lifted
-  // operator still reduces. Walking the empty or fallback body instead would
-  // lift an undeclared external to `[]`, and a caller passing it to a
-  // higher-order helper would inherit that `[]` while a direct call to the same
-  // name inherits `[Unknown]`. The recorded bounds name callback parameters
-  // too: a running fallback's girard-typed callback has no `fn(...)`
-  // annotation, and without its binder the summary's variable stays free and
-  // the application goes stuck.
+  // A sibling a declaration answers for is lifted from that declaration, not
+  // from the body beside it — the rule a direct same-module call into it
+  // already follows — abstracted over its own callback parameters so an
+  // application of the lifted operator still reduces.
+  //
+  // An `@external` has no body to lift at all: walking the empty or fallback
+  // body would lift an undeclared one to `[]`, and a caller passing it to a
+  // higher-order helper would inherit that `[]` while a direct call to the
+  // same name inherits `[Unknown]`.
+  //
+  // Ordinary Gleam under a module-level `assume` has a body, and walking it is
+  // just as wrong: the line is what its callers pay, and a helper that happens
+  // not to call the callback it is handed lifts to `λcb. []` — handing a
+  // caller a free pass the same line refuses a direct call. The term is the
+  // value channel's for that reason, so the sibling reference and a
+  // cross-module one read one answer.
+  //
+  // The bounds name callback parameters the signature does not: a running
+  // fallback's girard-typed callback carries no `fn(...)` annotation, and
+  // without its binder the term's variable stays free and the application goes
+  // stuck.
   use <- bool.lazy_guard(
-    when: foreign_definition(definition, context.package_targets),
+    when: declares_for_callers(definition, context, knowledge_base),
     return: fn() {
       let qualified = QualifiedName(module: context.module_path, function: name)
-      let declared = foreign_resolution(knowledge_base, qualified).term
+      let declared = effects.declared_effects(knowledge_base, qualified)
       let params =
         ordered_callback_param_names(
           function,
-          recorded_bound_names(knowledge_base, qualified),
+          value_channel_bound_names(knowledge_base, qualified),
         )
       #(
         list.fold_right(params, declared, fn(acc, param) {
@@ -6119,22 +6130,15 @@ pub fn unclosed_clause_variables(
   })
 }
 
-// The parameter names `name`'s recorded bounds state effects over, for the
+// The parameter names a value channel's bounds state effects over, for the
 // binders a lifted operator abstracts over. For one of this package's running
-// fallbacks these carry the girard-typed callbacks no syntactic signature shows.
-fn recorded_bound_names(
-  knowledge_base: KnowledgeBase,
-  name: QualifiedName,
-) -> Set(String) {
-  effects.bound_name_set(effects.lookup_param_bounds(knowledge_base, name))
-}
-
-// The same for the value channels, whose term may carry a callback variable
-// the recorded bounds do not name — a declared Gleam function's synthesized
-// share. The binder has to be the variable the term holds free: where the
-// callback is labeled, `fn_typed_param_names_ordered` prefers the label unless
-// a bound names the parameter, and a binder named after the label leaves the
-// term's variable free, the application stuck, and the result `[Unknown]`.
+// fallbacks these carry the girard-typed callbacks no syntactic signature
+// shows, and for a declared name they carry its synthesized callback share.
+//
+// The binder has to be the variable the term holds free: where the callback is
+// labeled, `fn_typed_param_names_ordered` prefers the label unless a bound
+// names the parameter, and a binder named after the label leaves the term's
+// variable free, the application stuck, and the result `[Unknown]`.
 fn value_channel_bound_names(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -126,6 +126,14 @@ pub type KnowledgeBase {
     // is one a walk reached, which is what `widens_with_dependency_fallback`
     // reads to tell a walked dependency body from an unwalked one.
     fallback_summaries: Dict(QualifiedName, #(EffectTerm, List(ParamBound))),
+    // The callback parameters of every function whose signature graded parsed,
+    // in position order — the signature registry's fn-typed parameters, folded
+    // in as plain names so this module stays glance-free. Read only where a
+    // *declaration* answers for a name and states no bounds of its own: there
+    // the callback share the declaration is silent about is one variable per
+    // name here, so a value channel charges the callback the same way a direct
+    // call's registry auto-injection does.
+    callback_params: Dict(QualifiedName, List(String)),
     // The targets the package under analysis is built for, and whether it named
     // them. Every foreign lookup is read on the build's own targets, and a
     // declaration is read on the wider set an assumption cannot narrow — see
@@ -225,6 +233,7 @@ pub fn knowledge_base_from_catalog(
     dependency_foreign:,
     project_functions: dict.new(),
     fallback_summaries: dict.new(),
+    callback_params: dict.new(),
     package_targets: types.all_targets(),
     active_targets: None,
   )
@@ -250,6 +259,7 @@ pub fn new_knowledge_base() -> KnowledgeBase {
     dependency_foreign: dict.new(),
     project_functions: dict.new(),
     fallback_summaries: dict.new(),
+    callback_params: dict.new(),
     package_targets: types.all_targets(),
     active_targets: None,
   )
@@ -273,6 +283,7 @@ pub fn empty_knowledge_base() -> KnowledgeBase {
     dependency_foreign: dict.new(),
     project_functions: dict.new(),
     fallback_summaries: dict.new(),
+    callback_params: dict.new(),
     package_targets: types.all_targets(),
     active_targets: None,
   )
@@ -551,6 +562,90 @@ pub fn with_fallback_summaries(
   )
 }
 
+// Record the callback parameters of the functions whose signatures graded
+// parsed, in position order. Merged into what is already recorded, so a caller
+// that parses one more module — the single-module fast path — adds to it.
+pub fn with_callback_params(
+  knowledge_base: KnowledgeBase,
+  callbacks: Dict(QualifiedName, List(String)),
+) -> KnowledgeBase {
+  KnowledgeBase(
+    ..knowledge_base,
+    callback_params: dict.merge(knowledge_base.callback_params, callbacks),
+  )
+}
+
+// The callback parameter names recorded for `name`, in position order. Empty
+// where no parsed signature keys it — a dependency whose source is absent or
+// would not parse, which is where this widening degrades to charging nothing.
+fn registry_callback_names(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> List(String) {
+  dict.get(knowledge_base.callback_params, name) |> result.unwrap([])
+}
+
+// Whether a declaration's silence about `name`'s callbacks is filled in from
+// the signature registry: a parsed signature says the name takes a callback at
+// all, it states no bounds of its own, no fallback summary carries the callback
+// variables already, and a declaration answers for the name.
+//
+// The bounds and summary gates are what keep this off every name that already
+// answers for its callbacks: a bounded line wrote its own answer, and a
+// recorded summary's bounds are the ones `conservative_callback_charge`
+// prefers. Requiring a declaration is what keeps an undeclared external out —
+// nothing speaks for it, and synthesizing a variable would put one in the term
+// no line ever scoped.
+//
+// Asked cheapest and most selective first, because every value channel asks it
+// of every name it resolves: almost nothing takes a callback at all, so the one
+// lookup that settles that comes before the three that weigh how the name is
+// declared — `raw_declaration`, the dearest of them, last.
+fn synthesizes_registry_share(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> Bool {
+  registry_callback_names(knowledge_base, name) != []
+  && line_param_bounds(knowledge_base, name) == []
+  && !dict.has_key(knowledge_base.fallback_summaries, name)
+  && option.is_some(raw_declaration(knowledge_base, name))
+}
+
+// Which side of the foreign split owns `name`'s synthesized callback share.
+// Two readings of one question, so the halves cannot drift into overlapping or
+// leaving a gap between them.
+//
+// The foreign half is folded into the charge itself, where every channel —
+// direct call included — reads it. The other half is a value channel's alone:
+// ordinary Gleam a catalog entry or module-level `assume` declares is reached
+// by direct calls too (a sibling's, through `declares_for_callers`), and those
+// are charged precisely from the argument in hand, so widening them would
+// charge a share nothing binds.
+fn synthesizes_foreign_share(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> Bool {
+  synthesizes_registry_share(knowledge_base, name)
+  && is_value_opaque(knowledge_base, name)
+}
+
+fn synthesizes_channel_share(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> Bool {
+  synthesizes_registry_share(knowledge_base, name)
+  && !is_value_opaque(knowledge_base, name)
+}
+
+// The bounds a per-function line states for `name`, raw — the map's own entry,
+// before a fallback summary's bounds are paired with it.
+fn line_param_bounds(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> List(ParamBound) {
+  dict.get(knowledge_base.param_bounds, name) |> result.unwrap([])
+}
+
 // What a foreign name costs the code being walked, and which halves the charge
 // is made of.
 //
@@ -629,6 +724,13 @@ pub fn declared_charge(
   // variables for distinct parameters and each binds exactly its own
   // argument. `lookup_param_bounds` serves the matching rewritten list.
   let declared = declared_beside_fallback(knowledge_base, name, raw)
+  // What the declaration charges wherever it answers without a running
+  // fallback beside it — three of the readings below. One definition, so no two
+  // of them can come to different terms, and deferred, so the three that read a
+  // fallback body instead pay nothing to have it in scope.
+  let alone = fn() {
+    conservative_callback_charge(knowledge_base, name, declared)
+  }
   let fallback = running_fallback_term(knowledge_base, name)
   case halves, fallback {
     // Every target this walk runs on has a foreign implementation for `name`, so
@@ -636,11 +738,12 @@ pub fn declared_charge(
     // declaration — suppressing or not — still keeps the conservative callback
     // charge on this reading: the foreign implementation may call the callback
     // too, the fallback term that would otherwise carry it is no part of the
-    // total, and the recorded summary bounds stand in for the registry
-    // injection they pre-empt at the call site.
+    // total, and the recorded summary bounds — or, for a name no summary
+    // covers, the parsed signature's callback parameters — stand in for the
+    // registry injection they pre-empt at the call site.
     DeclarationOnly, _ ->
       ForeignCharge(
-        term: conservative_callback_charge(knowledge_base, name, declared),
+        term: alone(),
         fallback: types.NoFallback,
         declaration: DeclarationCharged,
       )
@@ -667,7 +770,7 @@ pub fn declared_charge(
       case suppressed {
         True ->
           ForeignCharge(
-            term: conservative_callback_charge(knowledge_base, name, declared),
+            term: alone(),
             fallback: types.FallbackSuppressed(fallback),
             declaration: DeclarationCharged,
           )
@@ -678,9 +781,14 @@ pub fn declared_charge(
             declaration: DeclarationCharged,
           )
       }
+    // A declaration beside a fallback body nothing runs — a single-target
+    // external under defaulted targets, whose Gleam body the declaration's own
+    // target never reaches. The declaration is the whole charge, and being
+    // boundless it says nothing about the callbacks, so the same conservative
+    // share rides it.
     DeclarationAndFallback, None ->
       ForeignCharge(
-        term: declared,
+        term: alone(),
         fallback: types.NoFallback,
         declaration: DeclarationCharged,
       )
@@ -698,30 +806,55 @@ pub fn declared_charge(
 // bounds qualify: a dotted field bound (`r.go`) exists solely to bind the
 // body's own field call, and reviving it would charge the share the reading
 // dropped.
+//
+// A summary-less external — a bodyless one, or one whose declaration covers
+// every target — has no recorded bounds to read the callbacks off, so the
+// names come from the parsed signature instead
+// (`synthesizes_registry_share`). Without that the share stood on the direct
+// call alone, where the checker injects it from the same registry, and the
+// same external passed to a helper or wired into a field charged nothing for
+// its callback.
+//
+// Foreign names only on that last reading. Ordinary Gleam under a module-level
+// `assume` comes through this derivation too — a sibling call into one is
+// charged what declares it — and that is a *direct* call, where the checker's
+// registry injection answers with the argument's shape in hand and declines
+// the ones it cannot trace. Synthesizing here would charge that call a
+// variable no bound list of this name's binds. What such a name owes on a
+// value channel is `declared_effects`'.
 fn conservative_callback_charge(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
   declared: EffectTerm,
 ) -> EffectTerm {
-  let line_bounds = case dict.get(knowledge_base.param_bounds, name) {
-    Ok(bounds) -> bounds
-    Error(Nil) -> []
-  }
-  use <- bool.guard(when: line_bounds != [], return: declared)
-  let callback_bounds = case dict.get(knowledge_base.fallback_summaries, name) {
-    Ok(#(_term, fallback_bounds)) ->
-      list.filter(fallback_bounds, fn(bound) {
-        !string.contains(bound.name, ".")
-      })
-    Error(Nil) -> []
-  }
-  use <- bool.guard(when: callback_bounds == [], return: declared)
-  effect_term.normalize(
-    types.TUnion([
-      declared,
-      ..list.map(callback_bounds, fn(bound) { types.TVar(bound.name) })
-    ]),
+  use <- bool.guard(
+    when: line_param_bounds(knowledge_base, name) != [],
+    return: declared,
   )
+  let callback_names = case dict.get(knowledge_base.fallback_summaries, name) {
+    Ok(#(_term, fallback_bounds)) ->
+      fallback_bounds
+      |> list.filter(fn(bound) { !string.contains(bound.name, ".") })
+      |> list.map(fn(bound) { bound.name })
+    Error(Nil) -> foreign_registry_callbacks(knowledge_base, name)
+  }
+  use <- bool.guard(when: callback_names == [], return: declared)
+  effect_term.normalize(
+    types.TUnion([declared, ..list.map(callback_names, types.TVar)]),
+  )
+}
+
+// The registry's callback names for a summary-less *foreign* name, and none
+// for anything else — the reading `conservative_callback_charge` falls back to
+// where no recorded summary names the callbacks.
+fn foreign_registry_callbacks(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> List(String) {
+  case synthesizes_foreign_share(knowledge_base, name) {
+    True -> registry_callback_names(knowledge_base, name)
+    False -> []
+  }
 }
 
 // Whether a declaring origin's line, in reach beside a running Gleam fallback
@@ -1193,6 +1326,15 @@ pub fn declares_foreign_code(origin: LookupOrigin) -> Bool {
 // record field and a `check` line all come through here, so no two of them can
 // charge one name differently — a raw `lookup` that skipped the rule is exactly
 // how a stale `effects` line for an `@external` used to be believed.
+//
+// One share rides *beside* this boundary rather than inside it: the callback a
+// boundless declaration over a **non-foreign** name is silent about. It cannot
+// live here, because a same-module sibling's direct call routes through this
+// same answer (`declares_for_callers`) and a direct call already charges its
+// callbacks precisely, from the argument in hand. So a value channel reads
+// `declared_effects` and `value_channel_bounds`, which add it, and this
+// function answers those names as written. The invariant above holds outright
+// for foreign names, whose share `declared_charge` folds in below.
 pub fn lookup_declared(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
@@ -1253,13 +1395,84 @@ fn undeclared_lookup(
 // The same as an `EffectTerm`, `[Unknown]` where nothing answers for the name.
 // The term may be second-order (carry operator applications) for higher-order
 // functions; callers reduce it at the resolution boundary.
+//
+// This is the value channels' reading — a function passed to a higher-order
+// callee, lifted as an operator argument, or wired into a record field — and it
+// carries the conservative callback share for a *declared* name the charge
+// itself does not widen. A foreign name's share rides its charge, so every
+// channel reads one term; a Gleam function a catalog entry or a module-level
+// `assume` declares has no charge to ride, and a declaration silent about its
+// callbacks says nothing about what the value does with them.
 pub fn declared_effects(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
 ) -> EffectTerm {
   case lookup_declared(knowledge_base, name) {
-    Known(effect_term, _) -> effect_term
+    Known(effect_term, _) ->
+      value_channel_term(knowledge_base, name, effect_term)
     Unknown -> effect_term.unknown()
+  }
+}
+
+// `term` with one variable per recorded callback parameter, where a
+// declaration answers for `name` and states no bounds of its own. A foreign
+// name is left alone: `declared_charge` already unioned the same share into
+// the term every one of its channels reads, and unioning it twice would only
+// re-derive it.
+//
+fn value_channel_term(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+  term: EffectTerm,
+) -> EffectTerm {
+  use <- bool.guard(
+    when: !synthesizes_channel_share(knowledge_base, name),
+    return: term,
+  )
+  effect_term.normalize(
+    types.TUnion([
+      term,
+      ..list.map(registry_callback_names(knowledge_base, name), types.TVar)
+    ]),
+  )
+}
+
+// The same as `declared_effects`, with the source that answered travelling
+// beside the term — for the value channel that records provenance rather than
+// rendering it, a function wired into a record field.
+//
+// A value channel reads this rather than `lookup_declared`, whose answer is the
+// direct call's: pairing the two by hand at the call site is a step a later
+// channel can forget, and forgetting it silently under-charges every
+// non-foreign declared name.
+pub fn lookup_value_channel(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> EffectLookup {
+  case lookup_declared(knowledge_base, name) {
+    Known(term, source) ->
+      Known(value_channel_term(knowledge_base, name, term), source)
+    Unknown -> Unknown
+  }
+}
+
+// The bounds that bind what a value channel reads: `lookup_param_bounds`,
+// widened to the synthesized callback bounds where a declaration answers for
+// `name`, states none itself, and the channel's term carries the synthesized
+// variables. The bounds a channel binds with pair with the term it charges —
+// a variable no bound binds resolves to nothing, and `[Unknown]` is what a
+// consumer then reads where the argument's own effect was in hand.
+pub fn value_channel_bounds(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> List(ParamBound) {
+  case lookup_param_bounds(knowledge_base, name) {
+    [] ->
+      case synthesizes_channel_share(knowledge_base, name) {
+        True -> synthesized_callback_bounds(knowledge_base, name)
+        False -> []
+      }
+    bounds -> bounds
   }
 }
 
@@ -1298,14 +1511,27 @@ pub fn argument_value_effects(
 // a shared name between the halves is always the same parameter binding the
 // same argument. Exact duplicates are dropped, so the common case stays one
 // list.
+//
+// Where neither states any — a boundless declaration over a summary-less
+// foreign name — the bounds are synthesized from the parsed signature, one
+// self-referential bound per callback parameter. They pair with the variables
+// `conservative_callback_charge` unions into that name's term: a term carrying
+// a variable no bound binds is one the call site cannot resolve, and a bound
+// list without its term would send the call site's fast path straight past the
+// substitution. Foreign names only — a catalog-declared Gleam function keeps
+// its direct calls on the checker's registry auto-injection, which reads the
+// argument's shape before it charges anything.
+//
+// This is therefore the **direct call's** list. A channel that reads a name as
+// a *value* — an operator argument, a wired field — wants
+// `value_channel_bounds`, which pairs with the term `declared_effects` hands
+// that channel; binding a value channel with this list under-charges every
+// non-foreign declared name.
 pub fn lookup_param_bounds(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
 ) -> List(types.ParamBound) {
-  let declared = case dict.get(knowledge_base.param_bounds, name) {
-    Ok(bounds) -> bounds
-    Error(Nil) -> []
-  }
+  let declared = line_param_bounds(knowledge_base, name)
   case dict.get(knowledge_base.fallback_summaries, name) {
     Ok(#(_term, fallback_bounds)) -> {
       let #(declared, _rename) = self_referential_declaration(declared)
@@ -1316,8 +1542,25 @@ pub fn lookup_param_bounds(
         }),
       )
     }
-    Error(Nil) -> declared
+    Error(Nil) ->
+      case synthesizes_foreign_share(knowledge_base, name) {
+        True -> synthesized_callback_bounds(knowledge_base, name)
+        False -> declared
+      }
   }
+}
+
+// One self-referential bound per recorded callback parameter — the bound list
+// pairing the variables `conservative_callback_charge` synthesizes.
+fn synthesized_callback_bounds(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> List(ParamBound) {
+  knowledge_base
+  |> registry_callback_names(name)
+  |> list.map(fn(callback) {
+    types.ParamBound(name: callback, effects: types.TVar(callback))
+  })
 }
 
 // Format an effect set for display: [] for empty, [_] for wildcard, [A, B]

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -599,16 +599,56 @@ fn registry_callback_names(
 //
 // Asked cheapest and most selective first, because every value channel asks it
 // of every name it resolves: almost nothing takes a callback at all, so the one
-// lookup that settles that comes before the three that weigh how the name is
-// declared — `raw_declaration`, the dearest of them, last.
+// lookup that settles that comes before the two that weigh how the name is
+// declared — `raw_declaration`, the dearer of them, last.
 fn synthesizes_registry_share(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
 ) -> Bool {
   registry_callback_names(knowledge_base, name) != []
-  && line_param_bounds(knowledge_base, name) == []
   && !dict.has_key(knowledge_base.fallback_summaries, name)
-  && option.is_some(raw_declaration(knowledge_base, name))
+  && case raw_declaration(knowledge_base, name) {
+    None -> False
+    Some(#(_term, origin)) ->
+      declared_param_bounds(knowledge_base, name, origin) == []
+  }
+}
+
+// The bounds the *declaration* states for `name`.
+//
+// None where it is a module-level `assume`, which cannot state any: the grammar
+// refuses a bound list on a module path, so whatever `param_bounds` holds under
+// such a name came from somewhere else — this run's inference over the very
+// body the declaration speaks over, or a committed line for it. Those describe
+// what the body does with its callback, which is exactly what the declaration
+// overrode, and reading them as the declaration's own answer is what let a
+// module-level `assume` silently vouch for every callback its functions take.
+fn declared_param_bounds(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+  origin: LookupOrigin,
+) -> List(ParamBound) {
+  case origin {
+    ModuleExternalOrigin(_) -> []
+    _ -> line_param_bounds(knowledge_base, name)
+  }
+}
+
+// Whether `name`'s recorded bounds are inference's rather than a declaration's
+// — a module-level `assume` standing over a body this run also walked. They
+// bind nothing in the term the declaration put in that body's place, and
+// holding them out is what lets the call site's own registry injection run:
+// that reading weighs each argument's shape, declining the closures whose
+// bodies are walked separately, where a synthesized bound binds them all.
+fn holds_only_inferred_bounds(
+  knowledge_base: KnowledgeBase,
+  name: QualifiedName,
+) -> Bool {
+  line_param_bounds(knowledge_base, name) != []
+  && case raw_declaration(knowledge_base, name) {
+    Some(#(_term, ModuleExternalOrigin(_))) -> True
+    _ -> False
+  }
 }
 
 // Which side of the foreign split owns `name`'s synthesized callback share.
@@ -616,11 +656,12 @@ fn synthesizes_registry_share(
 // leaving a gap between them.
 //
 // The foreign half is folded into the charge itself, where every channel —
-// direct call included — reads it. The other half is a value channel's alone:
-// ordinary Gleam a catalog entry or module-level `assume` declares is reached
-// by direct calls too (a sibling's, through `declares_for_callers`), and those
-// are charged precisely from the argument in hand, so widening them would
-// charge a share nothing binds.
+// direct call included — reads it. The other half is a value channel's alone,
+// because a *direct* call into ordinary Gleam has a better reading available:
+// the call site's own registry injection, which weighs each argument's shape
+// and declines the closures whose bodies are walked separately. That reading
+// only runs where the callee states no bounds, which is what
+// `holds_only_inferred_bounds` restores for a module-declared name.
 fn synthesizes_foreign_share(
   knowledge_base: KnowledgeBase,
   name: QualifiedName,
@@ -1545,7 +1586,16 @@ pub fn lookup_param_bounds(
     Error(Nil) ->
       case synthesizes_foreign_share(knowledge_base, name) {
         True -> synthesized_callback_bounds(knowledge_base, name)
-        False -> declared
+        // Inference's own bounds over a body a module-level `assume` speaks
+        // over are held out: they bind nothing in the term that declaration
+        // put in the body's place, and stating them tells the call site a
+        // bound list already answers, which stands its registry injection down
+        // and leaves the callback charged to nobody.
+        False ->
+          case holds_only_inferred_bounds(knowledge_base, name) {
+            True -> []
+            False -> declared
+          }
       }
   }
 }

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -154,7 +154,7 @@ pub fn fn_typed_param_names_ordered(
     None -> []
     Some(params) ->
       params
-      |> list.sort(fn(a, b) { int.compare(a.position, b.position) })
+      |> by_position()
       |> list.filter_map(fn(p) {
         // The bound-name match wins for a syntactically fn-typed parameter
         // too: a labeled fallback callback (`with action:`) records its bound
@@ -180,6 +180,49 @@ pub fn fn_typed_param_names_ordered(
         }
       })
   }
+}
+
+// Every registry entry's fn-typed parameter names, in position order, keyed by
+// the function they belong to. Entries with no fn-typed parameter are dropped,
+// so a key here is a function that takes a callback.
+//
+// The in-body name leads and the label is the fallback — the reverse of
+// `fn_typed_param_names`' preference, and deliberately so. These names are
+// synthesized into the callback share a boundless declaration charges, and the
+// bounds recorded beside it; a recorded fallback summary states its own bounds
+// over in-body names, and `ordered_callback_param_names` binds over them too.
+// Naming the label instead would leave one channel's variable free of the
+// other's binder for every labeled callback.
+//
+// Strictly `is_fn_typed`, where `fn_typed_param_names_ordered` also counts an
+// unannotated parameter its bound list names. That function is *binding* an
+// operator whose term already holds the variable; this one is deciding whether
+// to put a variable there at all, and an unannotated parameter is no evidence
+// of a callback — synthesizing one per girard-typed parameter would charge a
+// share for every argument a declared function takes.
+pub fn callback_param_names(
+  registry: SignatureRegistry,
+) -> Dict(QualifiedName, List(String)) {
+  use acc, name, params <- dict.fold(registry.signatures, dict.new())
+  let callbacks =
+    params
+    |> list.filter(fn(p) { p.is_fn_typed })
+    |> by_position()
+    |> list.filter_map(fn(p) {
+      option.to_result(option.or(p.name, p.label), Nil)
+    })
+  case callbacks {
+    [] -> acc
+    _ -> dict.insert(acc, name, callbacks)
+  }
+}
+
+// A parameter list in declaration order. `from_glance_module` already builds
+// one that way, so this is a defence rather than a repair — but every reader
+// that depends on the order states that dependence through this one function,
+// so two of them cannot come to different orders.
+fn by_position(params: List(ParameterInfo)) -> List(ParameterInfo) {
+  list.sort(params, fn(a, b) { int.compare(a.position, b.position) })
 }
 
 // The argument positions of the callbacks of one *operator* parameter — the

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -4578,12 +4578,28 @@ pub fn plain(x: String) -> String {
 
 fn infer_annotation(source: String, name: String) -> EffectAnnotation {
   let assert Ok(module) = glance.module(source)
-  let registry = signatures.from_glance_module("m", module)
+  infer_annotation_with(
+    module,
+    name,
+    knowledge_base(),
+    signatures.from_glance_module("m", module),
+  )
+}
+
+// The same over an already-parsed module, against a caller-chosen base and
+// registry — for the callers whose scenario is which knowledge the analysis has,
+// not what the source says.
+fn infer_annotation_with(
+  module: glance.Module,
+  name: String,
+  knowledge_base: effects.KnowledgeBase,
+  registry: signatures.SignatureRegistry,
+) -> EffectAnnotation {
   let inferred =
     checker.infer(
       module,
       "",
-      knowledge_base(),
+      knowledge_base,
       [],
       registry,
       dict.new(),
@@ -6696,4 +6712,107 @@ pub fn an_open_clause_degrades_to_unknown_test() {
   // `ghost` is no parameter of `dep.wrap`, so there is nothing to bind it to.
   returned_call_effects("effects dep.wrap(f: [f]) : [] where returns : [ghost]")
   |> should.equal(Specific(set.from_list(["Unknown"])))
+}
+
+// A catalog-declared Gleam higher-order function on a value channel
+//
+// `gleam/list.map` is declared by a module-level catalog `assume`, and nothing
+// anywhere states what its callback costs. A direct call reads the argument's
+// shape at the call site and charges it there; a value channel has no such
+// reading, so the declaration's silence about the callback is charged as the
+// callback's own effect instead of vanishing.
+
+fn list_value_channel_kb() -> effects.KnowledgeBase {
+  knowledge_base()
+  |> effects.with_callback_params(
+    signatures.callback_param_names(list_registry()),
+  )
+}
+
+// The inferred effects of one named function of `source`, analysed with
+// `gleam/list`'s signature and its callback parameters both in reach.
+fn list_value_channel_effects(source: String, function: String) -> EffectSet {
+  let assert Ok(module) = glance.module(source)
+  infer_annotation_with(
+    module,
+    function,
+    list_value_channel_kb(),
+    list_registry(),
+  ).effects
+  |> effect_term.to_effect_set
+}
+
+pub fn a_declared_map_passed_as_a_value_charges_its_callback_test() {
+  // `list.map` handed to a helper that calls it. Its callback is *labelled*
+  // (`with fun:`), so the binder has to be the in-body name the synthesized
+  // variable carries: named after the label, the variable stays free, the
+  // application goes stuck, and the precise `[Stdout]` collapses to
+  // `[Unknown]`.
+  let source =
+    "
+import gleam/io
+import gleam/list
+
+fn invoke(
+  op: fn(List(String), fn(String) -> Nil) -> List(Nil),
+  xs: List(String),
+) -> List(Nil) {
+  op(xs, io.println)
+}
+
+pub fn run(xs: List(String)) -> List(Nil) {
+  invoke(list.map, xs)
+}
+"
+  list_value_channel_effects(source, "run")
+  |> should.equal(Specific(set.from_list(["Stdout"])))
+}
+
+pub fn a_declared_map_wired_into_a_field_charges_its_callback_test() {
+  // The same name wired into a record field and called through it.
+  let source =
+    "
+import gleam/io
+import gleam/list
+
+pub type Mapper {
+  Mapper(go: fn(List(String), fn(String) -> Nil) -> List(Nil))
+}
+
+fn make() -> Mapper {
+  Mapper(go: list.map)
+}
+
+pub fn via_field(xs: List(String)) -> List(Nil) {
+  let m = make()
+  m.go(xs, io.println)
+}
+"
+  list_value_channel_effects(source, "via_field")
+  |> should.equal(Specific(set.from_list(["Stdout"])))
+}
+
+pub fn a_declared_maps_direct_call_keeps_its_auto_bounds_test() {
+  // The direct-call channel is untouched: a tracked reference still charges
+  // its effect, and an inline closure — whose body the extractor walks
+  // separately — still charges nothing, rather than the `[Unknown]` a
+  // synthesized bound with nothing to bind would give.
+  let tracked =
+    "
+import gleam/io
+import gleam/list
+pub fn run(xs: List(String)) -> List(Nil) {
+  list.map(xs, io.println)
+}
+"
+  list_value_channel_effects(tracked, "run")
+  |> should.equal(Specific(set.from_list(["Stdout"])))
+  let closure =
+    "
+import gleam/list
+pub fn run(xs: List(Int)) -> List(Int) {
+  list.map(xs, fn(x) { x + 1 })
+}
+"
+  list_value_channel_effects(closure, "run") |> should.equal(types.empty())
 }

--- a/test/effect_cli_test.gleam
+++ b/test/effect_cli_test.gleam
@@ -887,3 +887,84 @@ pub fn effect_over_an_unparseable_spec_errors_test() {
   )
   cleanup(root)
 }
+
+// A summary-less higher-order external's answer
+//
+// A boundless declaration over one says nothing about its callbacks, and the
+// charge keeps a variable per callback parameter the parsed signature names.
+// The query states that variable and the bound that scopes it, on both paths.
+
+// A package whose one module holds a bodyless higher-order `@external`, under
+// the spec line given.
+fn higher_order_external_project(name: String, spec: String) -> String {
+  write_fixture("build/" <> name, [
+    #("gleam.toml", "name = \"" <> name <> "\"\n"),
+    #(name <> ".graded", spec),
+    #("ext.gleam", support.foreign_fn("run", "(action: fn() -> Nil) -> Nil")),
+  ])
+}
+
+pub fn a_bodyless_externals_answer_states_its_callback_bound_test() {
+  // The per-function `assume` states no bounds, so the bound that scopes the
+  // callback variable comes from the pairing alone — and both paths state it.
+  let project =
+    higher_order_external_project(
+      "graded_effect_bodyless_callback",
+      "assume ext.run : [Time]\n",
+    )
+  let expected =
+    Ok(
+      "effects ext.run(action: [action]) : [Time, action]
+// resolved from your spec's `assume` line",
+    )
+  graded.run_effect(project, "ext.run") |> should.equal(expected)
+  graded.run_effect_from_project(project, "ext.run") |> should.equal(expected)
+  cleanup(project)
+}
+
+pub fn a_module_assumed_externals_answer_states_its_callback_bound_test() {
+  // The same under a module-level `assume`, which states no bounds of its own
+  // anywhere: the answer took a running fallback's bounds there, and a bodyless
+  // external has none, so the variable stood in the term with nothing scoping it.
+  let project =
+    higher_order_external_project(
+      "graded_effect_module_assumed_callback",
+      "assume ext : [Time]\n",
+    )
+  let expected =
+    Ok(
+      "effects ext.run(action: [action]) : [Time, action]
+// resolved via module-level `assume` for ext",
+    )
+  graded.run_effect(project, "ext.run") |> should.equal(expected)
+  graded.run_effect_from_project(project, "ext.run") |> should.equal(expected)
+  cleanup(project)
+}
+
+pub fn a_dependency_externals_callback_answers_the_same_on_both_paths_test() {
+  // The dependency half of the fast path: the module the queried name lives in
+  // is parsed over there for its foreign names, and its callback parameters
+  // come off that same parse. Without them the fast path answered the declared
+  // term bare while the full context charged the callback beside it.
+  let project =
+    write_fixture("build/graded_effect_dependency_callback", [
+      #("gleam.toml", "name = \"graded_effect_dependency_callback\"\n"),
+      #(
+        "graded_effect_dependency_callback.graded",
+        "assume dep/ffi.run : [Time]\n",
+      ),
+      #(
+        "build/packages/dep/src/dep/ffi.gleam",
+        support.foreign_fn("run", "(action: fn() -> Nil) -> Nil"),
+      ),
+    ])
+  let expected =
+    Ok(
+      "effects dep/ffi.run(action: [action]) : [Time, action]
+// resolved from your spec's `assume` line",
+    )
+  graded.run_effect(project, "dep/ffi.run") |> should.equal(expected)
+  graded.run_effect_from_project(project, "dep/ffi.run")
+  |> should.equal(expected)
+  cleanup(project)
+}

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -2272,3 +2272,174 @@ pub fn a_later_self_binding_clears_an_earlier_alias_test() {
   ])
   |> should.equal([#("cb", "other")])
 }
+
+// A summary-less external's callback share
+//
+// A boundless declaration says nothing about the callbacks of the external it
+// declares, and a bodyless one leaves no fallback summary to read them off.
+// The parsed signature names them instead, and the charge and the bounds take
+// them from that one source — so a value channel charges the callback the same
+// way a direct call's registry injection does.
+
+const higher_order_ffi: QualifiedName = QualifiedName("app/ffi", "run")
+
+// A base holding one bodyless higher-order `@external`, declared for every
+// target this package builds — so a declaration alone answers for it and no
+// fallback body runs. `callbacks` is what a parsed signature says its callback
+// parameters are; `params` is what the declaring line states.
+fn bodyless_external_base(
+  params: List(ParamBound),
+  callbacks: List(String),
+) -> effects.KnowledgeBase {
+  effects.new_knowledge_base()
+  |> effects.with_package_targets(
+    types.NamedTargets(set.from_list(["erlang", "javascript"])),
+  )
+  |> effects.with_externals(
+    [
+      types.ExternalAnnotation(
+        module: higher_order_ffi.module,
+        target: types.FunctionExternal(higher_order_ffi.function),
+        params:,
+        effects: Some(Specific(set.from_list(["Time"]))),
+        returns: None,
+      ),
+    ],
+    types.UserExternal,
+  )
+  |> effects.with_foreign_functions(
+    dict.from_list([
+      #(
+        higher_order_ffi,
+        types.ForeignFunction(
+          runs_fallback_body: False,
+          compiled_targets: set.from_list(["erlang", "javascript"]),
+          declared_targets: set.from_list(["erlang", "javascript"]),
+        ),
+      ),
+    ]),
+  )
+  |> effects.with_callback_params(
+    dict.from_list([#(higher_order_ffi, callbacks)]),
+  )
+}
+
+pub fn a_boundless_declaration_charges_its_registry_callbacks_test() {
+  // Nothing but the parsed signature says `run` takes a callback, and the
+  // boundless line says nothing about it. The charge keeps a variable for it,
+  // so every channel that reads the charge charges the callback.
+  let base = bodyless_external_base([], ["action"])
+  charged(base, higher_order_ffi)
+  |> should.equal(Polymorphic(
+    set.from_list(["Time"]),
+    set.from_list(["action"]),
+  ))
+  effects.lookup_param_bounds(base, higher_order_ffi)
+  |> should.equal([ParamBound(name: "action", effects: types.TVar("action"))])
+}
+
+pub fn an_unparsed_signature_charges_no_callback_test() {
+  // No signature recorded — a dependency whose source is absent or would not
+  // parse. Nothing names a callback, so nothing is synthesized and the answer
+  // is the declaration as written.
+  let base = bodyless_external_base([], [])
+  charged(base, higher_order_ffi)
+  |> should.equal(Specific(set.from_list(["Time"])))
+  effects.lookup_param_bounds(base, higher_order_ffi) |> should.equal([])
+}
+
+pub fn a_bounded_declaration_keeps_its_own_callback_answer_test() {
+  // The line wrote its own answer for the callback: a ground budget for it,
+  // which stays as written and admits no synthesized variable beside it.
+  let base =
+    bodyless_external_base(
+      [
+        ParamBound(
+          name: "action",
+          effects: effect_term.from_effect_set(Specific(set.new())),
+        ),
+      ],
+      ["action"],
+    )
+  charged(base, higher_order_ffi)
+  |> should.equal(Specific(set.from_list(["Time"])))
+  effects.lookup_param_bounds(base, higher_order_ffi)
+  |> should.equal([
+    ParamBound(
+      name: "action",
+      effects: effect_term.from_effect_set(Specific(set.new())),
+    ),
+  ])
+}
+
+pub fn an_undeclared_external_synthesizes_no_callback_test() {
+  // Nothing declares the name, so nothing scopes a variable for its callback:
+  // the external carries the `[Unknown]` it always did, with no bounds beside
+  // it.
+  let base =
+    effects.new_knowledge_base()
+    |> effects.with_package_targets(
+      types.NamedTargets(set.from_list(["erlang", "javascript"])),
+    )
+    |> effects.with_foreign_functions(
+      dict.from_list([
+        #(
+          higher_order_ffi,
+          types.ForeignFunction(
+            runs_fallback_body: False,
+            compiled_targets: set.from_list(["erlang", "javascript"]),
+            declared_targets: set.from_list(["erlang", "javascript"]),
+          ),
+        ),
+      ]),
+    )
+    |> effects.with_callback_params(
+      dict.from_list([#(higher_order_ffi, ["action"])]),
+    )
+  charged(base, higher_order_ffi)
+  |> should.equal(Specific(set.from_list(["Unknown"])))
+  effects.lookup_param_bounds(base, higher_order_ffi) |> should.equal([])
+}
+
+pub fn a_walked_fallbacks_bounds_lead_the_registrys_test() {
+  // A recorded summary states its own bounds over the parameters the body
+  // names, girard-typed callbacks included. Those lead: the registry's list is
+  // the stand-in for a name no summary covers.
+  let base =
+    bodyless_external_base([], ["action"])
+    |> effects.with_fallback_summaries(
+      dict.from_list([
+        #(
+          higher_order_ffi,
+          #(types.TVar("cb"), [
+            ParamBound(name: "cb", effects: types.TVar("cb")),
+          ]),
+        ),
+      ]),
+    )
+  effects.lookup_param_bounds(base, higher_order_ffi)
+  |> should.equal([ParamBound(name: "cb", effects: types.TVar("cb"))])
+}
+
+pub fn a_declared_gleam_function_widens_on_the_value_channel_alone_test() {
+  // Ordinary Gleam a module-level `assume` declares: its direct calls keep the
+  // checker's registry injection, which reads the argument's shape first, so
+  // neither the lookup nor the bounds it binds with move. The value channels
+  // have no such counterpart, so they charge the callback here.
+  let name = QualifiedName("dep/list", "each")
+  let base =
+    effects.new_knowledge_base()
+    |> effects.with_externals(
+      [module_external("dep/list", [])],
+      types.ModuleExternalOrigin(types.CommittedSpec),
+    )
+    |> effects.with_callback_params(dict.from_list([#(name, ["with"])]))
+  let assert effects.Known(term, _source) = effects.lookup_declared(base, name)
+  effect_term.to_effect_set(term) |> should.equal(Specific(set.new()))
+  effects.lookup_param_bounds(base, name) |> should.equal([])
+  effects.declared_effects(base, name)
+  |> effect_term.to_effect_set
+  |> should.equal(Polymorphic(set.new(), set.from_list(["with"])))
+  effects.value_channel_bounds(base, name)
+  |> should.equal([ParamBound(name: "with", effects: types.TVar("with"))])
+}

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -1630,11 +1630,15 @@ pub fn a_fallback_lift_keeps_its_callback_arity_test() {
   // `run` has two girard-typed callbacks and invokes only the second; the
   // first contributes no variable to the settled term, so recording bounds
   // for surviving variables alone dropped it — and the lift rebuilt from the
-  // recorded names abstracted over `second` only, binding the *first* passed
-  // callback to it and leaving the second application stuck. Both budgets
-  // below then failed: the disk callback's effects landed on the wrong
-  // parameter and `[Unknown]` covered the rest. The bounds keep the full
-  // callback shape, so each argument reaches its own binder.
+  // recorded names abstracted over `second` only, leaving the second
+  // application stuck and `[Unknown]` covering the rest. The bounds keep the
+  // full callback shape, so both applications reduce and neither budget sees
+  // an `[Unknown]` a stuck spine would put there.
+  //
+  // Both shapes cost `[Disk]` wherever the disk callback is passed: `second`
+  // because the body calls it, and `first` because `keep` is a name
+  // `assume ext : []` declares, which states its own effects and nothing about
+  // the callback it is handed.
   let root = "build/external_fallback_callback_arity"
   support.write_fixture(root, [
     #("gleam.toml", support.dual_target_toml("proj")),
@@ -1643,7 +1647,7 @@ pub fn a_fallback_lift_keeps_its_callback_arity_test() {
       "assume ext : []
 assume app.disk : [Disk]
 check app.go : [Disk]
-check app.go_swapped : []
+check app.go_swapped : [Disk]
 ",
     ),
     #(
@@ -2529,6 +2533,94 @@ pub fn via_operator() -> Nil {
   violation.function |> should.equal("via_operator")
   violation.explanation.actual
   |> should.equal(types.Specific(set.from_list(["Disk", "Time"])))
+  support.cleanup(root)
+}
+
+pub fn a_module_assumed_helper_charges_its_callback_on_every_shape_test() {
+  // `assume m : []` over ordinary higher-order Gleam states what `each`'s own
+  // body costs and says nothing about the callback handed to it — the same
+  // reading a boundless per-function line gets. Every shape pays the callback:
+  // called or handed around, from inside the declared module or outside it.
+  //
+  // The same-module halves are the ones a declaration answers for through the
+  // sibling path, which kept the declaration's set alone and charged the
+  // callback to nobody; the cross-module halves were blocked by a second
+  // reading, the bounds this run's own inference recorded over the very body
+  // the line speaks over.
+  let root = "build/module_assumed_helper_callback"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "assume m : []
+assume m.disk : [Disk]
+check m.same_module_call : []
+check m.same_module_value : []
+check other.cross_module_call : []
+check other.cross_module_value : []
+",
+    ),
+    #(
+      "m.gleam",
+      "pub fn each(cb: fn() -> Nil) -> Nil {
+  cb()
+}
+
+@external(erlang, \"a\", \"d\")
+@external(javascript, \"a\", \"d\")
+pub fn disk() -> Nil
+
+fn invoke(op: fn(fn() -> Nil) -> Nil, x: fn() -> Nil) -> Nil {
+  op(x)
+}
+
+pub fn same_module_call() -> Nil {
+  each(disk)
+}
+
+pub fn same_module_value() -> Nil {
+  invoke(each, disk)
+}
+",
+    ),
+    #(
+      "other.gleam",
+      "import m
+
+fn invoke(op: fn(fn() -> Nil) -> Nil, x: fn() -> Nil) -> Nil {
+  op(x)
+}
+
+pub fn cross_module_call() -> Nil {
+  m.each(m.disk)
+}
+
+pub fn cross_module_value() -> Nil {
+  invoke(m.each, m.disk)
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let charged =
+    results
+    |> list.flat_map(fn(r) { r.violations })
+    |> list.filter_map(fn(violation) {
+      case violation.explanation.actual {
+        types.Specific(effects) ->
+          case set.contains(effects, "Disk") {
+            True -> Ok(violation.function)
+            False -> Error(Nil)
+          }
+        _ -> Error(Nil)
+      }
+    })
+    |> list.sort(string.compare)
+  charged
+  |> should.equal([
+    "cross_module_call", "cross_module_value", "same_module_call",
+    "same_module_value",
+  ])
   support.cleanup(root)
 }
 
@@ -10146,7 +10238,7 @@ pub fn a_governed_native_body_still_warns_about_its_references_test() {
       "proj.graded",
       "assume ffi.disk : [Disk]
 assume governed : [Net]
-check governed.wrapped : [Net]
+check governed.wrapped : [Disk, Net]
 check governed.strict : []
 ",
     ),
@@ -10180,9 +10272,11 @@ pub fn strict() -> Nil {
     list.find(results, fn(r) { r.file == root <> "/governed.gleam" })
 
   // A budget covers both halves: the declaration, and the visible body beside
-  // it. Both bodies call `helper`, a sibling the same line governs, so both
-  // halves are the `[Net]` a caller of `helper` from anywhere pays — `strict`
-  // breaks its `[]` on each and `wrapped` meets its `[Net]` on both.
+  // it. Both bodies call `helper`, a sibling the same line governs — and that
+  // line states `helper`'s own effects, not what it does with the callback it
+  // is handed, so a caller pays the `[Net]` plus the `[Disk]` reference it
+  // passes. `strict` breaks its `[]` on the declaration half and on the call;
+  // `wrapped` meets a budget stating both.
   r.violations
   |> list.map(fn(violation) {
     let assert types.Specific(effects) = violation.explanation.actual
@@ -10191,7 +10285,7 @@ pub fn strict() -> Nil {
     <> string.join(set.to_list(effects) |> list.sort(string.compare), ",")
   })
   |> list.sort(string.compare)
-  |> should.equal(["strict: Net", "strict: Net"])
+  |> should.equal(["strict: Disk,Net", "strict: Net"])
 
   // Both bodies still pass the reference, so both warn.
   r.warnings

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -2624,6 +2624,70 @@ pub fn cross_module_value() -> Nil {
   support.cleanup(root)
 }
 
+pub fn a_module_assumed_sibling_lifts_from_its_declaration_test() {
+  // The sibling *value* channel, isolated from every other reading. `ignore`
+  // never calls its callback, so walking its body lifts it to `λcb. []` and
+  // the disk callback rides through free; the declaration is what its callers
+  // pay, and it says nothing about the callback. `util.invoke` sits outside
+  // the assumed module so nothing but the lift can charge anything — the twin
+  // whose body does call the callback would pass either way, and is here to
+  // show the lift still reduces rather than going stuck.
+  let root = "build/module_assumed_sibling_lift"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "assume m : []
+assume m.disk : [Disk]
+check m.hands_over_an_uncalled_callback : []
+check m.hands_over_a_called_callback : []
+",
+    ),
+    #(
+      "util.gleam",
+      "pub fn invoke(op: fn(fn() -> Nil) -> Nil, x: fn() -> Nil) -> Nil {
+  op(x)
+}
+",
+    ),
+    #(
+      "m.gleam",
+      "import util
+
+@external(erlang, \"a\", \"d\")
+@external(javascript, \"a\", \"d\")
+pub fn disk() -> Nil
+
+pub fn ignore(cb: fn() -> Nil) -> Nil {
+  Nil
+}
+
+pub fn calls(cb: fn() -> Nil) -> Nil {
+  cb()
+}
+
+pub fn hands_over_an_uncalled_callback() -> Nil {
+  util.invoke(ignore, disk)
+}
+
+pub fn hands_over_a_called_callback() -> Nil {
+  util.invoke(calls, disk)
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) = list.find(results, fn(r) { r.file == root <> "/m.gleam" })
+  ["hands_over_an_uncalled_callback", "hands_over_a_called_callback"]
+  |> list.each(fn(function) {
+    let assert Ok(violation) =
+      list.find(r.violations, fn(v) { v.function == function })
+    violation.explanation.actual
+    |> should.equal(types.Specific(set.from_list(["Disk"])))
+  })
+  support.cleanup(root)
+}
+
 pub fn a_bodyless_externals_reference_warns_as_a_summarys_does_test() {
   // A reference to a var-carrying name warns quoting the set it carries, which
   // is what a summary-shaped one already did. The widened names inherit it:

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -2327,6 +2327,269 @@ pub fn via_field() -> Nil {
   support.cleanup(root)
 }
 
+pub fn a_bodyless_externals_callback_is_charged_on_every_channel_test() {
+  // `ext.run` is bodyless — foreign on every target, so no fallback summary
+  // records what its callbacks are — and its `assume` line is boundless. Only
+  // the parsed signature says it takes one. A direct call recovered the charge
+  // from that signature at the call site; every value channel read the bare
+  // `[Time]`, so an effectful callback passed a pure check on the call's shape
+  // alone. All three charge `[Disk, Time]`.
+  let root = "build/bodyless_external_value_channels"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "assume ext.run : [Time]
+assume app.disk : [Disk]
+check app.direct : []
+check app.via_operator : []
+check app.via_field : []
+",
+    ),
+    #("ext.gleam", support.foreign_fn("run", "(action: fn() -> Nil) -> Nil")),
+    #(
+      "app.gleam",
+      "import ext
+
+pub type Runner {
+  Runner(go: fn(fn() -> Nil) -> Nil)
+}
+
+@external(erlang, \"a\", \"d\")
+@external(javascript, \"a\", \"d\")
+pub fn disk() -> Nil
+
+fn invoke(op: fn(fn() -> Nil) -> Nil, x: fn() -> Nil) -> Nil {
+  op(x)
+}
+
+pub fn direct() -> Nil {
+  ext.run(disk)
+}
+
+pub fn via_operator() -> Nil {
+  invoke(ext.run, disk)
+}
+
+fn make() -> Runner {
+  Runner(go: ext.run)
+}
+
+pub fn via_field() -> Nil {
+  let r = make()
+  r.go(disk)
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  ["direct", "via_operator", "via_field"]
+  |> list.each(fn(function) {
+    let assert Ok(violation) =
+      list.find(r.violations, fn(v) { v.function == function })
+    violation.explanation.actual
+    |> should.equal(types.Specific(set.from_list(["Disk", "Time"])))
+  })
+  support.cleanup(root)
+}
+
+pub fn an_unbuilt_bodyless_externals_callback_is_charged_too_test() {
+  // The same name under defaulted targets, declared for javascript alone and
+  // with no Gleam body to run in its place: the declaration stands beside a
+  // fallback that is not there, the reading graded cannot narrow further. That
+  // arm returned the declared term bare, so the callback share stopped at the
+  // arm rather than at the shape of the line.
+  let root = "build/unbuilt_bodyless_external_callback"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "assume ext.run : [Time]
+assume app.disk : [Disk]
+check app.via_operator : []
+",
+    ),
+    #(
+      "ext.gleam",
+      "@external(javascript, \"m\", \"run\")
+pub fn run(action: fn() -> Nil) -> Nil
+",
+    ),
+    #(
+      "app.gleam",
+      "import ext
+
+@external(erlang, \"a\", \"d\")
+@external(javascript, \"a\", \"d\")
+pub fn disk() -> Nil
+
+fn invoke(op: fn(fn() -> Nil) -> Nil, x: fn() -> Nil) -> Nil {
+  op(x)
+}
+
+pub fn via_operator() -> Nil {
+  invoke(ext.run, disk)
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.function |> should.equal("via_operator")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk", "Time"])))
+  support.cleanup(root)
+}
+
+pub fn a_sibling_bodyless_external_charges_its_callback_test() {
+  // The same external passed to a helper in its *own* module, which resolves
+  // through the definition rather than through the knowledge base. The lift
+  // reads the same charge, so the sibling channel charges what the cross-module
+  // one does.
+  let root = "build/bodyless_external_sibling_channel"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "assume ext.run : [Time]
+assume ext.disk : [Disk]
+check ext.via_sibling : []
+",
+    ),
+    #(
+      "ext.gleam",
+      support.foreign_fn("run", "(action: fn() -> Nil) -> Nil")
+        <> support.foreign_fn("disk", "() -> Nil")
+        <> "
+fn invoke(op: fn(fn() -> Nil) -> Nil, x: fn() -> Nil) -> Nil {
+  op(x)
+}
+
+pub fn via_sibling() -> Nil {
+  invoke(run, disk)
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
+  let assert Ok(violation) =
+    list.find(r.violations, fn(v) { v.function == "via_sibling" })
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk", "Time"])))
+  support.cleanup(root)
+}
+
+pub fn a_dependency_externals_callback_is_charged_on_a_value_channel_test() {
+  // A dependency's bodyless higher-order `@external`, declared by the
+  // dependency's own shipped spec. The consumer never calls it directly — it
+  // hands it to a helper — and the callback it hands over is charged.
+  let root = "build/dependency_bodyless_external_value_channel"
+  support.write_project_with_dependency(
+    directory: root,
+    package: "proj",
+    spec: "assume app.disk : [Disk]\ncheck app.via_operator : []\n",
+    sources: [
+      #(
+        "app.gleam",
+        "import dep/ffi
+
+@external(erlang, \"a\", \"d\")
+@external(javascript, \"a\", \"d\")
+pub fn disk() -> Nil
+
+fn invoke(op: fn(fn() -> Nil) -> Nil, x: fn() -> Nil) -> Nil {
+  op(x)
+}
+
+pub fn via_operator() -> Nil {
+  invoke(ffi.run, disk)
+}
+",
+      ),
+    ],
+    dependency: "dep",
+    dependency_spec: "assume dep/ffi.run : [Time]\n",
+    dependency_sources: [
+      #(
+        "dep/ffi.gleam",
+        support.foreign_fn("run", "(action: fn() -> Nil) -> Nil"),
+      ),
+    ],
+  )
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  let assert [violation] = r.violations
+  violation.function |> should.equal("via_operator")
+  violation.explanation.actual
+  |> should.equal(types.Specific(set.from_list(["Disk", "Time"])))
+  support.cleanup(root)
+}
+
+pub fn a_bodyless_externals_reference_warns_as_a_summarys_does_test() {
+  // A reference to a var-carrying name warns quoting the set it carries, which
+  // is what a summary-shaped one already did. The widened names inherit it:
+  // the `[Time]`-declared external quotes both halves, and the pure one quotes
+  // its variable alone rather than falling silent.
+  let root = "build/bodyless_external_reference_warning"
+  support.write_fixture(root, [
+    #("gleam.toml", "name = \"proj\"\n"),
+    #(
+      "proj.graded",
+      "assume ext.loud : [Time]
+assume ext.quiet : []
+check app.loud_go : [_]
+check app.quiet_go : [_]
+",
+    ),
+    #(
+      "ext.gleam",
+      support.foreign_fn("loud", "(action: fn() -> Nil) -> Nil")
+        <> support.foreign_fn("quiet", "(action: fn() -> Nil) -> Nil"),
+    ),
+    #(
+      "app.gleam",
+      "import ext
+
+pub fn apply_callback(f: fn(fn() -> Nil) -> Nil) -> Nil {
+  f(fn() { Nil })
+}
+
+pub fn loud_go() -> Nil {
+  apply_callback(ext.loud)
+}
+
+pub fn quiet_go() -> Nil {
+  apply_callback(ext.quiet)
+}
+",
+    ),
+  ])
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/app.gleam" })
+  r.warnings
+  |> list.map(fn(warning) {
+    let assert types.UntrackedEffectWarning(function:, effects:, ..) = warning
+    #(function, effects)
+  })
+  |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
+  |> should.equal([
+    #(
+      "loud_go",
+      types.Polymorphic(set.from_list(["Time"]), set.from_list(["action"])),
+    ),
+    #("quiet_go", types.Polymorphic(set.new(), set.from_list(["action"]))),
+  ])
+  support.cleanup(root)
+}
+
 pub fn a_suppressed_share_binds_through_the_fallback_bounds_test() {
   // The `assume` line's bound decouples its payload variable from the
   // parameter name (`cb: [e]`), while the suppressed body's term is stated


### PR DESCRIPTION
## What

A boundless `assume` over a higher-order `@external` charged its callback
argument only at direct call sites. Handed around as a value — passed to a
helper, wired into a record field, referenced by a sibling — the same external
charged nothing for the same callback, so an effectful call passed a pure check
on the call's shape alone:

```gleam
assume ext.run : [Time]      // says nothing about `action`
check app.via_operator : []  // passed, charging [Time] and never [Disk]

pub fn via_operator() -> Nil {
  invoke(ext.run, disk)      // `disk` is [Disk]
}
```

All three shapes — direct call, operator argument, wired field — now charge
`[Disk, Time]`.

## How

The callback parameters of every parsed signature reach the knowledge base as
plain names (`callback_params`), so `effects.gleam` stays free of `glance`.

- **Foreign names** widen inside the one derivation every channel already reads
  (`declared_charge` → `conservative_callback_charge`), paired with matching
  bound synthesis in `lookup_param_bounds` so the term and the bounds that bind
  it cannot drift.
- **A Gleam function a catalog entry or module-level `assume` declares** takes
  the same share on the **value channels only**. Its direct calls keep the
  checker's registry injection, which reads the argument's shape before it
  charges anything — and a same-module sibling's direct call comes through that
  same reading, so widening it would charge a share nothing binds.

The `graded effect` fast path folds the callback parameters of the single
module it parses, its dependency half included, so both paths still answer byte
for byte.

## Compatibility

Actual sets only widen. A check that passed because the external was handed
around as a value may now fail, and a call shape graded cannot trace charges
`[Unknown]`. A line with its own bound list answers for its callbacks as
written and is unaffected.

The external's own `check` line is **not** affected: it reads the declaration
raw rather than the charge, which I verified on a fixture rather than assuming.

## Tests

1315 passing, up from 1298. The 17 new tests were checked against ablation
rather than merely passing: disabling the foreign-name gates fails 9 of them,
disabling the value-channel edits fails 3.

Covered: the direct/operator/field triple over a bodyless external; the
unbuilt-target reading; the sibling channel; a dependency's external under a
shipped spec; a catalog-declared Gleam function on a value channel with a
*labelled* callback (which pins the binder/variable alignment) alongside a
direct-call control proving that path is unchanged; the `graded effect` surface
on both paths; and reference-warning parity.

## Verification

`gleam format --check src/ test/`, `gleam build --warnings-as-errors`,
`gleam test`, `gleam run -m glinter` — all green. Smoke-checked `effect`, `why`
and `infer --dry-run` on a fixture tree: three surfaces quote one term, and the
dry-run diff only widens.
