### PR TITLE
Charge a girard-typed callback to same-module callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A helper whose callback parameter carries no `fn(...)` annotation now charges
+  its callers in the same module the callback's own effects, as callers in
+  another module already paid. The same answer now reaches a reference to that
+  helper handed to a higher-order function. Both read `[Unknown]` before.
 - A call from inside a walked fallback body to an external declared for the
   walk's targets now charges its callback arguments beside the declaration,
   instead of the declaration alone.

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -2343,6 +2343,11 @@ pub type LocalCache {
     // `type Resolver = fn(...)`) to its underlying function type and callback
     // positions.
     fn_alias_types: dict.Dict(String, glance.Type),
+    // girard's fn-typed parameter names, function name → parameter names. A
+    // parameter that infers to a function without carrying a `fn(...)`
+    // annotation is recognised as effect-polymorphic wherever a walk reaches
+    // it from inside the module, not only at the module's top level.
+    girard_fn_typed: dict.Dict(String, Set(String)),
   )
 }
 
@@ -2390,7 +2395,13 @@ pub fn build_scc_ids(
     |> set.from_list()
   topo.scc_order(local_call_graph(definitions, context))
   |> list.index_fold(
-    LocalCache(dict.new(), dict.new(), set.new(), fn_alias_types),
+    LocalCache(
+      dict.new(),
+      dict.new(),
+      set.new(),
+      fn_alias_types,
+      girard_fn_typed,
+    ),
     fn(cache, component, id) {
       let scc_id =
         list.fold(component, cache.scc_id, fn(ids, name) {
@@ -2407,6 +2418,7 @@ pub fn build_scc_ids(
         members: dict.insert(cache.members, id, component),
         collapsible:,
         fn_alias_types: cache.fn_alias_types,
+        girard_fn_typed: cache.girard_fn_typed,
       )
     },
   )
@@ -3994,7 +4006,8 @@ fn substitute_local_call_effects(
           || suppressed_share_vars(one.resolution.fallback)
         })
       use <- bool.guard(when: !any_polymorphic, return: #(recursive, memo))
-      let bounds = local_polymorphic_bounds(local_definition.definition)
+      let bounds =
+        local_polymorphic_bounds(local_definition, cache.girard_fn_typed)
       let args = call_args_for(call_args, local_call.span)
       let callee_name =
         QualifiedName(module: local_sentinel, function: local_call.function)
@@ -4076,8 +4089,19 @@ fn substitute_local_call_effects(
 // Derive the polymorphic param bounds a local function would carry
 // after auto-inference: one bound per fn-typed parameter, with an
 // effect variable matching the parameter name.
-fn local_polymorphic_bounds(function: Function) -> List(ParamBound) {
-  synthetic_fn_typed_bounds(signatures.fn_typed_params_from_function(function))
+//
+// The same set the walk abstracted over, girard's parameters included, so a
+// term the walk left polymorphic is bound here rather than substituting
+// nothing and collapsing to `[Unknown]`.
+fn local_polymorphic_bounds(
+  definition: Definition(Function),
+  girard_fn_typed: dict.Dict(String, Set(String)),
+) -> List(ParamBound) {
+  synthetic_fn_typed_bounds(unbound_fn_typed_params(
+    definition,
+    [],
+    girard_fn_typed,
+  ))
 }
 
 // Resolve effect variables at a call site. If the callee's effects
@@ -5931,7 +5955,14 @@ fn lift_local_function(
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
   let function = definition.definition
-  let fn_param_names = ordered_fn_typed_param_names(function)
+  // girard's names come along: a callback carrying no `fn(...)` annotation
+  // needs its binder here too, or the lifted term's variable stays free and
+  // the application goes stuck.
+  let fn_param_names =
+    ordered_callback_param_names(
+      function,
+      typeinfo.fn_typed_params(cache.girard_fn_typed, name),
+    )
   // A sibling a declaration answers for is lifted from that declaration, not
   // from the body beside it — the rule a direct same-module call into it
   // already follows — abstracted over its own callback parameters so an
@@ -6404,8 +6435,10 @@ fn memoized_local(
       // can produce effect variables too (nested higher-order calls stay
       // polymorphic through the transitive analysis).
       let nested_bounds =
-        synthetic_fn_typed_bounds(signatures.fn_typed_params_from_function(
-          local_definition.definition,
+        synthetic_fn_typed_bounds(unbound_fn_typed_params(
+          local_definition,
+          [],
+          cache.girard_fn_typed,
         ))
       let key = memo_key(local_call.function, visited, cache)
       case dict.get(memo.locals, key) {

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -14,7 +14,7 @@ import graded/internal/cli
 import graded/internal/effect_term
 import graded/internal/effects
 import graded/internal/signatures
-import graded/internal/types
+import graded/internal/types.{type EffectTerm}
 import simplifile
 import support
 
@@ -11804,5 +11804,94 @@ pub fn helper() -> Nil {
   violation.explanation.actual
   |> types.contains_unknown
   |> should.be_true
+  support.cleanup(root)
+}
+
+// Girard-typed callback parameters
+//
+// A parameter carrying no `fn(...)` annotation is a callback all the same when
+// girard infers a function type for it. Every channel that reaches such a
+// helper — a same-module call, the operator lift of a reference to it, a
+// cross-module call — charges the one answer.
+
+// The package the section runs over: `apply` takes an unannotated callback,
+// and three callers reach it. `ffi.shout` is the only source of an effect, so
+// nothing here depends on an installed dependency.
+fn girard_callback_project(root: String) -> List(types.EffectAnnotation) {
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) = simplifile.create_directory_all(root)
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/gleam.toml", "name = \"proj\"\n")
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/ffi.gleam",
+      support.foreign_fn("shout", "() -> Nil"),
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/proj.gleam",
+      "import ffi
+
+pub fn shout() -> Nil {
+  ffi.shout()
+}
+
+pub fn apply(f) {
+  f()
+}
+
+pub fn same_module() -> Nil {
+  apply(shout)
+}
+
+pub fn twice(g: fn(fn() -> Nil) -> Nil, cb: fn() -> Nil) -> Nil {
+  g(cb)
+}
+
+pub fn via_lift() -> Nil {
+  twice(apply, shout)
+}
+",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/other.gleam",
+      "import proj
+
+pub fn cross_module() -> Nil {
+  proj.apply(proj.shout)
+}
+",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/proj.graded", "assume ffi.shout : [Stdout]\n")
+  let assert Ok(Nil) = graded.run_infer(root)
+  let assert Ok(content) = simplifile.read(root <> "/proj.graded")
+  let assert Ok(file) = annotation.parse_file(content)
+  annotation.extract_annotations(file)
+}
+
+fn inferred_effects(
+  annotations: List(types.EffectAnnotation),
+  function: String,
+) -> EffectTerm {
+  let assert Ok(annotation) =
+    list.find(annotations, fn(a) { a.function == function })
+  annotation.effects
+}
+
+pub fn girard_typed_callback_charges_every_caller_alike_test() {
+  let root = "build/girard_callback_parity"
+  let annotations = girard_callback_project(root)
+  let stdout = types.TLabels(set.from_list(["Stdout"]))
+
+  // The helper itself: one bound over the unannotated parameter.
+  inferred_effects(annotations, "proj.apply")
+  |> should.equal(types.TVar("f"))
+  // The caller beside it, the caller in another module, and the lift of a
+  // reference to it all charge the callback's own effects.
+  inferred_effects(annotations, "proj.same_module") |> should.equal(stdout)
+  inferred_effects(annotations, "other.cross_module") |> should.equal(stdout)
+  inferred_effects(annotations, "proj.via_lift") |> should.equal(stdout)
   support.cleanup(root)
 }


### PR DESCRIPTION
A helper whose callback parameter carries no `fn(...)` annotation is effect-polymorphic all the same — girard infers the function type. The top-level walk knew that and published the bound (`effects proj.apply(f: [f]) : [f]`), but three same-module readings computed "which parameters are callbacks" from the glance signature alone:

- the `memoized_local` seed, so the callee's body was walked with no bound for the parameter and its call to it collapsed to `[Unknown]`;
- `local_polymorphic_bounds`, feeding `substitute_local_call_effects`, so even a correctly polymorphic term had nothing to bind at the call site;
- `ordered_fn_typed_param_names` on the lift path, so the lifted operator's variable had no binder and the application went stuck.

All three had to move together: a polymorphic term nobody binds substitutes nothing.

The result was a divergence — a same-module caller paid `[Unknown]` while a cross-module caller of the same helper got the argument's actual effects. Conservative, not unsound, but not what `infer` published.

**The change.** `LocalCache` carries girard's fn-typed parameter names (`build_scc_ids` already consumed the dict for its collapse decision, so this is a store-what-you-were-handed field, per-module like the rest of the cache). The three sites read it through `unbound_fn_typed_params` — the computation the top-level walk and the dependency fallback walk already share — instead of `signatures.fn_typed_params_from_function` directly.

Alias-typed parameters (`run: Action` where `type Action = fn() -> Nil`) are a separate gap and are not touched here; the parity target is what the top-level walk does.

**Test.** A package where `apply(f)` takes an unannotated callback and three callers reach it — beside it, from another module, and through an operator lift of a reference to it. All three now infer `[Stdout]`; before, they read `[Stdout]`, `[Unknown]` and `[Unknown([Stdout])]` respectively. The only effect source is a bodyless `@external` with an `assume` line, so nothing depends on an installed dependency.

Gates: `gleam format --check`, `gleam build --warnings-as-errors`, `gleam test` (1318 passed), `glinter`.