### PR TITLE
Track the piped argument into a function capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Piping into a function capture — `x |> f(_, y)` — now tracks the piped
+  value at the discard's position, with the discard's label, so a callback
+  reaching a parameter that way is charged to the caller. Such a call resolved
+  nothing about its arguments, which read as pure where the callee's effects
+  are its callback's. Every callee shape is covered: qualified, unqualified,
+  and a nested field access.
 - A call from inside a walked fallback body to an external declared for the
   walk's targets now charges its callback arguments beside the declaration,
   instead of the declaration alone.

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -2035,8 +2035,113 @@ fn extract_pipe_target(
     glance.Case(location: span, ..) ->
       pipe_into_operator_value(expression, span, context, env, pipe_args)
 
+    // `value |> f(a, _, b)` — a function capture as the pipe target, which is
+    // `f(a, value, b)`: the piped value takes the discard's position and the
+    // explicit arguments keep theirs on either side of it.
+    glance.FnCapture(
+      location: span,
+      label:,
+      function: function_expression,
+      arguments_before:,
+      arguments_after:,
+    ) -> {
+      let discard = list.length(arguments_before)
+      // The discard's own label rides with the piped value. Inserting it
+      // unlabelled mis-binds a call site writing its labelled arguments in
+      // another order than the callee declares them.
+      let piped =
+        list.map(pipe_args, fn(argument) {
+          CallArgument(..argument, position: discard, label:)
+        })
+      let args =
+        list.flatten([
+          classify_arguments(arguments_before, context, env, 0),
+          piped,
+          classify_arguments(arguments_after, context, env, discard + 1),
+        ])
+      let arguments =
+        merge(
+          extract_from_arguments(arguments_before, context, env),
+          extract_from_arguments(arguments_after, context, env),
+        )
+      pipe_into_capture(
+        function_expression,
+        span,
+        context,
+        env,
+        arguments,
+        args,
+      )
+    }
+
     // Any other shape — handle normally; no arg tracking.
     _ -> extract_from_expression(expression, context, env)
+  }
+}
+
+// The callee half of a piped function capture, by the shape the capture names:
+// qualified (`x |> m.f(_, y)`), a nested field access (`x |> o.inner.run(_)`),
+// or unqualified (`x |> f(_, y)`) — the same three the ordinary pipe branches
+// resolve. `arguments` is the walk of the capture's explicit arguments, and
+// `args` the full argument list with the piped value already at the discard's
+// position. Any other callee shape names nothing to key the call by, so the
+// capture's parts are walked as values.
+fn pipe_into_capture(
+  function_expression: Expression,
+  span: glance.Span,
+  context: ImportContext,
+  env: Env,
+  arguments: ExtractResult,
+  args: List(CallArgument),
+) -> ExtractResult {
+  case function_expression {
+    glance.FieldAccess(
+      container: glance.Variable(receiver_span, alias),
+      label: function_name,
+      ..,
+    ) ->
+      merge_with_args(
+        resolve_qualified_call(
+          alias,
+          function_name,
+          span,
+          receiver_span,
+          context,
+          env,
+        ),
+        arguments,
+        span,
+        args,
+      )
+
+    glance.FieldAccess(container: receiver, label: function_name, ..) ->
+      merge_with_args(
+        resolve_nested_field_call(
+          receiver,
+          function_name,
+          span,
+          receiver.location,
+          context,
+          env,
+        ),
+        merge(extract_from_expression(receiver, context, env), arguments),
+        span,
+        args,
+      )
+
+    glance.Variable(name:, ..) ->
+      merge_with_args(
+        resolve_variable_call(name, span, context, env),
+        arguments,
+        span,
+        args,
+      )
+
+    _ ->
+      merge(
+        extract_from_expression(function_expression, context, env),
+        arguments,
+      )
   }
 }
 

--- a/src/graded/internal/extract.gleam
+++ b/src/graded/internal/extract.gleam
@@ -2064,14 +2064,10 @@ fn extract_pipe_target(
           extract_from_arguments(arguments_before, context, env),
           extract_from_arguments(arguments_after, context, env),
         )
-      pipe_into_capture(
-        function_expression,
-        span,
-        context,
-        env,
-        arguments,
-        args,
-      )
+      piped_call(function_expression, span, context, env, arguments, args)
+      |> result.lazy_unwrap(fn() {
+        extract_from_expression(expression, context, env)
+      })
     }
 
     // Any other shape — handle normally; no arg tracking.
@@ -2079,28 +2075,30 @@ fn extract_pipe_target(
   }
 }
 
-// The callee half of a piped function capture, by the shape the capture names:
-// qualified (`x |> m.f(_, y)`), a nested field access (`x |> o.inner.run(_)`),
-// or unqualified (`x |> f(_, y)`) — the same three the ordinary pipe branches
-// resolve. `arguments` is the walk of the capture's explicit arguments, and
-// `args` the full argument list with the piped value already at the discard's
-// position. Any other callee shape names nothing to key the call by, so the
-// capture's parts are walked as values.
-fn pipe_into_capture(
-  function_expression: Expression,
+// The callee half of a piped call, by the shape the target names: qualified
+// (`x |> m.f(y)`), a nested field access (`x |> o.inner.run(y)`), or
+// unqualified (`x |> f(y)`). `arguments` is the walk of the explicit
+// arguments, and `args` the full argument list with the piped value already at
+// its position — which is what differs between an ordinary pipe, where it
+// leads, and a capture, where it takes the discard's place.
+//
+// `Error(Nil)` where the callee is none of the three, so each caller keeps its
+// own fallback for a target that names nothing to key a call by.
+fn piped_call(
+  callee: Expression,
   span: glance.Span,
   context: ImportContext,
   env: Env,
   arguments: ExtractResult,
   args: List(CallArgument),
-) -> ExtractResult {
-  case function_expression {
+) -> Result(ExtractResult, Nil) {
+  case callee {
     glance.FieldAccess(
       container: glance.Variable(receiver_span, alias),
       label: function_name,
       ..,
     ) ->
-      merge_with_args(
+      Ok(merge_with_args(
         resolve_qualified_call(
           alias,
           function_name,
@@ -2112,10 +2110,10 @@ fn pipe_into_capture(
         arguments,
         span,
         args,
-      )
+      ))
 
     glance.FieldAccess(container: receiver, label: function_name, ..) ->
-      merge_with_args(
+      Ok(merge_with_args(
         resolve_nested_field_call(
           receiver,
           function_name,
@@ -2127,21 +2125,17 @@ fn pipe_into_capture(
         merge(extract_from_expression(receiver, context, env), arguments),
         span,
         args,
-      )
+      ))
 
     glance.Variable(name:, ..) ->
-      merge_with_args(
+      Ok(merge_with_args(
         resolve_variable_call(name, span, context, env),
         arguments,
         span,
         args,
-      )
+      ))
 
-    _ ->
-      merge(
-        extract_from_expression(function_expression, context, env),
-        arguments,
-      )
+    _ -> Error(Nil)
   }
 }
 

--- a/test/extract_test.gleam
+++ b/test/extract_test.gleam
@@ -1,6 +1,8 @@
 import glance
 import gleam/dict
+import gleam/int
 import gleam/list
+import gleam/option.{None, Some}
 import gleam/set.{type Set}
 import gleeunit/should
 import graded/internal/extract
@@ -392,6 +394,89 @@ pub fn target() { \"hi\" |> println }"
   result.resolved
   |> list.map(fn(r) { r.name })
   |> should.equal([QualifiedName("gleam/io", "println")])
+}
+
+// Pipes into a function capture
+//
+// `x |> f(_, y)` is `f(x, y)`: the piped value takes the discard's position,
+// carries the discard's label, and the callee is resolved by the shape the
+// capture names.
+
+// The arguments recorded for the one resolved call `src`'s `target` makes,
+// as `#(position, label, value)` in position order.
+fn captured_args(
+  src: String,
+) -> List(#(Int, option.Option(String), types.ArgumentValue)) {
+  let result = parse_and_extract(src)
+  let assert [call] = result.resolved
+  let assert Ok(args) = dict.get(result.call_args, extract.span_key(call.span))
+  args
+  |> list.sort(fn(a, b) { int.compare(a.position, b.position) })
+  |> list.map(fn(arg) { #(arg.position, arg.label, arg.value) })
+}
+
+pub fn pipe_into_capture_at_position_zero_test() {
+  captured_args(
+    "import gleam/io
+import helper
+pub fn target() { io.println |> helper.apply(_, 1) }",
+  )
+  |> should.equal([
+    #(0, None, FunctionRef(QualifiedName("gleam/io", "println"))),
+    #(1, None, OtherExpression),
+  ])
+}
+
+pub fn pipe_into_capture_at_a_later_position_test() {
+  captured_args(
+    "import gleam/io
+import helper
+pub fn target() { io.println |> helper.apply(1, _) }",
+  )
+  |> should.equal([
+    #(0, None, OtherExpression),
+    #(1, None, FunctionRef(QualifiedName("gleam/io", "println"))),
+  ])
+}
+
+pub fn pipe_into_a_labelled_capture_test() {
+  // The labelled arguments are written in the other order than the callee
+  // declares them, so only the label the discard carries binds it correctly.
+  captured_args(
+    "import gleam/io
+import helper
+pub fn target() { io.println |> helper.apply(times: 1, callback: _) }",
+  )
+  |> should.equal([
+    #(0, Some("times"), OtherExpression),
+    #(1, Some("callback"), FunctionRef(QualifiedName("gleam/io", "println"))),
+  ])
+}
+
+pub fn pipe_into_a_local_capture_test() {
+  let result =
+    parse_and_extract(
+      "import gleam/io
+pub fn target() { io.println |> helper(_, 1) }",
+    )
+  let assert [call] = result.local
+  call.function |> should.equal("helper")
+  let assert Ok(args) = dict.get(result.call_args, extract.span_key(call.span))
+  let assert Ok(piped) = list.find(args, fn(a) { a.position == 0 })
+  piped.value |> should.equal(FunctionRef(QualifiedName("gleam/io", "println")))
+}
+
+pub fn pipe_into_a_nested_field_capture_test() {
+  let result =
+    parse_and_extract(
+      "import gleam/io
+pub fn target(o) { io.println |> o.inner.run(_, 1) }",
+    )
+  let assert [call] = result.field
+  call.label |> should.equal("run")
+  let assert Ok(args) = dict.get(result.call_args, extract.span_key(call.span))
+  let assert Ok(piped) = list.find(args, fn(a) { a.position == 0 })
+  piped.value |> should.equal(FunctionRef(QualifiedName("gleam/io", "println")))
 }
 
 pub fn closure_test() {

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -11806,3 +11806,121 @@ pub fn helper() -> Nil {
   |> should.be_true
   support.cleanup(root)
 }
+
+// Pipes into a function capture
+//
+// `x |> f(_, y)` is `f(x, y)`, so the piped value binds the parameter at the
+// discard's position — a callback among them. Every callee shape the ordinary
+// pipe branches resolve is covered, and a receiver nothing traces reads the
+// `[Unknown]` the direct call reads rather than passing for pure.
+
+fn pipe_capture_project(root: String) -> List(types.EffectAnnotation) {
+  let _ = simplifile.delete(root)
+  let assert Ok(Nil) = simplifile.create_directory_all(root)
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/gleam.toml", "name = \"proj\"\n")
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/ffi.gleam",
+      support.foreign_fn("shout", "() -> Nil"),
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/helper.gleam",
+      "pub type Inner {
+  Inner(run: fn(fn() -> Nil, Int) -> Nil)
+}
+
+pub type Outer {
+  Outer(inner: Inner)
+}
+
+pub fn apply(cb: fn() -> Nil, n: Int) -> Nil {
+  case n {
+    0 -> Nil
+    _ -> cb()
+  }
+}
+
+pub fn labelled(callback cb: fn() -> Nil, times n: Int) -> Nil {
+  apply(cb, n)
+}
+",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(
+      root <> "/proj.gleam",
+      "import ffi
+import helper
+
+pub fn shout() -> Nil {
+  ffi.shout()
+}
+
+fn local(cb: fn() -> Nil, n: Int) -> Nil {
+  helper.apply(cb, n)
+}
+
+pub fn discard_first() -> Nil {
+  shout |> helper.apply(_, 1)
+}
+
+pub fn discard_later() -> Nil {
+  1 |> helper.apply(shout, _)
+}
+
+pub fn discard_labelled() -> Nil {
+  shout |> helper.labelled(times: 1, callback: _)
+}
+
+pub fn discard_local() -> Nil {
+  shout |> local(_, 1)
+}
+
+pub fn discard_nested_field(o: helper.Outer) -> Nil {
+  shout |> o.inner.run(_, 1)
+}
+
+pub fn nested_field_direct(o: helper.Outer) -> Nil {
+  o.inner.run(shout, 1)
+}
+",
+    )
+  let assert Ok(Nil) =
+    simplifile.write(root <> "/proj.graded", "assume ffi.shout : [Stdout]\n")
+  let assert Ok(Nil) = graded.run_infer(root)
+  let assert Ok(content) = simplifile.read(root <> "/proj.graded")
+  let assert Ok(file) = annotation.parse_file(content)
+  annotation.extract_annotations(file)
+}
+
+fn effects_named(
+  annotations: List(types.EffectAnnotation),
+  function: String,
+) -> types.EffectTerm {
+  let assert Ok(annotation) =
+    list.find(annotations, fn(a) { a.function == function })
+  annotation.effects
+}
+
+pub fn piping_into_a_capture_binds_the_callback_test() {
+  let root = "build/pipe_capture_project"
+  let annotations = pipe_capture_project(root)
+  let stdout = types.TLabels(set.from_list(["Stdout"]))
+
+  [
+    "proj.discard_first",
+    "proj.discard_later",
+    "proj.discard_labelled",
+    "proj.discard_local",
+  ]
+  |> list.each(fn(function) {
+    effects_named(annotations, function) |> should.equal(stdout)
+  })
+
+  // A receiver with no traceable construction resolves the same way it does
+  // without the capture — conservatively, not as pure.
+  effects_named(annotations, "proj.discard_nested_field")
+  |> should.equal(effects_named(annotations, "proj.nested_field_direct"))
+  support.cleanup(root)
+}


### PR DESCRIPTION
`x |> f(_, y)` means `f(x, y)`. The right-hand side is a `glance.FnCapture`, which had no branch in `extract_pipe_target` and fell to its catch-all ("no arg tracking"): the capture was walked as a value and the piped value attached to no call at all. Nothing bound the parameter at the discard's position, so a callback reaching a parameter that way charged its caller nothing — and where the callee's whole effect *is* its callback's, the caller read as **pure**. On the probe package every capture shape inferred `[]` for a caller passing a `[Stdout]` function; they now infer `[Stdout]`.

**The change.** A `FnCapture` branch rebuilds the argument list as `arguments_before ++ [piped] ++ arguments_after`, classified with the right index offsets, and routes through the same call construction the other pipe branches use.

- **The discard's label rides with the piped value.** `FnCapture` carries a `label` for the discarded argument (`x |> f(callback: _)`), and inserting the argument with `None` mis-binds a call site that writes its labelled arguments in another order than the callee declares them.
- **All three callee shapes**, the same ones the ordinary `Call` pipe branches resolve: qualified (`m.f(_, y)`), nested field access (`x |> o.inner.run(_, y)`), and unqualified (`f(_, y)`). Covering only the first and last would recreate the lost-argument bug for the field shape this codebase treats as first-class everywhere else. Any other callee shape names nothing to key the call by, so the capture's parts stay walked as values.

**Tests.** Extract cases pinning the recorded argument list for a discard at position 0, at a later position, and labelled with the labelled arguments written out of declaration order, plus the local and nested-field callee shapes. An integration case where all four resolvable shapes now charge `[Stdout]`, and where the nested-field capture resolves to exactly what the direct call `o.inner.run(shout, 1)` resolves to on an untraceable receiver — conservative, rather than passing for pure.

Gates: `gleam format --check`, `gleam build --warnings-as-errors`, `gleam test` (1323 passed), `glinter`.

---

### Follow-up commit: `Resolve every piped callee through one dispatch`

The capture branch spelled the qualified / nested-field / unqualified callee dispatch a second time, beside the three `glance.Call` branches that already had it — a third copy of a shape `extract_from_expression` also carries.

Both now call `piped_call`, which answers `Error(Nil)` for a callee shape it does not name, so each caller keeps its own fallback (the whole pipe expression, walked as a value — which is what both did before, and is identical for a capture since `extract_from_expression` on one walks exactly the callee plus both argument lists). The three `Call` branches collapse into one. What differs between an ordinary pipe and a capture is only the argument list the caller assembles — the piped value leads in one and takes the discard's place in the other — so that is what gets passed in.

Net −6 lines, and a fourth callee shape now lands in one place instead of two.

**Deliberately not done:** desugaring the capture into the `glance.Call` it means, so it re-enters the general dispatch. That would also route an unnamed callee through `extract_expression_call`, which models the application (`DirectOperatorCall` / `unknown_apps`) where the pipe path drops it — a behaviour change, and out of scope for a cleanup.
