### PR TITLE
Resolve callback parameters through fn type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A callback parameter spelled through a `fn` type alias — `run(action:
+  Action)` with `type Action = fn() -> Nil` — now resolves like a directly
+  annotated one: the bound is written on the inferred line, the call site binds
+  the argument, and a second-order parameter whose own callback is aliased
+  keeps its shape. Such a call read `[Unknown]`, or, where a lift discharged
+  the argument, an under-approximation. A boundless `assume` over an external
+  whose callback is aliased now charges that callback to its callers too, so a
+  check that passed on the old answer may now fail.
 - A helper whose callback parameter carries no `fn(...)` annotation now charges
   its callers in the same module the callback's own effects, as callers in
   another module already paid. The same answer now reaches a reference to that

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -235,7 +235,12 @@ pub fn infer_with_returns(
       // variables instead of [Unknown]. The same bounds every other walk of a
       // body uses.
       let fn_typed_params =
-        unbound_fn_typed_params(definition, param_bounds, girard_fn_typed)
+        unbound_fn_typed_params(
+          definition,
+          param_bounds,
+          cache.fn_alias_types,
+          girard_fn_typed,
+        )
       let effective_bounds = effective_bounds(param_bounds, fn_typed_params)
       // A bodyless `@external` is opaque FFI — conservatively `[Unknown]`, not
       // the `[]` its empty body would otherwise infer.
@@ -377,7 +382,12 @@ pub fn explain(
       let #(_memo, explained) =
         list.map_fold(bounds, new_memo(), fn(memo, bounds) {
           let fn_typed_params =
-            unbound_fn_typed_params(definition, bounds, girard_fn_typed)
+            unbound_fn_typed_params(
+              definition,
+              bounds,
+              cache.fn_alias_types,
+              girard_fn_typed,
+            )
           let #(contribution, memo) =
             contributors(
               definition,
@@ -979,6 +989,7 @@ pub fn unwalked_fallback_effects(
       foreign_definition(definition, package_targets)
       && runs_fallback_body(definition, package_targets)
     }),
+    signatures.type_alias_map(module.type_aliases),
     girard_fn_typed,
   )
 }
@@ -994,12 +1005,14 @@ pub fn unwalked_dependency_fallback_effects(
       extract.declares_external(definition)
       && has_running_fallback(definition, package_targets)
     }),
+    signatures.type_alias_map(module.type_aliases),
     dict.new(),
   )
 }
 
 fn unwalked_summaries(
   targets: List(Definition(Function)),
+  alias_map: dict.Dict(String, glance.Type),
   girard_fn_typed: dict.Dict(String, Set(String)),
 ) -> dict.Dict(String, #(EffectTerm, List(ParamBound))) {
   targets
@@ -1008,6 +1021,7 @@ fn unwalked_summaries(
       synthetic_fn_typed_bounds(unbound_fn_typed_params(
         definition,
         [],
+        alias_map,
         girard_fn_typed,
       ))
     let term =
@@ -1276,7 +1290,12 @@ fn walk_component(
         // fallback has no `check` line of its own to declare any, so every one
         // of them is synthesised.
         let fn_typed_params =
-          unbound_fn_typed_params(definition, [], walk.girard_fn_typed)
+          unbound_fn_typed_params(
+            definition,
+            [],
+            walk.cache.fn_alias_types,
+            walk.girard_fn_typed,
+          )
         let synthetic_bounds = synthetic_fn_typed_bounds(fn_typed_params)
         let #(pairs, memo) =
           collect_effects(
@@ -2184,15 +2203,23 @@ fn synthetic_fn_typed_bounds(fn_typed_params: Set(String)) -> List(ParamBound) {
 // bounds already name is left to what was declared for it, which is the more
 // specific claim.
 //
-// Detected from the glance signature and from girard's inferred one, which
-// covers a parameter carrying no `fn(...)` annotation.
+// Detected from the glance signature — through the module's own type aliases,
+// so `run: Action` with `type Action = fn() -> Nil` counts — and from girard's
+// inferred one, which covers a parameter carrying no annotation at all. The
+// alias leg is deterministic where girard's is best-effort, so a bound stays
+// where girard declines the function.
+//
+// The one answer to "which of this function's parameters are callbacks":
+// every walk, every substitution and every lift reads it, so no two of them
+// can abstract over different parameters.
 fn unbound_fn_typed_params(
   definition: Definition(Function),
   declared: List(ParamBound),
+  alias_map: dict.Dict(String, glance.Type),
   girard_fn_typed: dict.Dict(String, Set(String)),
 ) -> Set(String) {
   let declared_names = effects.bound_name_set(declared)
-  signatures.fn_typed_params_from_function(definition.definition)
+  signatures.fn_typed_params_from_function(definition.definition, alias_map)
   |> set.union(typeinfo.fn_typed_params(
     girard_fn_typed,
     definition.definition.name,
@@ -2375,15 +2402,12 @@ pub fn build_scc_ids(
   // silently drop a fn-typed parameter and let an effect-polymorphic function be
   // wrongly collapsed. Resolving aliases ourselves keeps the collapse decision
   // independent of girard's availability.
-  let fn_aliases = function_type_aliases(module.type_aliases)
-  let fn_alias_types = type_alias_map(module.type_aliases)
+  let fn_alias_types = signatures.type_alias_map(module.type_aliases)
   let needs_exact =
     list.filter_map(definitions, fn(definition) {
       let name = definition.definition.name
       let first_order =
-        signatures.fn_typed_params_from_function(definition.definition)
-        |> set.union(alias_fn_typed_params(definition.definition, fn_aliases))
-        |> set.union(typeinfo.fn_typed_params(girard_fn_typed, name))
+        unbound_fn_typed_params(definition, [], fn_alias_types, girard_fn_typed)
         |> set.is_empty()
       case
         first_order && !foreign_definition(definition, context.package_targets)
@@ -2430,46 +2454,13 @@ pub fn build_scc_ids(
 fn function_type_aliases(
   aliases: List(Definition(glance.TypeAlias)),
 ) -> Set(String) {
-  let alias_map = type_alias_map(aliases)
+  let alias_map = signatures.type_alias_map(aliases)
   list.filter(dict.keys(alias_map), fn(name) {
     signatures.resolve_function_type(
       glance.NamedType(Span(0, 0), name, None, []),
       alias_map,
     )
     |> result.is_ok
-  })
-  |> set.from_list()
-}
-
-// Module-local type aliases as a raw `name → aliased type` map. Shared by the
-// collapse decision (`function_type_aliases`) and the returns machinery
-// (`LocalCache.fn_alias_types`).
-fn type_alias_map(
-  aliases: List(Definition(glance.TypeAlias)),
-) -> dict.Dict(String, glance.Type) {
-  list.fold(aliases, dict.new(), fn(acc, definition) {
-    dict.insert(acc, definition.definition.name, definition.definition.aliased)
-  })
-}
-
-// Parameters of `function` whose declared type resolves to a function through a
-// module-local alias. The direct `fn(...)` case is already covered by
-// `signatures.fn_typed_params_from_function`; this adds the alias-resolved ones.
-fn alias_fn_typed_params(
-  function: Function,
-  fn_aliases: Set(String),
-) -> Set(String) {
-  list.filter_map(function.parameters, fn(parameter) {
-    case parameter.name, parameter.type_ {
-      glance.Named(name),
-        Some(glance.NamedType(name: type_name, module: None, ..))
-      ->
-        case set.contains(fn_aliases, type_name) {
-          True -> Ok(name)
-          False -> Error(Nil)
-        }
-      _, _ -> Error(Nil)
-    }
   })
   |> set.from_list()
 }
@@ -3044,6 +3035,7 @@ fn check_annotation(
         unbound_fn_typed_params(
           function_definition,
           annotation.params,
+          cache.fn_alias_types,
           girard_fn_typed,
         )
       // The same contributors `why` explains — including the declaration that
@@ -3308,7 +3300,10 @@ fn collect_effects(
   // The function's own fn-typed params join the inherited ambient operators, so
   // a closure in this body that captures one resolves it to its effect variable.
   let operator_params =
-    dict.merge(ambient_operators, signatures.operator_param_shapes(function))
+    dict.merge(
+      ambient_operators,
+      signatures.operator_param_shapes(function, cache.fn_alias_types),
+    )
   let lift_operator_arg =
     build_lift_operator_arg(
       context,
@@ -4006,8 +4001,7 @@ fn substitute_local_call_effects(
           || suppressed_share_vars(one.resolution.fallback)
         })
       use <- bool.guard(when: !any_polymorphic, return: #(recursive, memo))
-      let bounds =
-        local_polymorphic_bounds(local_definition, cache.girard_fn_typed)
+      let bounds = local_polymorphic_bounds(local_definition, cache)
       let args = call_args_for(call_args, local_call.span)
       let callee_name =
         QualifiedName(module: local_sentinel, function: local_call.function)
@@ -4015,15 +4009,10 @@ fn substitute_local_call_effects(
       // single-entry registry from this local function's glance AST so
       // positional argument matching has parameter info to work with.
       let local_registry =
-        signatures.from_glance_module(
+        signatures.from_single_function(
           local_sentinel,
-          glance.Module(
-            imports: [],
-            custom_types: [],
-            type_aliases: [],
-            constants: [],
-            functions: [local_definition],
-          ),
+          local_definition,
+          cache.fn_alias_types,
         )
       let merged_registry = signatures.merge(registry, local_registry)
       let #(bindings, memo) =
@@ -4095,12 +4084,13 @@ fn substitute_local_call_effects(
 // nothing and collapsing to `[Unknown]`.
 fn local_polymorphic_bounds(
   definition: Definition(Function),
-  girard_fn_typed: dict.Dict(String, Set(String)),
+  cache: LocalCache,
 ) -> List(ParamBound) {
   synthetic_fn_typed_bounds(unbound_fn_typed_params(
     definition,
     [],
-    girard_fn_typed,
+    cache.fn_alias_types,
+    cache.girard_fn_typed,
   ))
 }
 
@@ -5488,15 +5478,10 @@ fn bind_producer_params(
           // detection whatever the summary: a `Declared` summary's carried
           // bounds replace only the scoping list, never the registry.
           let local_registry =
-            signatures.from_glance_module(
+            signatures.from_single_function(
               "",
-              glance.Module(
-                imports: [],
-                custom_types: [],
-                type_aliases: [],
-                constants: [],
-                functions: [definition],
-              ),
+              definition,
+              cache.fn_alias_types,
             )
           // A **Declared** summary — an assumption over this package's own
           // `@external`, whose producer is called from its own module — binds
@@ -5513,7 +5498,7 @@ fn bind_producer_params(
             effects.Declared(bounds:) -> bounds
             effects.Fresh | effects.Closed(..) ->
               definition.definition
-              |> ordered_fn_typed_param_names()
+              |> ordered_fn_typed_param_names(cache.fn_alias_types)
               |> list.map(self_referential_bound)
           }
           #(scoping, signatures.merge(registry, local_registry))
@@ -5624,11 +5609,13 @@ fn compute_returned_operator(
   case gated {
     Error(Nil) -> #(Error(Nil), memo)
     Ok(#(positions, value)) -> {
-      let producer_operators = signatures.operator_param_shapes(function)
+      let producer_operators =
+        signatures.operator_param_shapes(function, cache.fn_alias_types)
       // All fn-typed params of the producer. `ordered_fn_typed_param_names` and
       // `operator_param_shapes` filter to the same set (fn-typed Named params), so
       // this covers both seed origins S1 (producer_bounds) and S3 (ambient ops).
-      let ordered_params = ordered_fn_typed_param_names(function)
+      let ordered_params =
+        ordered_fn_typed_param_names(function, cache.fn_alias_types)
       let producer_params = set.from_list(ordered_params)
       // Fix D S1: seed the producer's params as sentinels (`$op$name`) rather than
       // self-referential, so a residual leaked var of the same name cannot merge
@@ -5961,6 +5948,7 @@ fn lift_local_function(
   let fn_param_names =
     ordered_callback_param_names(
       function,
+      cache.fn_alias_types,
       typeinfo.fn_typed_params(cache.girard_fn_typed, name),
     )
   // A sibling a declaration answers for is lifted from that declaration, not
@@ -5992,6 +5980,7 @@ fn lift_local_function(
       let params =
         ordered_callback_param_names(
           function,
+          cache.fn_alias_types,
           value_channel_bound_names(knowledge_base, qualified),
         )
       #(
@@ -6092,22 +6081,35 @@ fn lift_operator_miss(
   #(operator, Memo(..memo, lifts: dict.insert(memo.lifts, key, operator)))
 }
 
-// In-body names of a function's fn-typed parameters, in declaration order.
-fn ordered_fn_typed_param_names(function: Function) -> List(String) {
-  ordered_callback_param_names(function, set.new())
+// In-body names of a function's fn-typed parameters, in declaration order,
+// read through the module's own type aliases.
+fn ordered_fn_typed_param_names(
+  function: Function,
+  alias_map: dict.Dict(String, glance.Type),
+) -> List(String) {
+  ordered_callback_param_names(function, alias_map, set.new())
 }
 
 // The same, counting parameters named in `bound_names` as fn-typed too — a
 // running fallback's girard-typed callback carries no `fn(...)` annotation and
-// exists only as the bound recorded beside its settled summary.
+// exists only as the bound recorded beside its settled summary. The alias map
+// is this function's own input rather than folded into `bound_names`: an
+// alias-typed callback is read off the source, so it must be found with no
+// girard run and with no summary recorded.
 fn ordered_callback_param_names(
   function: Function,
+  alias_map: dict.Dict(String, glance.Type),
   bound_names: Set(String),
 ) -> List(String) {
   list.filter_map(function.parameters, fn(param) {
-    case param.type_, param.name {
-      Some(glance.FunctionType(..)), glance.Named(name) -> Ok(name)
-      _, glance.Named(name) ->
+    let fn_typed = case param.type_ {
+      Some(type_) ->
+        signatures.resolve_function_type(type_, alias_map) |> result.is_ok
+      None -> False
+    }
+    case fn_typed, param.name {
+      True, glance.Named(name) -> Ok(name)
+      False, glance.Named(name) ->
         case set.contains(bound_names, name) {
           True -> Ok(name)
           False -> Error(Nil)
@@ -6438,6 +6440,7 @@ fn memoized_local(
         synthetic_fn_typed_bounds(unbound_fn_typed_params(
           local_definition,
           [],
+          cache.fn_alias_types,
           cache.girard_fn_typed,
         ))
       let key = memo_key(local_call.function, visited, cache)

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -79,7 +79,6 @@ pub fn check(
           knowledge_base,
           registry,
           module_types,
-          girard_fn_typed,
           cache,
           memo,
         )
@@ -235,12 +234,7 @@ pub fn infer_with_returns(
       // variables instead of [Unknown]. The same bounds every other walk of a
       // body uses.
       let fn_typed_params =
-        unbound_fn_typed_params(
-          definition,
-          param_bounds,
-          cache.fn_alias_types,
-          girard_fn_typed,
-        )
+        unbound_fn_typed_params(definition, param_bounds, cache)
       let effective_bounds = effective_bounds(param_bounds, fn_typed_params)
       // A bodyless `@external` is opaque FFI — conservatively `[Unknown]`, not
       // the `[]` its empty body would otherwise infer.
@@ -382,12 +376,7 @@ pub fn explain(
       let #(_memo, explained) =
         list.map_fold(bounds, new_memo(), fn(memo, bounds) {
           let fn_typed_params =
-            unbound_fn_typed_params(
-              definition,
-              bounds,
-              cache.fn_alias_types,
-              girard_fn_typed,
-            )
+            unbound_fn_typed_params(definition, bounds, cache)
           let #(contribution, memo) =
             contributors(
               definition,
@@ -1018,12 +1007,9 @@ fn unwalked_summaries(
   targets
   |> list.map(fn(definition) {
     let bounds =
-      synthetic_fn_typed_bounds(unbound_fn_typed_params(
-        definition,
-        [],
-        alias_map,
-        girard_fn_typed,
-      ))
+      synthetic_fn_typed_bounds(
+        set.from_list(callback_params(definition, alias_map, girard_fn_typed)),
+      )
     let term =
       effect_term.normalize(
         TUnion([
@@ -1092,7 +1078,6 @@ fn walk_fallbacks(
             knowledge_base:,
             registry:,
             module_types:,
-            girard_fn_typed:,
             package_targets:,
           ),
         )
@@ -1211,7 +1196,6 @@ type FallbackWalk {
     knowledge_base: KnowledgeBase,
     registry: SignatureRegistry,
     module_types: dict.Dict(#(Int, Int), girard.Type),
-    girard_fn_typed: dict.Dict(String, Set(String)),
     // What decides the targets each member's body runs on, and so the targets
     // every name that body calls is read on.
     package_targets: types.PackageTargets,
@@ -1290,12 +1274,7 @@ fn walk_component(
         // fallback has no `check` line of its own to declare any, so every one
         // of them is synthesised.
         let fn_typed_params =
-          unbound_fn_typed_params(
-            definition,
-            [],
-            walk.cache.fn_alias_types,
-            walk.girard_fn_typed,
-          )
+          unbound_fn_typed_params(definition, [], walk.cache)
         let synthetic_bounds = synthetic_fn_typed_bounds(fn_typed_params)
         let #(pairs, memo) =
           collect_effects(
@@ -1382,7 +1361,7 @@ fn module_context(
     |> extract.with_cross_updates(effects.updates(knowledge_base))
     |> extract.with_fn_typed_fields(signatures.fn_typed_fields_from_module(
       module,
-      function_type_aliases(module.type_aliases),
+      signatures.type_alias_map(module.type_aliases),
     ))
   ModuleContext(
     context:,
@@ -2203,6 +2182,8 @@ fn synthetic_fn_typed_bounds(fn_typed_params: Set(String)) -> List(ParamBound) {
 // bounds already name is left to what was declared for it, which is the more
 // specific claim.
 //
+// A function's callback parameters, in declaration order.
+//
 // Detected from the glance signature — through the module's own type aliases,
 // so `run: Action` with `type Action = fn() -> Nil` counts — and from girard's
 // inferred one, which covers a parameter carrying no annotation at all. The
@@ -2212,19 +2193,46 @@ fn synthetic_fn_typed_bounds(fn_typed_params: Set(String)) -> List(ParamBound) {
 // The one answer to "which of this function's parameters are callbacks":
 // every walk, every substitution and every lift reads it, so no two of them
 // can abstract over different parameters.
+fn callback_params(
+  definition: Definition(Function),
+  alias_map: dict.Dict(String, glance.Type),
+  girard_fn_typed: dict.Dict(String, Set(String)),
+) -> List(String) {
+  signatures.ordered_callback_params(
+    definition.definition,
+    alias_map,
+    typeinfo.fn_typed_params(girard_fn_typed, definition.definition.name),
+  )
+}
+
+// The same set for a function of the module the cache was built over, read off
+// the cache rather than recomputed: `build_scc_ids` derives it for every
+// function to decide collapsibility, so every later reader is a lookup.
+// `declared` names the bounds a line already carries, which are left to what
+// was declared for them — the more specific claim.
 fn unbound_fn_typed_params(
   definition: Definition(Function),
   declared: List(ParamBound),
-  alias_map: dict.Dict(String, glance.Type),
-  girard_fn_typed: dict.Dict(String, Set(String)),
+  cache: LocalCache,
 ) -> Set(String) {
   let declared_names = effects.bound_name_set(declared)
-  signatures.fn_typed_params_from_function(definition.definition, alias_map)
-  |> set.union(typeinfo.fn_typed_params(
-    girard_fn_typed,
-    definition.definition.name,
-  ))
+  cached_callback_params(definition, cache)
+  |> set.from_list
   |> set.filter(fn(name) { !set.contains(declared_names, name) })
+}
+
+// In declaration order, which the lift path needs to abstract over them.
+fn cached_callback_params(
+  definition: Definition(Function),
+  cache: LocalCache,
+) -> List(String) {
+  case dict.get(cache.callback_params, definition.definition.name) {
+    Ok(params) -> params
+    // A definition the cache was not built over — nothing keys it, so derive
+    // it from the same two sources rather than reporting no callbacks.
+    Error(Nil) ->
+      callback_params(definition, cache.fn_alias_types, cache.girard_fn_typed)
+  }
 }
 
 // The bounds a body is walked under: what was declared for it, plus a
@@ -2375,6 +2383,11 @@ pub type LocalCache {
     // annotation is recognised as effect-polymorphic wherever a walk reaches
     // it from inside the module, not only at the module's top level.
     girard_fn_typed: dict.Dict(String, Set(String)),
+    // Each function's callback parameters, in declaration order — the two
+    // sources above already unioned. Derived here because the collapse
+    // decision below needs it for every function anyway, so every later
+    // reader is a lookup rather than a second walk of the signature.
+    callback_params: dict.Dict(String, List(String)),
   )
 }
 
@@ -2403,12 +2416,18 @@ pub fn build_scc_ids(
   // wrongly collapsed. Resolving aliases ourselves keeps the collapse decision
   // independent of girard's availability.
   let fn_alias_types = signatures.type_alias_map(module.type_aliases)
+  let callbacks =
+    list.fold(definitions, dict.new(), fn(acc, definition) {
+      dict.insert(
+        acc,
+        definition.definition.name,
+        callback_params(definition, fn_alias_types, girard_fn_typed),
+      )
+    })
   let needs_exact =
     list.filter_map(definitions, fn(definition) {
       let name = definition.definition.name
-      let first_order =
-        unbound_fn_typed_params(definition, [], fn_alias_types, girard_fn_typed)
-        |> set.is_empty()
+      let first_order = dict.get(callbacks, name) == Ok([])
       case
         first_order && !foreign_definition(definition, context.package_targets)
       {
@@ -2425,6 +2444,7 @@ pub fn build_scc_ids(
       set.new(),
       fn_alias_types,
       girard_fn_typed,
+      callbacks,
     ),
     fn(cache, component, id) {
       let scc_id =
@@ -2443,26 +2463,10 @@ pub fn build_scc_ids(
         collapsible:,
         fn_alias_types: cache.fn_alias_types,
         girard_fn_typed: cache.girard_fn_typed,
+        callback_params: cache.callback_params,
       )
     },
   )
-}
-
-// Names of module-local type aliases that resolve (transitively, through other
-// aliases) to a function type. `type Decoder(a) = fn(...)` and an alias of such
-// an alias both qualify; an alias to a record or tuple does not.
-fn function_type_aliases(
-  aliases: List(Definition(glance.TypeAlias)),
-) -> Set(String) {
-  let alias_map = signatures.type_alias_map(aliases)
-  list.filter(dict.keys(alias_map), fn(name) {
-    signatures.resolve_function_type(
-      glance.NamedType(Span(0, 0), name, None, []),
-      alias_map,
-    )
-    |> result.is_ok
-  })
-  |> set.from_list()
 }
 
 // Build the same-module call graph: each function mapped to the same-module
@@ -3022,7 +3026,6 @@ fn check_annotation(
   knowledge_base: KnowledgeBase,
   registry: SignatureRegistry,
   module_types: dict.Dict(#(Int, Int), girard.Type),
-  girard_fn_typed: dict.Dict(String, Set(String)),
   cache: LocalCache,
   memo: Memo,
 ) -> #(#(List(Violation), List(Warning)), Memo) {
@@ -3032,12 +3035,7 @@ fn check_annotation(
     Error(Nil) -> #(#([], []), memo)
     Ok(function_definition) -> {
       let fn_typed_params =
-        unbound_fn_typed_params(
-          function_definition,
-          annotation.params,
-          cache.fn_alias_types,
-          girard_fn_typed,
-        )
+        unbound_fn_typed_params(function_definition, annotation.params, cache)
       // The same contributors `why` explains — including the declaration that
       // stands in for an `@external`'s absent body, so a `check` line
       // contradicting a declaration is a violation, as is one over an external
@@ -4086,12 +4084,7 @@ fn local_polymorphic_bounds(
   definition: Definition(Function),
   cache: LocalCache,
 ) -> List(ParamBound) {
-  synthetic_fn_typed_bounds(unbound_fn_typed_params(
-    definition,
-    [],
-    cache.fn_alias_types,
-    cache.girard_fn_typed,
-  ))
+  synthetic_fn_typed_bounds(unbound_fn_typed_params(definition, [], cache))
 }
 
 // Resolve effect variables at a call site. If the callee's effects
@@ -5498,7 +5491,9 @@ fn bind_producer_params(
             effects.Declared(bounds:) -> bounds
             effects.Fresh | effects.Closed(..) ->
               definition.definition
-              |> ordered_fn_typed_param_names(cache.fn_alias_types)
+              |> signatures.fn_typed_params_from_function(cache.fn_alias_types)
+              |> set.to_list
+              |> list.sort(string.compare)
               |> list.map(self_referential_bound)
           }
           #(scoping, signatures.merge(registry, local_registry))
@@ -5615,7 +5610,11 @@ fn compute_returned_operator(
       // `operator_param_shapes` filter to the same set (fn-typed Named params), so
       // this covers both seed origins S1 (producer_bounds) and S3 (ambient ops).
       let ordered_params =
-        ordered_fn_typed_param_names(function, cache.fn_alias_types)
+        signatures.ordered_callback_params(
+          function,
+          cache.fn_alias_types,
+          set.new(),
+        )
       let producer_params = set.from_list(ordered_params)
       // Fix D S1: seed the producer's params as sentinels (`$op$name`) rather than
       // self-referential, so a residual leaked var of the same name cannot merge
@@ -5942,15 +5941,6 @@ fn lift_local_function(
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
   let function = definition.definition
-  // girard's names come along: a callback carrying no `fn(...)` annotation
-  // needs its binder here too, or the lifted term's variable stays free and
-  // the application goes stuck.
-  let fn_param_names =
-    ordered_callback_param_names(
-      function,
-      cache.fn_alias_types,
-      typeinfo.fn_typed_params(cache.girard_fn_typed, name),
-    )
   // A sibling a declaration answers for is lifted from that declaration, not
   // from the body beside it — the rule a direct same-module call into it
   // already follows — abstracted over its own callback parameters so an
@@ -5978,7 +5968,7 @@ fn lift_local_function(
       let qualified = QualifiedName(module: context.module_path, function: name)
       let declared = effects.declared_effects(knowledge_base, qualified)
       let params =
-        ordered_callback_param_names(
+        signatures.ordered_callback_params(
           function,
           cache.fn_alias_types,
           value_channel_bound_names(knowledge_base, qualified),
@@ -6023,8 +6013,7 @@ fn lift_local_function(
         Error(Nil) ->
           lift_operator_miss(
             name,
-            function,
-            fn_param_names,
+            definition,
             key,
             context,
             function_map,
@@ -6045,8 +6034,7 @@ fn lift_local_function(
 // variables, then abstract over those params in declaration order.
 fn lift_operator_miss(
   name: String,
-  function: Function,
-  fn_param_names: List(String),
+  definition: Definition(Function),
   key: #(String, List(String)),
   context: ImportContext,
   function_map: dict.Dict(String, Definition(Function)),
@@ -6057,6 +6045,11 @@ fn lift_operator_miss(
   cache: LocalCache,
   memo: Memo,
 ) -> #(EffectTerm, Memo) {
+  let function = definition.definition
+  // The canonical callback set, in declaration order: a callback carrying no
+  // `fn(...)` annotation needs its binder here too, or the lifted term's
+  // variable stays free and the application goes stuck.
+  let fn_param_names = cached_callback_params(definition, cache)
   let bounds = list.map(fn_param_names, self_referential_bound)
   let #(body_pairs, memo) =
     collect_effects(
@@ -6079,44 +6072,6 @@ fn lift_operator_miss(
       types.TAbs(param, acc)
     })
   #(operator, Memo(..memo, lifts: dict.insert(memo.lifts, key, operator)))
-}
-
-// In-body names of a function's fn-typed parameters, in declaration order,
-// read through the module's own type aliases.
-fn ordered_fn_typed_param_names(
-  function: Function,
-  alias_map: dict.Dict(String, glance.Type),
-) -> List(String) {
-  ordered_callback_param_names(function, alias_map, set.new())
-}
-
-// The same, counting parameters named in `bound_names` as fn-typed too — a
-// running fallback's girard-typed callback carries no `fn(...)` annotation and
-// exists only as the bound recorded beside its settled summary. The alias map
-// is this function's own input rather than folded into `bound_names`: an
-// alias-typed callback is read off the source, so it must be found with no
-// girard run and with no summary recorded.
-fn ordered_callback_param_names(
-  function: Function,
-  alias_map: dict.Dict(String, glance.Type),
-  bound_names: Set(String),
-) -> List(String) {
-  list.filter_map(function.parameters, fn(param) {
-    let fn_typed = case param.type_ {
-      Some(type_) ->
-        signatures.resolve_function_type(type_, alias_map) |> result.is_ok
-      None -> False
-    }
-    case fn_typed, param.name {
-      True, glance.Named(name) -> Ok(name)
-      False, glance.Named(name) ->
-        case set.contains(bound_names, name) {
-          True -> Ok(name)
-          False -> Error(Nil)
-        }
-      _, _ -> Error(Nil)
-    }
-  })
 }
 
 // Whether every free variable of a `where returns` clause is a real callback
@@ -6440,8 +6395,7 @@ fn memoized_local(
         synthetic_fn_typed_bounds(unbound_fn_typed_params(
           local_definition,
           [],
-          cache.fn_alias_types,
-          cache.girard_fn_typed,
+          cache,
         ))
       let key = memo_key(local_call.function, visited, cache)
       case dict.get(memo.locals, key) {

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -10,7 +10,7 @@
 // Project modules are parsed during `run_infer` / `run`; dependency
 // modules are parsed from `build/packages/<dep>/src/` on demand.
 
-import glance.{type Function, type Module, FunctionType}
+import glance.{type Definition, type Function, type Module, FunctionType}
 import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
@@ -255,40 +255,82 @@ pub fn operator_callback_positions(
 // `run_infer` / `run` to give the checker position information for
 // every function in the project — which powers positional argument
 // matching at polymorphic call sites.
+//
+// Parameter types are read through the module's own type aliases, so
+// `run: Action` with `type Action = fn() -> Nil` registers as the callback it
+// is.
 pub fn from_glance_module(
   module_path: String,
   module: Module,
 ) -> SignatureRegistry {
+  let alias_map = type_alias_map(module.type_aliases)
   let signatures =
     list.fold(module.functions, dict.new(), fn(acc, definition) {
-      let function = definition.definition
-      let params =
-        list.index_map(function.parameters, fn(param, i) {
-          let callback_positions = case param.type_ {
-            Some(FunctionType(_, param_types, _)) ->
-              all_function_indices(param_types)
-            _ -> []
-          }
-          ParameterInfo(
-            position: i,
-            label: param.label,
-            name: assignment_name(param.name),
-            is_fn_typed: case param.type_ {
-              Some(FunctionType(_, _, _)) -> True
-              _ -> False
-            },
-            is_annotated: option.is_some(param.type_),
-            is_operator: callback_positions != [],
-            callback_positions:,
-          )
-        })
       dict.insert(
         acc,
-        QualifiedName(module: module_path, function: function.name),
-        params,
+        QualifiedName(module: module_path, function: definition.definition.name),
+        parameter_infos(definition.definition, alias_map),
       )
     })
   SignatureRegistry(signatures:)
+}
+
+// A registry holding one function, against an alias map handed in. The
+// synthetic same-module registries build a `glance.Module` around a single
+// definition and have no `type_aliases` list to carry the module's aliases,
+// so they state the map directly and reach the same resolution
+// `from_glance_module` performs.
+pub fn from_single_function(
+  module_path: String,
+  definition: Definition(Function),
+  alias_map: Dict(String, glance.Type),
+) -> SignatureRegistry {
+  SignatureRegistry(
+    signatures: dict.from_list([
+      #(
+        QualifiedName(module: module_path, function: definition.definition.name),
+        parameter_infos(definition.definition, alias_map),
+      ),
+    ]),
+  )
+}
+
+// One function's parameters as registry entries, in declaration order.
+fn parameter_infos(
+  function: Function,
+  alias_map: Dict(String, glance.Type),
+) -> List(ParameterInfo) {
+  list.index_map(function.parameters, fn(param, i) {
+    let resolved =
+      param.type_
+      |> option.then(fn(type_) {
+        resolve_function_type(type_, alias_map) |> option.from_result
+      })
+    let callback_positions = case resolved {
+      Some(FunctionType(_, param_types, _)) ->
+        all_function_indices(param_types, alias_map)
+      _ -> []
+    }
+    ParameterInfo(
+      position: i,
+      label: param.label,
+      name: assignment_name(param.name),
+      is_fn_typed: option.is_some(resolved),
+      is_annotated: option.is_some(param.type_),
+      is_operator: callback_positions != [],
+      callback_positions:,
+    )
+  })
+}
+
+// Module-local type aliases as a raw `name → aliased type` map, the input every
+// alias-aware reading resolves against.
+pub fn type_alias_map(
+  aliases: List(Definition(glance.TypeAlias)),
+) -> Dict(String, glance.Type) {
+  list.fold(aliases, dict.new(), fn(acc, definition) {
+    dict.insert(acc, definition.definition.name, definition.definition.aliased)
+  })
 }
 
 // Function-typed *record fields* of a module's custom types, keyed by
@@ -350,21 +392,24 @@ fn is_field_fn_typed(type_: glance.Type, fn_aliases: Set(String)) -> Bool {
 
 // Names of a local function's fn-typed parameters, detected from
 // glance AST type annotations. Returns names of parameters whose
-// type annotation is `fn(...) -> ...`.
+// type annotation is `fn(...) -> ...`, or a module-local alias resolving to
+// one (`run: Action` with `type Action = fn() -> Nil`).
 //
 // Parameters without explicit type annotations (or with non-function
 // types) are omitted.
-pub fn fn_typed_params_from_function(function: Function) -> Set(String) {
+pub fn fn_typed_params_from_function(
+  function: Function,
+  alias_map: Dict(String, glance.Type),
+) -> Set(String) {
   function.parameters
   |> list.filter_map(fn(param) {
     case param.type_ {
-      Some(FunctionType(_, _, _)) -> {
-        case assignment_name(param.name) {
-          Some(name) -> Ok(name)
-          None -> Error(Nil)
+      Some(type_) ->
+        case resolve_function_type(type_, alias_map), param.name {
+          Ok(_), glance.Named(name) -> Ok(name)
+          _, _ -> Error(Nil)
         }
-      }
-      _ -> Error(Nil)
+      None -> Error(Nil)
     }
   })
   |> set.from_list()
@@ -380,35 +425,57 @@ pub fn fn_typed_params_from_function(function: Function) -> Set(String) {
 // Nil`) maps to `[]`. This lets a call site lift each callback argument over
 // exactly its own function parameters — discharging value parameters — instead
 // of guessing.
+//
+// Alias-aware at every depth: the parameter's own type, each of its arguments,
+// and those arguments' arguments each resolve through `alias_map`, so
+// `type Action = fn(Callback) -> Nil` over `type Callback = fn() -> Nil` reads
+// the same shape as the types written out.
 pub fn operator_param_shapes(
   function: Function,
+  alias_map: Dict(String, glance.Type),
 ) -> Dict(String, List(#(Int, List(Int)))) {
   function.parameters
   |> list.filter_map(fn(param) {
-    case param.type_, assignment_name(param.name) {
-      Some(FunctionType(_, param_types, _)), Some(name) -> {
-        let shape =
-          param_types
-          |> list.index_map(fn(t, i) { #(i, t) })
-          |> list.filter(fn(pair) { is_function_type(pair.1) })
-          |> list.map(fn(pair) {
-            #(pair.0, operator_callback_positions_of_type(pair.1))
-          })
-        Ok(#(name, shape))
-      }
-      _, _ -> Error(Nil)
+    use name <- result.try(option.to_result(assignment_name(param.name), Nil))
+    use type_ <- result.try(option.to_result(param.type_, Nil))
+    use resolved <- result.try(resolve_function_type(type_, alias_map))
+    case resolved {
+      FunctionType(_, param_types, _) ->
+        Ok(#(name, callback_shape(param_types, alias_map)))
+      _ -> Error(Nil)
     }
   })
   |> dict.from_list()
+}
+
+// One operator parameter's callback shape: each function-typed argument's
+// index paired with that argument's own callback positions. Every layer is
+// resolved through `alias_map`.
+fn callback_shape(
+  param_types: List(glance.Type),
+  alias_map: Dict(String, glance.Type),
+) -> List(#(Int, List(Int))) {
+  param_types
+  |> list.index_map(fn(type_, index) { #(index, type_) })
+  |> list.filter_map(fn(pair) {
+    let #(index, type_) = pair
+    use _ <- result.try(resolve_function_type(type_, alias_map))
+    Ok(#(index, operator_callback_positions_of_type(type_, alias_map)))
+  })
 }
 
 // The callback positions of an operator-shaped *type* — the function-typed
 // argument indices of a `fn(.., fn(..) -> _, ..) -> _`, in order. Empty when
 // the type isn't a function type that takes a function (i.e. not an operator).
 // Used to lift a function *returned* by a producer (its declared return type).
-pub fn operator_callback_positions_of_type(type_: glance.Type) -> List(Int) {
-  case type_ {
-    FunctionType(_, param_types, _) -> all_function_indices(param_types)
+// The type and each of its arguments resolve through `alias_map`.
+pub fn operator_callback_positions_of_type(
+  type_: glance.Type,
+  alias_map: Dict(String, glance.Type),
+) -> List(Int) {
+  case resolve_function_type(type_, alias_map) {
+    Ok(FunctionType(_, param_types, _)) ->
+      all_function_indices(param_types, alias_map)
     _ -> []
   }
 }
@@ -467,14 +534,7 @@ pub fn returned_callback_positions(
   use resolved <- result.try(resolve_function_type(type_, alias_map))
   case resolved {
     FunctionType(_, param_types, _) ->
-      Ok(
-        param_types
-        |> list.index_map(fn(t, i) {
-          #(i, resolve_function_type(t, alias_map) |> result.is_ok)
-        })
-        |> list.filter(fn(pair) { pair.1 })
-        |> list.map(fn(pair) { pair.0 }),
-      )
+      Ok(all_function_indices(param_types, alias_map))
     _ -> Error(Nil)
   }
 }
@@ -487,19 +547,18 @@ pub fn assignment_name(name: glance.AssignmentName) -> Option(String) {
 }
 
 // The indices of the function-typed arguments in a type list, in order. These
-// are the callback positions for an operator parameter's own argument list.
-fn all_function_indices(types: List(glance.Type)) -> List(Int) {
+// are the callback positions for an operator parameter's own argument list. An
+// argument spelled through a module-local alias counts.
+fn all_function_indices(
+  types: List(glance.Type),
+  alias_map: Dict(String, glance.Type),
+) -> List(Int) {
   types
-  |> list.index_map(fn(t, i) { #(i, is_function_type(t)) })
+  |> list.index_map(fn(t, i) {
+    #(i, resolve_function_type(t, alias_map) |> result.is_ok)
+  })
   |> list.filter(fn(pair) { pair.1 })
   |> list.map(fn(pair) { pair.0 })
-}
-
-fn is_function_type(t: glance.Type) -> Bool {
-  case t {
-    FunctionType(_, _, _) -> True
-    _ -> False
-  }
 }
 
 // Dependency loading

--- a/src/graded/internal/signatures.gleam
+++ b/src/graded/internal/signatures.gleam
@@ -308,7 +308,7 @@ fn parameter_infos(
       })
     let callback_positions = case resolved {
       Some(FunctionType(_, param_types, _)) ->
-        all_function_indices(param_types, alias_map)
+        fn_typed_argument_positions(param_types, alias_map)
       _ -> []
     }
     ParameterInfo(
@@ -343,14 +343,14 @@ pub fn type_alias_map(
 // collapsing it to `[Unknown]`.
 pub fn fn_typed_fields_from_module(
   module: Module,
-  fn_aliases: Set(String),
+  alias_map: Dict(String, glance.Type),
 ) -> Set(#(String, String)) {
   module.custom_types
   |> list.flat_map(fn(definition) {
     let type_name = definition.definition.name
     definition.definition.variants
     |> list.flat_map(fn(variant) { variant.fields })
-    |> list.filter_map(labelled_fn_field(type_name, _, fn_aliases))
+    |> list.filter_map(labelled_fn_field(type_name, _, alias_map))
   })
   |> set.from_list()
 }
@@ -360,27 +360,15 @@ pub fn fn_typed_fields_from_module(
 fn labelled_fn_field(
   type_name: String,
   field: glance.VariantField,
-  fn_aliases: Set(String),
+  alias_map: Dict(String, glance.Type),
 ) -> Result(#(String, String), Nil) {
   case field {
     glance.LabelledVariantField(item:, label:) ->
-      case is_field_fn_typed(item, fn_aliases) {
+      case is_fn_typed(item, alias_map) {
         True -> Ok(#(type_name, label))
         False -> Error(Nil)
       }
     _ -> Error(Nil)
-  }
-}
-
-// Whether a field's declared type is callable: a direct `fn(..)` or a
-// module-local alias that resolves to one (`run: Action` with
-// `type Action = fn() -> Nil`). Mirrors the alias handling applied to fn-typed
-// parameters.
-fn is_field_fn_typed(type_: glance.Type, fn_aliases: Set(String)) -> Bool {
-  case type_ {
-    FunctionType(_, _, _) -> True
-    glance.NamedType(name:, module: None, ..) -> set.contains(fn_aliases, name)
-    _ -> False
   }
 }
 
@@ -390,29 +378,55 @@ fn is_field_fn_typed(type_: glance.Type, fn_aliases: Set(String)) -> Bool {
 // parameters and operator shapes straight off glance annotations, for
 // definition-site inference where no registry lookup applies.
 
-// Names of a local function's fn-typed parameters, detected from
-// glance AST type annotations. Returns names of parameters whose
-// type annotation is `fn(...) -> ...`, or a module-local alias resolving to
-// one (`run: Action` with `type Action = fn() -> Nil`).
+// Whether a declared type is callable: a `fn(...)` written out, or a
+// module-local alias resolving to one (`run: Action` with
+// `type Action = fn() -> Nil`). The one alias-aware reading of "is this a
+// callback", so the registry, the definition-site detection below and the
+// checker's bound synthesis cannot come to different answers about one
+// parameter.
+pub fn is_fn_typed(
+  type_: glance.Type,
+  alias_map: Dict(String, glance.Type),
+) -> Bool {
+  resolve_function_type(type_, alias_map) |> result.is_ok
+}
+
+// In-body names of a function's callback parameters, in declaration order.
+// A parameter named in `extra` counts as one however its type reads — the
+// girard-typed case, which carries no annotation for the alias map to chase,
+// and a callback a settled summary records a bound for.
 //
-// Parameters without explicit type annotations (or with non-function
-// types) are omitted.
+// Parameters carrying a non-function type, and discarded ones, are omitted.
+pub fn ordered_callback_params(
+  function: Function,
+  alias_map: Dict(String, glance.Type),
+  extra: Set(String),
+) -> List(String) {
+  list.filter_map(function.parameters, fn(param) {
+    case param.name {
+      glance.Named(name) ->
+        case
+          option.unwrap(
+            option.map(param.type_, is_fn_typed(_, alias_map)),
+            False,
+          )
+          || set.contains(extra, name)
+        {
+          True -> Ok(name)
+          False -> Error(Nil)
+        }
+      glance.Discarded(_) -> Error(Nil)
+    }
+  })
+}
+
+// The same as a set, with no extras: the parameters a signature alone shows
+// are callbacks.
 pub fn fn_typed_params_from_function(
   function: Function,
   alias_map: Dict(String, glance.Type),
 ) -> Set(String) {
-  function.parameters
-  |> list.filter_map(fn(param) {
-    case param.type_ {
-      Some(type_) ->
-        case resolve_function_type(type_, alias_map), param.name {
-          Ok(_), glance.Named(name) -> Ok(name)
-          _, _ -> Error(Nil)
-        }
-      None -> Error(Nil)
-    }
-  })
-  |> set.from_list()
+  ordered_callback_params(function, alias_map, set.new()) |> set.from_list()
 }
 
 // Every fn-typed parameter of a function, mapped to the *shape* of its
@@ -450,34 +464,22 @@ pub fn operator_param_shapes(
 
 // One operator parameter's callback shape: each function-typed argument's
 // index paired with that argument's own callback positions. Every layer is
-// resolved through `alias_map`.
+// resolved through `alias_map`, each layer exactly once.
 fn callback_shape(
   param_types: List(glance.Type),
   alias_map: Dict(String, glance.Type),
 ) -> List(#(Int, List(Int))) {
-  param_types
-  |> list.index_map(fn(type_, index) { #(index, type_) })
-  |> list.filter_map(fn(pair) {
-    let #(index, type_) = pair
-    use _ <- result.try(resolve_function_type(type_, alias_map))
-    Ok(#(index, operator_callback_positions_of_type(type_, alias_map)))
+  fn_typed_arguments(param_types, alias_map)
+  |> list.map(fn(pair) {
+    let #(index, resolved) = pair
+    case resolved {
+      FunctionType(_, inner, _) -> #(
+        index,
+        fn_typed_argument_positions(inner, alias_map),
+      )
+      _ -> #(index, [])
+    }
   })
-}
-
-// The callback positions of an operator-shaped *type* — the function-typed
-// argument indices of a `fn(.., fn(..) -> _, ..) -> _`, in order. Empty when
-// the type isn't a function type that takes a function (i.e. not an operator).
-// Used to lift a function *returned* by a producer (its declared return type).
-// The type and each of its arguments resolve through `alias_map`.
-pub fn operator_callback_positions_of_type(
-  type_: glance.Type,
-  alias_map: Dict(String, glance.Type),
-) -> List(Int) {
-  case resolve_function_type(type_, alias_map) {
-    Ok(FunctionType(_, param_types, _)) ->
-      all_function_indices(param_types, alias_map)
-    _ -> []
-  }
 }
 
 // Resolve a type to its underlying function type, following module-local type
@@ -534,7 +536,7 @@ pub fn returned_callback_positions(
   use resolved <- result.try(resolve_function_type(type_, alias_map))
   case resolved {
     FunctionType(_, param_types, _) ->
-      Ok(all_function_indices(param_types, alias_map))
+      Ok(fn_typed_argument_positions(param_types, alias_map))
     _ -> Error(Nil)
   }
 }
@@ -546,19 +548,29 @@ pub fn assignment_name(name: glance.AssignmentName) -> Option(String) {
   }
 }
 
-// The indices of the function-typed arguments in a type list, in order. These
-// are the callback positions for an operator parameter's own argument list. An
-// argument spelled through a module-local alias counts.
-fn all_function_indices(
+// The function-typed arguments of a type list: each one's index paired with
+// its type resolved through `alias_map`, in order. The one place an argument
+// list is filtered for callbacks, so a reader that needs only the indices and
+// one that needs the resolved types read the same rule.
+fn fn_typed_arguments(
+  types: List(glance.Type),
+  alias_map: Dict(String, glance.Type),
+) -> List(#(Int, glance.Type)) {
+  types
+  |> list.index_map(fn(type_, index) { #(index, type_) })
+  |> list.filter_map(fn(pair) {
+    use resolved <- result.map(resolve_function_type(pair.1, alias_map))
+    #(pair.0, resolved)
+  })
+}
+
+// Their indices alone — the callback positions for an operator parameter's
+// own argument list.
+fn fn_typed_argument_positions(
   types: List(glance.Type),
   alias_map: Dict(String, glance.Type),
 ) -> List(Int) {
-  types
-  |> list.index_map(fn(t, i) {
-    #(i, resolve_function_type(t, alias_map) |> result.is_ok)
-  })
-  |> list.filter(fn(pair) { pair.1 })
-  |> list.map(fn(pair) { pair.0 })
+  fn_typed_arguments(types, alias_map) |> list.map(fn(pair) { pair.0 })
 }
 
 // Dependency loading

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -11895,3 +11895,210 @@ pub fn girard_typed_callback_charges_every_caller_alike_test() {
   inferred_effects(annotations, "proj.via_lift") |> should.equal(stdout)
   support.cleanup(root)
 }
+
+// Callback parameters spelled through a `fn` type alias
+//
+// `run(action: Action)` with `type Action = fn() -> Nil` takes a callback, and
+// every reading says so: the bound `infer` writes, the call-site binding beside
+// it and across the module boundary, the shape of a second-order parameter
+// whose own callback is aliased too, and the conservative charge a boundless
+// declaration makes.
+
+// The package the section runs over. `ffi.shout` is the only source of an
+// effect, and `ffi.each` is a boundless declared external taking an
+// alias-typed callback.
+fn alias_callback_project(root: String) -> Nil {
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) = simplifile.create_directory_all(root)
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/gleam.toml", "name = \"proj\"\n")
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/ffi.gleam", "pub type Callback =
+  fn() -> Nil
+
+" <> support.foreign_fn("shout", "() -> Nil") <> "
+" <> support.foreign_fn("each", "(cb: Callback) -> Nil"))
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/proj.gleam",
+      "import ffi
+
+pub type Action =
+  fn() -> Nil
+
+pub type Callback =
+  fn() -> Nil
+
+pub type Op =
+  fn(Callback) -> Nil
+
+pub fn shout() -> Nil {
+  ffi.shout()
+}
+
+pub fn run(action: Action) -> Nil {
+  action()
+}
+
+pub fn same_module() -> Nil {
+  run(shout)
+}
+
+pub fn use_op(op: Op, cb: Callback) -> Nil {
+  op(cb)
+}
+
+pub fn drive() -> Nil {
+  use_op(run, shout)
+}
+",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/other.gleam",
+      "import ffi
+import proj
+
+pub fn cross_module() -> Nil {
+  proj.run(proj.shout)
+}
+
+pub fn via_declared_external() -> Nil {
+  ffi.each(proj.shout)
+}
+",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/proj.graded",
+      "assume ffi.shout : [Stdout]\nassume ffi.each : []\n",
+    )
+  Nil
+}
+
+pub fn an_alias_typed_callback_resolves_like_an_annotated_one_test() {
+  let root = "build/alias_callback_project"
+  alias_callback_project(root)
+  let assert Ok(Nil) = graded.run_infer(root)
+  let assert Ok(content) = simplifile.read(root <> "/proj.graded")
+  let assert Ok(file) = annotation.parse_file(content)
+  let annotations = annotation.extract_annotations(file)
+  let stdout = types.TLabels(set.from_list(["Stdout"]))
+
+  // The bound is written, so a line stays closed by itself with no girard run.
+  let assert Ok(run) =
+    list.find(annotations, fn(a) { a.function == "proj.run" })
+  run.effects |> should.equal(types.TVar("action"))
+  run.params |> list.map(fn(b) { b.name }) |> should.equal(["action"])
+
+  // Bound at the call site, beside the definition and from another module.
+  inferred_effects(annotations, "proj.same_module") |> should.equal(stdout)
+  inferred_effects(annotations, "other.cross_module") |> should.equal(stdout)
+
+  // A second-order parameter whose own callback is aliased keeps its shape,
+  // so applying it to the callback reduces instead of going stuck.
+  let assert Ok(use_op) =
+    list.find(annotations, fn(a) { a.function == "proj.use_op" })
+  use_op.params
+  |> list.map(fn(b) { b.name })
+  |> list.sort(string.compare)
+  |> should.equal(["cb", "op"])
+  use_op.effects
+  |> should.equal(types.TApp(types.TVar("op"), types.TVar("cb")))
+  inferred_effects(annotations, "proj.drive") |> should.equal(stdout)
+
+  // A boundless declaration says nothing about its callbacks, so the caller
+  // pays the one it passes — through the alias too.
+  inferred_effects(annotations, "other.via_declared_external")
+  |> should.equal(stdout)
+  support.cleanup(root)
+}
+
+pub fn an_inferred_alias_callback_spec_checks_clean_test() {
+  // The spec `infer` writes for the same package passes `check`: every bound
+  // it names is one the closedness oracle admits.
+  let root = "build/alias_callback_roundtrip"
+  alias_callback_project(root)
+  let assert Ok(Nil) = graded.run_infer(root)
+  let assert Ok(results) = graded.run(root)
+  list.flat_map(results, fn(r) { r.violations }) |> should.equal([])
+  list.flat_map(results, fn(r) { r.warnings }) |> should.equal([])
+  support.cleanup(root)
+}
+
+pub fn a_cyclic_dependency_records_an_alias_typed_callback_test() {
+  // The cycle skips the walk, so `dep/x.run` keeps the `[Unknown]` an unwalked
+  // body carries — with its callback recorded beside it, though the callback is
+  // spelled through an alias. Both callers pay the `[Disk]` they pass.
+  let root =
+    support.write_project_with_dependency(
+      directory: "build/dep_cycle_alias_callback",
+      package: "proj",
+      spec: "assume proj.disk : [Disk]
+check proj.direct : []
+check proj.via_operator : []
+",
+      sources: [
+        #(
+          "proj.gleam",
+          "import dep/x
+
+@external(erlang, \"d\", \"w\")
+@external(javascript, \"d\", \"w\")
+pub fn disk() -> Nil
+
+pub fn direct() -> Nil {
+  x.run(disk)
+}
+
+fn invoke(op: fn(fn() -> Nil) -> Nil, cb: fn() -> Nil) -> Nil {
+  op(cb)
+}
+
+pub fn via_operator() -> Nil {
+  invoke(x.run, disk)
+}
+",
+        ),
+      ],
+      dependency: "dep",
+      dependency_spec: "assume dep/x.run : [Time]\nassume dep/y.tick : []\n",
+      dependency_sources: [
+        #(
+          "dep/x.gleam",
+          "import dep/y
+
+pub type Action =
+  fn() -> Nil
+
+@external(javascript, \"x\", \"r\")
+pub fn run(action: Action) -> Nil {
+  y.tick()
+  action()
+}
+",
+        ),
+        #(
+          "dep/y.gleam",
+          "import dep/x
+
+@external(javascript, \"y\", \"t\")
+pub fn tick() -> Nil {
+  x.run(fn() { Nil })
+}
+",
+        ),
+      ],
+    )
+  let assert Ok(results) = graded.run(root)
+  let assert Ok(r) =
+    list.find(results, fn(r) { r.file == root <> "/proj.gleam" })
+  ["direct", "via_operator"]
+  |> list.each(fn(function) {
+    let assert Ok(violation) =
+      list.find(r.violations, fn(v) { v.function == function })
+    violation.explanation.actual
+    |> should.equal(types.Specific(set.from_list(["Disk", "Time"])))
+  })
+  support.cleanup(root)
+}

--- a/test/signatures_test.gleam
+++ b/test/signatures_test.gleam
@@ -85,14 +85,14 @@ pub type Runner {
 }
 "
   let assert Ok(module) = glance.module(source)
-  signatures.fn_typed_fields_from_module(module, set.new())
+  signatures.fn_typed_fields_from_module(module, alias_map_of(module))
   |> should.equal(set.from_list([#("Runner", "run")]))
 }
 
 pub fn glance_detects_fn_typed_field_via_alias_test() {
   // A field declared through a module-local function alias (`run: Action` with
-  // `type Action = fn() -> Nil`) is callable, so it is recorded when the alias
-  // is in the resolved function-alias set.
+  // `type Action = fn() -> Nil`) is callable, so it is recorded — the alias is
+  // chased through the module's own alias map, as a parameter's is.
   let source =
     "
 pub type Action = fn() -> Nil
@@ -102,7 +102,7 @@ pub type Runner {
 }
 "
   let assert Ok(module) = glance.module(source)
-  signatures.fn_typed_fields_from_module(module, set.from_list(["Action"]))
+  signatures.fn_typed_fields_from_module(module, alias_map_of(module))
   |> should.equal(set.from_list([#("Runner", "run")]))
 }
 
@@ -116,7 +116,7 @@ pub type Wrapped {
 }
 "
   let assert Ok(module) = glance.module(source)
-  signatures.fn_typed_fields_from_module(module, set.new())
+  signatures.fn_typed_fields_from_module(module, alias_map_of(module))
   |> should.equal(set.new())
 }
 

--- a/test/signatures_test.gleam
+++ b/test/signatures_test.gleam
@@ -22,7 +22,10 @@ pub fn apply(f: fn(Int) -> Int, x: Int) -> Int {
 "
   let assert Ok(module) = glance.module(source)
   let assert [definition] = module.functions
-  signatures.fn_typed_params_from_function(definition.definition)
+  signatures.fn_typed_params_from_function(
+    definition.definition,
+    signatures.type_alias_map(module.type_aliases),
+  )
   |> should.equal(set.from_list(["f"]))
 }
 
@@ -35,7 +38,10 @@ pub fn greet(name: String) -> String {
 "
   let assert Ok(module) = glance.module(source)
   let assert [definition] = module.functions
-  signatures.fn_typed_params_from_function(definition.definition)
+  signatures.fn_typed_params_from_function(
+    definition.definition,
+    signatures.type_alias_map(module.type_aliases),
+  )
   |> should.equal(set.new())
 }
 
@@ -48,7 +54,10 @@ pub fn apply(f, x) {
 "
   let assert Ok(module) = glance.module(source)
   let assert [definition] = module.functions
-  signatures.fn_typed_params_from_function(definition.definition)
+  signatures.fn_typed_params_from_function(
+    definition.definition,
+    signatures.type_alias_map(module.type_aliases),
+  )
   |> should.equal(set.new())
 }
 
@@ -61,7 +70,10 @@ pub fn apply2(f: fn(Int) -> Int, g: fn(Int) -> Int, x: Int) -> Int {
 "
   let assert Ok(module) = glance.module(source)
   let assert [definition] = module.functions
-  signatures.fn_typed_params_from_function(definition.definition)
+  signatures.fn_typed_params_from_function(
+    definition.definition,
+    signatures.type_alias_map(module.type_aliases),
+  )
   |> should.equal(set.from_list(["f", "g"]))
 }
 
@@ -114,9 +126,7 @@ pub type Wrapped {
 // module-local aliases, keeping callback positions.
 
 fn alias_map_of(module: glance.Module) -> dict.Dict(String, glance.Type) {
-  list.fold(module.type_aliases, dict.new(), fn(acc, d) {
-    dict.insert(acc, d.definition.name, d.definition.aliased)
-  })
+  signatures.type_alias_map(module.type_aliases)
 }
 
 fn return_type_of(module: glance.Module, name: String) -> glance.Type {
@@ -216,6 +226,101 @@ pub fn make() -> foo.Resolver { todo }
   let map = alias_map_of(module)
   signatures.resolve_function_type(return_type_of(module, "make"), map)
   |> should.be_error()
+}
+
+// Alias-typed parameters in the registry
+//
+// A parameter spelled through a module-local `fn` alias is the callback its
+// underlying type says it is. The registry resolves it at every depth: the
+// parameter's own type, an alias of an alias, and the callback positions
+// inside an operator parameter's own argument list.
+
+fn params_of(
+  source: String,
+  function: String,
+) -> List(signatures.ParameterInfo) {
+  let assert Ok(module) = glance.module(source)
+  let assert Some(params) =
+    signatures.lookup(
+      signatures.from_glance_module("m", module),
+      QualifiedName(module: "m", function: function),
+    )
+  params
+}
+
+pub fn registry_reads_an_alias_typed_param_as_fn_typed_test() {
+  let assert [param] =
+    params_of(
+      "
+pub type Action = fn() -> Nil
+pub fn run(action: Action) -> Nil { action() }
+",
+      "run",
+    )
+  param.is_fn_typed |> should.be_true
+  param.is_annotated |> should.be_true
+  param.is_operator |> should.be_false
+  param.callback_positions |> should.equal([])
+}
+
+pub fn registry_reads_an_alias_of_an_alias_as_fn_typed_test() {
+  let assert [param] =
+    params_of(
+      "
+pub type Action = Runner
+pub type Runner = fn() -> Nil
+pub fn run(action: Action) -> Nil { action() }
+",
+      "run",
+    )
+  param.is_fn_typed |> should.be_true
+}
+
+pub fn registry_reads_an_alias_typed_operator_param_test() {
+  // Both layers are aliases: the parameter's own type, and the callback it
+  // takes. The callback position is read through the inner one.
+  let assert [param] =
+    params_of(
+      "
+pub type Callback = fn() -> Nil
+pub type Op = fn(Callback) -> Nil
+pub fn drive(op: Op) -> Nil { op(fn() { Nil }) }
+",
+      "drive",
+    )
+  param.is_fn_typed |> should.be_true
+  param.is_operator |> should.be_true
+  param.callback_positions |> should.equal([0])
+}
+
+pub fn registry_leaves_a_non_function_alias_first_order_test() {
+  let assert [param] =
+    params_of(
+      "
+pub type Id = Int
+pub fn keep(id: Id) -> Id { id }
+",
+      "keep",
+    )
+  param.is_fn_typed |> should.be_false
+  param.is_annotated |> should.be_true
+}
+
+pub fn operator_param_shapes_resolve_aliases_at_every_depth_test() {
+  // `op`'s type, its callback, and that callback's own callback are each
+  // spelled through an alias.
+  let source =
+    "
+pub type Inner = fn() -> Nil
+pub type Callback = fn(Inner) -> Nil
+pub type Op = fn(Callback) -> Nil
+pub fn drive(op: Op) -> Nil { todo }
+"
+  let assert Ok(module) = glance.module(source)
+  let assert Ok(definition) =
+    list.find(module.functions, fn(d) { d.definition.name == "drive" })
+  signatures.operator_param_shapes(definition.definition, alias_map_of(module))
+  |> should.equal(dict.from_list([#("op", [#(0, [0])])]))
 }
 
 // Parsing a dependency source tree


### PR DESCRIPTION
Stacked on #73 — review that one first; this PR's base is its branch.

`run(action: Action)` with `type Action = fn() -> Nil` takes a callback. `signatures.from_glance_module` matched `param.type_` against `FunctionType` directly, so the parameter registered as first-order: it missed `operator_param_names`, the argument lifted first-order, the application spine went stuck, and the call resolved `[Unknown]`.

The *shapes* were blind the same way — `operator_param_shapes` and the inner-type readers it calls also direct-matched, at every nesting depth. That is the worse half: an alias-typed second-order parameter could receive a bound from the widened name set and still be applied as though it took no callback, which discharged the argument and **under-charged** the caller. On the probe package `drive()` came out `[]` where it calls a `[Stdout]` function through two alias layers.

**The sets had to move together**, because the closedness oracle is the registry's fn-typed params ∪ the line's own bound list:

- the **registry** (`is_fn_typed`, `is_operator`, callback positions) resolves each parameter type through `resolve_function_type`;
- the **canonical helper** `unbound_fn_typed_params` gains the alias leg beside girard's — deterministic where girard is best-effort, so the bound stays where girard declines a function. Top-level inferred bounds, the local-call seed, the substitution and the lift all pick it up from #73's seam;
- `ordered_callback_param_names` takes the alias map as its own input, not through the `bound_names` hook — that hook is girard's, and this set must be right with no girard run;
- `operator_param_shapes` and `operator_callback_positions_of_type` resolve at every depth, so `type Action = fn(Callback) -> Nil` over `type Callback = fn() -> Nil` reads the same shape as the types written out;
- `build_scc_ids` converges on the canonical helper, deleting its inline triple union.

The two synthetic same-module registries built a one-function `glance.Module` with `type_aliases: []`, so an alias-aware `from_glance_module` would still have seen no aliases there. They now go through `signatures.from_single_function(module, definition, alias_map)`, which `from_glance_module` also delegates to — one resolution path, not two.

**Intended widening.** `signatures.callback_param_names` reads `is_fn_typed`, so an alias-typed callback now joins the conservative charge a boundless `assume` over an external makes. That is the fix, not a regression; a check that passed because the callback was spelled through an alias may now fail. Pinned by a test.

**Tests.** Registry unit cases (alias-typed parameter registers fn-typed; alias of an alias; alias-typed operator with the right callback position; a non-function alias stays first-order; shapes resolve at every depth). Integration: one package where the bound is written on the inferred line, the call site binds it beside the definition and from another module, the aliased second-order parameter keeps `[op([cb])]`, and the boundless declaration charges its aliased callback — plus a round-trip asserting the spec `infer` writes passes `check` with no violations or warnings. And a cyclic dependency whose callback is alias-typed: the unwalked summary now records it, so `direct` charges `[Disk, Time]` where it charged `[Time]` and `via_operator` `[Unknown]`.

Gates: `gleam format --check`, `gleam build --warnings-as-errors`, `gleam test` (1326 passed), `glinter`.

---

### Follow-up commit: `Derive the callback set once per module`

A cleanup pass over this branch found the "one computation" claim was only two-thirds true, and that the change had made two hot paths more expensive than what they replaced.

- The alias-aware "is this a callback" test was written in **five idioms** across `signatures` and `checker`. It is now one `signatures.ordered_callback_params`, which `fn_typed_params_from_function`, the registry's `is_fn_typed`, the lift path's ordered list and the field detection all read.
- `is_field_fn_typed` + `function_type_aliases` — a **second alias mechanism**, kept only for record fields — are deleted; fields resolve through `resolve_function_type` like parameters.
- `build_scc_ids` already derived the set for every function to decide collapsibility and threw it away. It keeps it in `LocalCache`, so `memoized_local`, `local_polymorphic_bounds` and the lift path are lookups rather than fresh signature walks — those two had gone from a plain pattern match to a cycle-guarded alias chase **per local call site**.
- `unbound_fn_typed_params` takes the cache instead of two dicts drawn out of that same cache, which also retires `FallbackWalk`'s duplicate girard map and `check_annotation`'s parameter for it. One fact, one channel.
- `callback_shape` resolved each argument's alias chain twice — once to filter, once to read positions. One pass does both, leaving `operator_callback_positions_of_type` with no callers.
- `lift_local_function` built its parameter list above three paths that never use it.

**Known, deliberately not fixed here:** `ordered_fn_typed_param_names`' two readers — the `Fresh | Closed` scoping bounds in `bind_producer_params` and `ordered_params` in `compute_returned_operator` — take the alias leg but not girard's, while the walk that produced the term they scope takes both. That is a behaviour question, not a cleanup, so it is left for review rather than changed silently.
