### PR TITLE
Report a gleam.toml that cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `gleam.toml` that is there but cannot be read — a directory, a permission
+  error, a failing device — is now reported. Previously any read failure fell
+  back to defaults, so the package name came from the directory and `check`
+  and `infer` silently used a spec file the manifest never named. A missing
+  `gleam.toml` still falls back to defaults.
 - A call from inside a walked fallback body to an external declared for the
   walk's targets now charges its callback arguments beside the declaration,
   instead of the declaration alone.

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -91,8 +91,9 @@ pub type GradedError {
   GleamParseError(path: String, cause: glance.Error)
   /// A `.graded` annotation file could not be parsed.
   GradedParseError(path: String, cause: annotation.ParseError)
-  /// `gleam.toml` was present but malformed, or missing its `name`. A missing
-  /// `gleam.toml` is tolerated and does not produce this error.
+  /// `gleam.toml` was present but malformed, unreadable, or missing its
+  /// `name`. A missing `gleam.toml` is tolerated and does not produce this
+  /// error.
   InvalidConfig(path: String, cause: config.ConfigError)
   /// One or more `.graded` files are not formatted (returned by `run_format_check`).
   FormatCheckFailed(paths: List(String))
@@ -3691,8 +3692,11 @@ fn read_config(directory: String) -> Result(config.GradedConfig, GradedError) {
   let toml_path = filepath.join(project_root, "gleam.toml")
   use raw <- result.try(case config.read(toml_path) {
     Ok(cfg) -> Ok(cfg)
-    // Missing gleam.toml: fall back to defaults. Malformed gleam.toml: error.
-    Error(config.TomlReadError(..)) ->
+    // Missing gleam.toml: fall back to defaults. A gleam.toml that is there
+    // and unreadable — a directory, no permission, a failing device — is an
+    // error, so a spec file named from the directory is never written in place
+    // of the one the manifest names.
+    Error(config.TomlReadError(_, simplifile.Enoent)) ->
       Ok(config.defaults_for(default_package_name(project_root)))
     Error(cause) -> Error(InvalidConfig(path: toml_path, cause:))
   })

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -11,6 +11,7 @@ import graded
 import graded/internal/annotation
 import graded/internal/checker
 import graded/internal/cli
+import graded/internal/config
 import graded/internal/effect_term
 import graded/internal/effects
 import graded/internal/signatures
@@ -7138,6 +7139,36 @@ pub fn check_over_an_unreadable_spec_errors_test() {
   graded.run(root)
   |> should.equal(
     Error(graded.FileReadError(root <> "/proj.graded", simplifile.Eisdir)),
+  )
+  let _ = simplifile.delete(root)
+  Nil
+}
+
+// Unreadable manifests
+//
+// A `gleam.toml` that is there but cannot be read is not the same as a package
+// with no `gleam.toml`: defaulting the package name to the directory's would
+// read and write a spec file the manifest never named.
+
+pub fn check_over_an_unreadable_manifest_errors_test() {
+  // Rooted outside the repository so the walk-up stops at this directory
+  // rather than adopting graded's own manifest.
+  let root = "/tmp/graded_unreadable_manifest"
+  write_project(
+    root,
+    [#("proj.gleam", "pub fn main() -> Nil {\n  Nil\n}\n")],
+    "",
+  )
+  let assert Ok(Nil) = simplifile.delete(root <> "/gleam.toml")
+  let assert Ok(Nil) = simplifile.create_directory(root <> "/gleam.toml")
+
+  let toml = root <> "/gleam.toml"
+  graded.run(root)
+  |> should.equal(
+    Error(graded.InvalidConfig(
+      path: toml,
+      cause: config.TomlReadError(toml, simplifile.Eisdir),
+    )),
   )
   let _ = simplifile.delete(root)
   Nil


### PR DESCRIPTION
`read_config` caught every `simplifile.FileError` from the manifest read and fell back to defaults. A `gleam.toml` that is present but unreadable — a directory, `Eacces`, `Eio` — therefore yielded a package name taken from the directory's base name and a spec file `<that>.graded`, so `check` and `infer` read and wrote the wrong spec file with no diagnostic.

Only `Enoent` falls back now; every other cause reaches the existing `InvalidConfig(path:, cause:)` arm with the OS error intact.

`config.gleam` is unchanged — the wrapping was fine, the policy sits in the one caller.

**Deliberately out of scope.** Dependency-side manifest reads (`load_dep_spec`, `enrich_with_path_deps`) stay lenient: a consumer cannot fix a dependency's tree, and falling through the resolution tiers is the designed answer there.

Test: a project whose `gleam.toml` is a directory (a deterministic non-`Enoent` failure that survives running as root) asserts `InvalidConfig` with `Eisdir`; the existing missing-manifest tests keep pinning the fallback.

Gates: `gleam format --check`, `gleam build --warnings-as-errors`, `gleam test` (1318 passed), `glinter`.