### PR TITLE
Define every public type in graded itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Lint
         run: gleam run -m glinter
+
+      - name: Public API names no internal type
+        run: python3 scripts/check_public_interface.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Sixteen modules, no circular dependencies. Only `src/graded.gleam` is the public
 
 | File | Responsibility |
 |---|---|
-| `src/graded.gleam` | CLI entry point + public API: orchestrate `run_infer` (write spec + cache), `run_infer_dry_run` (preview it), `run` (check the spec against source), `run_effect` (look up one name, read-only) and `run_pack` (inject the spec into the hex tarball); run girard type inference; scan dependency sources once into the signature registry and the update-builder map |
+| `src/graded.gleam` | CLI entry point + public API: orchestrate `run_infer` (write spec + cache), `run_infer_dry_run` (preview it), `run` (check the spec against source), `run_effect` (look up one name, read-only) and `pack_project` (inject the spec into the hex tarball); run girard type inference; scan dependency sources once into the signature registry and the update-builder map. Every type the public API names is defined here — nothing under `graded/internal` is part of it, and `scripts/check_public_interface.py` gates that |
 | `src/graded/internal/cli.gleam` | Pure command-line argument decoders for `main`'s dispatch branches |
 | `src/graded/internal/answer.gleam` | One `graded effect` lookup held as data (`EffectAnswer`), plus the prose and `.graded` renderers over it |
 | `src/graded/internal/types.gleam` | Shared types: QualifiedName, EffectSet, EffectTerm, EffectAnnotation, ParamBound, FieldCall, TypeFieldAnnotation, Violation |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (library API).** Every type graded's public functions name is now
+  defined in the `graded` module, so linking against it never means importing
+  `graded/internal`. A CI gate holds the boundary.
+
+  - `run` returns `List(ModuleReport)` — per module, its path and the warning
+    and violation lines graded prints for it — instead of
+    `List(types.CheckResult)`. The structured results are `@internal`.
+  - `run_effect_formatted` takes `graded.Graded` / `graded.Prose` instead of
+    `answer.Format`.
+  - `run_catalog` is replaced by `catalog_list()` and
+    `catalog_show(package, version, directory)`; it no longer takes
+    `cli.CatalogRequest`.
+  - `run_format_stdin` returns `Result(String, GradedError)`, with a parse
+    failure as `GradedParseError("<stdin>", message)`, instead of
+    `Result(String, annotation.ParseError)`.
+  - `GradedError`'s `GradedParseError` and `InvalidConfig` carry the rendered
+    cause as a `String` instead of `annotation.ParseError` and
+    `config.ConfigError`. `InvalidConfig` now says what was wrong with the
+    manifest, where it named only the path.
+  - `infer_path_dep` and `run_effect_from_project` are `@internal`.
+
+  The CLI is unchanged: every command prints exactly what it printed before.
 - An `assume` line over your own or a dependency's `@external` now answers
   alone even where a Gleam fallback body runs; previously the body's effects
   were unioned into what callers pay. Explanations quote the suppressed half,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,18 +29,25 @@ is per-clone, so the `git config` line above is needed once after cloning.
 
 ## Pre-flight checklist
 
-CI runs four gates, in this order. Run them locally before pushing — green here
+CI runs five gates, in this order. Run them locally before pushing — green here
 means green on CI:
 
 ```sh
-gleam format --check src/ test/    # formatting (test/ too, not just src/)
-gleam build --warnings-as-errors   # no warnings allowed
-gleam test                         # full suite
-gleam run -m glinter               # lint (warnings are errors)
+gleam format --check src/ test/          # formatting (test/ too, not just src/)
+gleam build --warnings-as-errors         # no warnings allowed
+gleam test                               # full suite
+gleam run -m glinter                     # lint (warnings are errors)
+python3 scripts/check_public_interface.py  # public API names no internal type
 ```
 
 `gleam format src/ test/` (no `--check`) fixes formatting in place. Lint rules and
 the `warnings_as_errors` setting live under `[tools.glinter]` in `gleam.toml`.
+
+The last gate walks the package interface Gleam exports and fails if anything a
+consumer can name — a parameter, a return type, a variant field — resolves to a
+`graded/internal` module. Everything the public API names is defined in
+`src/graded.gleam`; a function that exists only for graded's own tests is marked
+`@internal`, which keeps it out of the interface entirely.
 
 ## Adding a catalog entry
 

--- a/scripts/check_public_interface.py
+++ b/scripts/check_public_interface.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Assert graded's public API names no `graded/internal` type.
+
+A `pub fn` name allowlist cannot see an allowed function acquiring an internal
+parameter or return type, and the package's own build happily imports its own
+internals — so this inspects what a *consumer* sees: the package interface
+Gleam exports, walked for every type reference in the `graded` module.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+INTERNAL_PREFIX = "graded/internal"
+
+
+def type_references(node, path):
+    """Yield (path, module) for every named type reference under `node`."""
+    if isinstance(node, dict):
+        module = node.get("module")
+        if node.get("kind") == "named" and isinstance(module, str):
+            yield path, module
+        for key, value in node.items():
+            # Documentation is prose, not a type reference.
+            if key in ("documentation", "deprecation"):
+                continue
+            yield from type_references(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from type_references(value, f"{path}[{index}]")
+
+
+def main():
+    with tempfile.TemporaryDirectory() as directory:
+        out = Path(directory) / "interface.json"
+        subprocess.run(
+            ["gleam", "export", "package-interface", "--out", str(out)],
+            check=True,
+        )
+        interface = json.loads(out.read_text())
+
+    module = interface["modules"].get("graded")
+    if module is None:
+        sys.exit("no `graded` module in the exported package interface")
+
+    leaks = sorted(
+        {
+            f"{path}: {referenced}"
+            for path, referenced in type_references(module, "graded")
+            if referenced.startswith(INTERNAL_PREFIX)
+        }
+    )
+    if leaks:
+        print("graded's public API names internal types:", file=sys.stderr)
+        for leak in leaks:
+            print(f"  {leak}", file=sys.stderr)
+        sys.exit(1)
+
+    print("graded's public API names no graded/internal type")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -832,7 +832,7 @@ fn native_functions_of(
 fn declaring_externals(
   spec: GradedFile,
   stale: Set(String),
-) -> List(types.ExternalAnnotation) {
+) -> List(types.AssumeAnnotation) {
   annotation.extract_externals(spec)
   |> list.filter(fn(external) {
     case annotation.external_qualified_name(external) {
@@ -1486,7 +1486,7 @@ fn function_effect(
     effects.Unknown -> Error(Nil)
     // Which map answered is reported by the lookup itself, so the recorded
     // source can't disagree with the term beside it.
-    effects.Known(term, types.ModuleExternalEntry(origin:)) ->
+    effects.Known(term, types.ModuleAssumeEntry(origin:)) ->
       Ok(answer.FunctionAnswer(
         name:,
         module:,
@@ -1497,7 +1497,7 @@ fn function_effect(
         // in no other.
         bounds: effects.lookup_param_bounds(knowledge_base, qualified),
         term:,
-        source: answer.Entry(types.ModuleExternalEntry(origin:), fallback:),
+        source: answer.Entry(types.ModuleAssumeEntry(origin:), fallback:),
       ))
     effects.Known(term, types.FunctionEntry(origin:)) ->
       Ok(answer.FunctionAnswer(
@@ -3816,7 +3816,7 @@ fn with_spec_externals(
   effects.with_externals(
     knowledge_base,
     declaring_externals(spec, stale_externals),
-    types.UserExternal,
+    types.UserAssume,
   )
 }
 
@@ -3833,7 +3833,7 @@ fn with_spec_declared_returns(
     knowledge_base,
     effects.load_spec_external_returns_from_file(spec)
       |> drop_stale_names(stale_returns_clauses),
-    types.UserExternal,
+    types.UserAssume,
   )
 }
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -21,14 +21,18 @@
 ////
 //// ## Programmatic API
 ////
-//// Use `run` to check a directory and get back a list of `CheckResult` values,
-//// each containing any violations found per file. Use `run_infer` to infer
-//// effects and write `.graded` files, or `run_infer_dry_run` to get back a
-//// diff of what that write would change without performing it. Use
-//// `run_effect` to resolve one function or type-field name and get its
-//// `.graded` line back, `run_why` to get the effects of one function explained
-//// call by call, or `run_catalog` to read graded's own bundled catalog — none
-//// of them touching anything on disk.
+//// Use `run` to check a directory and get back one `ModuleReport` per file,
+//// carrying the warning and violation lines graded prints for it. Use
+//// `run_infer` to infer effects and write `.graded` files, or
+//// `run_infer_dry_run` to get back a diff of what that write would change
+//// without performing it. Use `run_effect` to resolve one function or
+//// type-field name and get its `.graded` line back, `run_why` to get the
+//// effects of one function explained call by call, or `catalog_list` /
+//// `catalog_show` to read graded's own bundled catalog — none of them
+//// touching anything on disk.
+////
+//// Every type this module's signatures name is defined here. Nothing under
+//// `graded/internal` is part of the API, and a release may change it freely.
 ////
 
 import argv
@@ -61,8 +65,8 @@ import graded/internal/topo
 import graded/internal/typeinfo
 import graded/internal/types.{
   type CheckResult, type EffectAnnotation, type EffectTerm, type GradedFile,
-  type QualifiedName, type Violation, type Warning, AnnotationLine, CheckResult,
-  EffectAnnotation, GradedFile, QualifiedName,
+  type QualifiedName, AnnotationLine, CheckResult, EffectAnnotation, GradedFile,
+  QualifiedName,
 }
 import simplifile
 
@@ -72,6 +76,10 @@ import simplifile
 // to the per-command runners below.
 
 /// Errors that can occur during checking, inference, or formatting.
+///
+/// Every variant is renderable on its own: where the cause is a graded type,
+/// the variant carries what graded would print for it rather than the type
+/// itself, so naming an error never means importing `graded/internal`.
 pub type GradedError {
   /// Could not read the source directory.
   DirectoryReadError(path: String, cause: simplifile.FileError)
@@ -83,11 +91,13 @@ pub type GradedError {
   DirectoryCreateError(path: String, cause: simplifile.FileError)
   /// A `.gleam` source file could not be parsed.
   GleamParseError(path: String, cause: glance.Error)
-  /// A `.graded` annotation file could not be parsed.
-  GradedParseError(path: String, cause: annotation.ParseError)
+  /// A `.graded` annotation file could not be parsed. `message` is the
+  /// description graded itself prints, line number and hint included.
+  GradedParseError(path: String, message: String)
   /// `gleam.toml` was present but malformed, or missing its `name`. A missing
-  /// `gleam.toml` is tolerated and does not produce this error.
-  InvalidConfig(path: String, cause: config.ConfigError)
+  /// `gleam.toml` is tolerated and does not produce this error. `message`
+  /// describes what was wrong with it.
+  InvalidConfig(path: String, message: String)
   /// One or more `.graded` files are not formatted (returned by `run_format_check`).
   FormatCheckFailed(paths: List(String))
   /// The project's import graph contains a cycle. Gleam disallows circular
@@ -137,13 +147,11 @@ pub fn main() -> Nil {
     ["format", "--stdin"] ->
       case run_format_stdin(read_stdin()) {
         Ok(output) -> io.print(output)
-        Error(error) -> {
-          io.println_error(
-            "graded: error: parse error in stdin:"
-            <> annotation.describe_parse_error(error),
-          )
+        Error(GradedParseError(message:, ..)) -> {
+          io.println_error("graded: error: parse error in stdin:" <> message)
           halt(1)
         }
+        Error(error) -> fail(error)
       }
 
     ["format", "--check", ..rest] ->
@@ -175,7 +183,7 @@ pub fn main() -> Nil {
     ["effect", ..rest] ->
       report(cli.parse_effect_args(rest), fn(arguments) {
         let #(name, directory, format) = arguments
-        run_effect_formatted(directory, name, format)
+        run_effect_formatted(directory, name, public_format(format))
       })
 
     ["why", ..rest] ->
@@ -411,13 +419,52 @@ fn pack_error(problem: pack.PackProblem) -> GradedError {
 // The `check` command: assemble the knowledge base for the project, run the
 // checker over each source file, and collect violations and warnings.
 
+/// What checking one file found, as the lines graded prints for it.
+///
+/// Both halves, because both are what a caller acts on: the CLI prints the
+/// warnings with their count and the violations with theirs, and exits on the
+/// violations alone. A count is `list.length` of the list.
+pub type ModuleReport {
+  ModuleReport(
+    /// The source file these results belong to — the spec file, for the
+    /// warnings a spec line earns on its own.
+    file: String,
+    /// One rendered line per warning, in the order graded reports them.
+    warnings: List(String),
+    /// One rendered line per violation, likewise.
+    violations: List(String),
+  )
+}
+
 /// Run the checker on all .gleam files in a directory.
 ///
 /// Reads the project's single spec file (default `<package_name>.graded`)
-/// to find inferred public-API effects, `check` invariants, `external`
-/// hints, and `type` field annotations, then reports violations per source
-/// file.
-pub fn run(directory: String) -> Result(List(CheckResult), GradedError) {
+/// to find inferred public-API effects, `check` invariants, `assume`
+/// declarations, and field annotations, then reports one `ModuleReport` per
+/// source file, plus one for the spec file itself where a spec line is dead.
+pub fn run(directory: String) -> Result(List(ModuleReport), GradedError) {
+  check_project(directory) |> result.map(list.map(_, module_report))
+}
+
+// One file's results, rendered exactly as the CLI prints them.
+fn module_report(result: CheckResult) -> ModuleReport {
+  ModuleReport(
+    file: result.file,
+    warnings: list.map(result.warnings, checker.format_warning(result.file, _)),
+    violations: list.map(result.violations, checker.format_violation(
+      result.file,
+      _,
+    )),
+  )
+}
+
+// The same run, keeping the structured results. `why` and graded's own tests
+// read the resolution behind a violation; a caller linking against the module
+// gets the rendered form, so the structured types stay free to change.
+@internal
+pub fn check_project(
+  directory: String,
+) -> Result(List(CheckResult), GradedError) {
   use ctx <- result.try(load_project_context(directory))
   let ProjectContext(sources:, registry:, type_info:, knowledge_base:, ..) = ctx
   let ProjectSources(
@@ -957,20 +1004,43 @@ pub fn run_effect(
   directory: String,
   name: String,
 ) -> Result(String, GradedError) {
-  run_effect_formatted(directory, name, answer.Graded)
+  run_effect_formatted(directory, name, Graded)
 }
 
-/// Look up one name's effect and render it in `format`: `answer.Graded` for
-/// the `.graded` line above, `answer.Prose` for sentences describing the same
-/// answer. Both render one structured answer, so they can differ in wording but
-/// never in what they report.
+/// How `run_effect_formatted` renders an answer.
+pub type Format {
+  /// A `.graded` line, with any provenance as a `//` comment — the whole
+  /// output parses as spec syntax.
+  Graded
+  /// Sentences describing the same answer, as `graded effect` prints them.
+  Prose
+}
+
+/// Look up one name's effect and render it in `format`. Both formats render
+/// one structured answer, so they can differ in wording but never in what they
+/// report.
 pub fn run_effect_formatted(
   directory: String,
   name: String,
-  format: answer.Format,
+  format: Format,
 ) -> Result(String, GradedError) {
   effect_answer(directory, name)
-  |> result.map(answer.render(_, format))
+  |> result.map(answer.render(_, answer_format(format)))
+}
+
+// And back, for the CLI's own decoder, which reads the internal enum.
+fn public_format(format: answer.Format) -> Format {
+  case format {
+    answer.Graded -> Graded
+    answer.Prose -> Prose
+  }
+}
+
+fn answer_format(format: Format) -> answer.Format {
+  case format {
+    Graded -> answer.Graded
+    Prose -> answer.Prose
+  }
 }
 
 // Resolve `name` to a structured answer, trying the spec-only fast path first.
@@ -995,6 +1065,7 @@ fn effect_answer(
 /// Exposed (pub) primarily so a test can assert the two paths agree. A
 /// fast-path answer is only correct if it is what the full context would have
 /// said, byte for byte; nothing else about the two is allowed to differ.
+@internal
 pub fn run_effect_from_project(
   directory: String,
   name: String,
@@ -1661,19 +1732,32 @@ fn why_block(
 // listing marks the file each installed package resolves to; the show forms
 // print one file verbatim under a header naming it and why it was chosen.
 
-/// List the bundled catalog, or print one bundled catalog file.
-///
-/// `ListCatalog` prints one `package@version` line per bundled file, sorted,
-/// with a comment on the line each of this project's installed packages
-/// resolves to. `ShowCatalog` prints one file: at the version this project
-/// installs, or at the version the request names, under a `//` header line that
-/// says which file it is and why — so the output is itself a valid `.graded`
-/// file.
+/// List the bundled catalog: one `package@version` line per bundled file,
+/// sorted, with a comment on the line each installed package of the project
+/// the process runs in resolves to.
 ///
 /// This is graded's bundled catalog alone: a dependency's shipped spec, a path
-/// dependency's spec and your own `assume` all override it, so
-/// `run_effect` is what answers which source wins for a name. Nothing is
-/// written to disk.
+/// dependency's spec and your own `assume` all override it, so `run_effect` is
+/// what answers which source wins for a name. Nothing is written to disk.
+pub fn catalog_list() -> Result(String, GradedError) {
+  run_catalog(cli.ListCatalog)
+}
+
+/// Print one bundled catalog file for `package`, under a `//` header line
+/// saying which file it is and why — so the output is itself a valid `.graded`
+/// file. `version` names a bundled version exactly; `None` selects the one
+/// `directory`'s project installs. Nothing is written to disk.
+pub fn catalog_show(
+  package: String,
+  version: option.Option(String),
+  directory: String,
+) -> Result(String, GradedError) {
+  run_catalog(cli.ShowCatalog(package:, version:, directory:))
+}
+
+// The two forms behind `catalog_list` and `catalog_show`, over the CLI's own
+// decoded request so `main` dispatches without rebuilding it.
+@internal
 pub fn run_catalog(request: cli.CatalogRequest) -> Result(String, GradedError) {
   use manifest <- result.try(case request {
     // The listing takes no directory of its own, so it walks up from the one
@@ -1926,12 +2010,11 @@ pub fn run_format(directory: String) -> Result(Nil, GradedError) {
 
 /// Format a `.graded` spec given as a string, as `graded format --stdin` does
 /// for editor integration: parse the input, then sort and reformat it. Returns
-/// the input's parse error if it doesn't parse.
-pub fn run_format_stdin(
-  input: String,
-) -> Result(String, annotation.ParseError) {
-  use file <- result.map(annotation.parse_file(input))
-  annotation.format_sorted(file)
+/// a `GradedParseError` naming `<stdin>` if the input doesn't parse.
+pub fn run_format_stdin(input: String) -> Result(String, GradedError) {
+  annotation.parse_file(input)
+  |> result.map(annotation.format_sorted)
+  |> result.map_error(graded_parse_error("<stdin>", _))
 }
 
 /// Check that the project's spec file is already formatted. Returns error
@@ -1963,7 +2046,7 @@ fn format_one_spec(
     Ok(content) ->
       annotation.parse_file(content)
       |> result.map(fn(file) { Some(annotation.format_sorted(file)) })
-      |> result.map_error(GradedParseError(spec_path, _))
+      |> result.map_error(graded_parse_error(spec_path, _))
   }
 }
 
@@ -2900,7 +2983,11 @@ fn read_config(directory: String) -> Result(config.GradedConfig, GradedError) {
     // Missing gleam.toml: fall back to defaults. Malformed gleam.toml: error.
     Error(config.TomlReadError(..)) ->
       Ok(config.defaults_for(default_package_name(project_root)))
-    Error(cause) -> Error(InvalidConfig(path: toml_path, cause:))
+    Error(cause) ->
+      Error(InvalidConfig(
+        path: toml_path,
+        message: config.describe_error(cause),
+      ))
   })
   Ok(
     config.GradedConfig(
@@ -3420,7 +3507,7 @@ fn read_spec_on_disk(
     Ok(content) ->
       annotation.parse_file(content)
       |> result.map(fn(file) { #(content, file) })
-      |> result.map_error(GradedParseError(spec_path, _))
+      |> result.map_error(graded_parse_error(spec_path, _))
   }
 }
 
@@ -3554,6 +3641,7 @@ fn fold_inferred_into_kb(
 /// inference on a temporary directory tree without going through
 /// `gleam.toml` resolution. Production callers go through
 /// `enrich_with_path_deps` which reads `gleam.toml` to discover dep paths.
+@internal
 pub fn infer_path_dep(
   dep_path: String,
   base_kb: KnowledgeBase,
@@ -3826,12 +3914,10 @@ fn drop_stale_names(
 
 fn run_check(directory: String) -> Nil {
   case run(directory) {
-    Ok(results) -> {
-      let violations =
-        list.flat_map(results, fn(check_result) { check_result.violations })
-      let warnings =
-        list.flat_map(results, fn(check_result) { check_result.warnings })
-      list.each(results, print_warnings)
+    Ok(reports) -> {
+      let violations = list.flat_map(reports, fn(report) { report.violations })
+      let warnings = list.flat_map(reports, fn(report) { report.warnings })
+      list.each(warnings, io.println)
       case warnings {
         [] -> Nil
         _ ->
@@ -3842,7 +3928,7 @@ fn run_check(directory: String) -> Nil {
       case violations {
         [] -> io.println("graded: all checks passed")
         _ -> {
-          list.each(results, print_violations)
+          list.each(violations, io.println)
           io.println(
             "\ngraded: "
             <> int.to_string(list.length(violations))
@@ -3856,6 +3942,16 @@ fn run_check(directory: String) -> Nil {
   }
 }
 
+// The public parse error for a spec file: the description graded prints for
+// the cause, so the variant carries no internal type. One renderer, so the
+// wording a caller reads and the wording the CLI prints cannot fork.
+fn graded_parse_error(
+  path: String,
+  cause: annotation.ParseError,
+) -> GradedError {
+  GradedParseError(path:, message: annotation.describe_parse_error(cause))
+}
+
 fn format_error(error: GradedError) -> String {
   case error {
     DirectoryReadError(path, _) -> "Could not read directory: " <> path
@@ -3863,9 +3959,10 @@ fn format_error(error: GradedError) -> String {
     FileWriteError(path, _) -> "Could not write: " <> path
     DirectoryCreateError(path, _) -> "Could not create directory: " <> path
     GleamParseError(path, _) -> "Could not parse: " <> path
-    GradedParseError(path, cause) ->
-      "Parse error in " <> path <> ":" <> annotation.describe_parse_error(cause)
-    InvalidConfig(path, _) -> "Invalid gleam.toml: " <> path
+    GradedParseError(path, message) ->
+      "Parse error in " <> path <> ":" <> message
+    InvalidConfig(path, message) ->
+      "Invalid gleam.toml: " <> path <> ": " <> message
     FormatCheckFailed(paths:) ->
       "Unformatted .graded files:\n"
       <> string.join(list.map(paths, fn(path) { "  " <> path }), "\n")
@@ -3915,26 +4012,6 @@ pub fn format_catalog_problem(problem: CatalogProblem) -> String {
       "no bundled catalog directory; looked in "
       <> string.join(candidates, ", ")
   }
-}
-
-fn print_violations(check_result: CheckResult) -> Nil {
-  list.each(check_result.violations, fn(violation) {
-    print_violation(check_result.file, violation)
-  })
-}
-
-fn print_violation(file: String, violation: Violation) -> Nil {
-  io.println(checker.format_violation(file, violation))
-}
-
-fn print_warnings(check_result: CheckResult) -> Nil {
-  list.each(check_result.warnings, fn(warning) {
-    print_warning(check_result.file, warning)
-  })
-}
-
-fn print_warning(file: String, warning: Warning) -> Nil {
-  io.println(checker.format_warning(file, warning))
 }
 
 @external(erlang, "erlang", "halt")

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -183,7 +183,9 @@ pub fn main() -> Nil {
     ["effect", ..rest] ->
       report(cli.parse_effect_args(rest), fn(arguments) {
         let #(name, directory, format) = arguments
-        run_effect_formatted(directory, name, public_format(format))
+        // The decoder already answers in the renderer's own vocabulary, so
+        // the CLI takes the internal path rather than converting twice.
+        effect_answer(directory, name) |> result.map(answer.render(_, format))
       })
 
     ["why", ..rest] ->
@@ -1026,14 +1028,6 @@ pub fn run_effect_formatted(
 ) -> Result(String, GradedError) {
   effect_answer(directory, name)
   |> result.map(answer.render(_, answer_format(format)))
-}
-
-// And back, for the CLI's own decoder, which reads the internal enum.
-fn public_format(format: answer.Format) -> Format {
-  case format {
-    answer.Graded -> Graded
-    answer.Prose -> Prose
-  }
 }
 
 fn answer_format(format: Format) -> answer.Format {

--- a/src/graded/internal/annotation.gleam
+++ b/src/graded/internal/annotation.gleam
@@ -8,14 +8,13 @@ import gleam/set
 import gleam/string
 import graded/internal/effect_term
 import graded/internal/types.{
-  type AnnotationKind, type EffectAnnotation, type EffectSet, type EffectTerm,
-  type ExternalAnnotation, type GradedFile, type GradedLine, type ParamBound,
-  type QualifiedName, type TypeFieldAnnotation, type UnknownClause,
-  AnnotationLine, BlankLine, Check, CommentLine, EffectAnnotation, Effects,
-  ExternalAnnotation, ExternalLine, FunctionExternal, GradedFile, ModuleExternal,
-  ParamBound, Polymorphic, RetainedAssumeLine, Specific, TAbs, TApp, TLabels,
-  TTop, TUnion, TVar, TypeFieldAnnotation, TypeFieldLine, UnknownClause,
-  Wildcard,
+  type AnnotationKind, type AssumeAnnotation, type EffectAnnotation,
+  type EffectSet, type EffectTerm, type FieldAnnotation, type GradedFile,
+  type GradedLine, type ParamBound, type QualifiedName, type UnknownClause,
+  AnnotationLine, AssumeAnnotation, AssumeLine, BlankLine, Check, CommentLine,
+  EffectAnnotation, Effects, FieldAnnotation, FieldAssumeLine, FunctionAssume,
+  GradedFile, ModuleAssume, ParamBound, Polymorphic, RetainedAssumeLine,
+  Specific, TAbs, TApp, TLabels, TTop, TUnion, TVar, UnknownClause, Wildcard,
 }
 
 // Parsing
@@ -556,10 +555,10 @@ fn parse_assume_head(
     _, _ ->
       case subject {
         AssumeModule(module:) ->
-          Ok(ExternalLine(
-            ExternalAnnotation(
+          Ok(AssumeLine(
+            AssumeAnnotation(
               module:,
-              target: ModuleExternal,
+              target: ModuleAssume,
               params: [],
               effects:,
               returns:,
@@ -567,10 +566,10 @@ fn parse_assume_head(
             unknown_clauses,
           ))
         AssumeFunction(module:, function:) ->
-          Ok(ExternalLine(
-            ExternalAnnotation(
+          Ok(AssumeLine(
+            AssumeAnnotation(
               module:,
-              target: FunctionExternal(function),
+              target: FunctionAssume(function),
               params: case bounds {
                 ParsedBounds(params) -> params
                 NoBounds | RetainedBounds(_) -> []
@@ -584,8 +583,8 @@ fn parse_assume_head(
           // A field annotation has no slot for a returned operator.
           use <- bool.guard(when: returns != None, return: Error(Nil))
           use effects <- result.try(option.to_result(term, Nil))
-          Ok(TypeFieldLine(
-            TypeFieldAnnotation(module:, type_name:, field:, effects:),
+          Ok(FieldAssumeLine(
+            FieldAnnotation(module:, type_name:, field:, effects:),
             unknown_clauses,
           ))
         }
@@ -962,8 +961,8 @@ pub fn extract_annotations(file: GradedFile) -> List(EffectAnnotation) {
   list.filter_map(file.lines, fn(line) {
     case line {
       AnnotationLine(annotation, _) -> Ok(annotation)
-      TypeFieldLine(_, _) -> Error(Nil)
-      ExternalLine(_, _) -> Error(Nil)
+      FieldAssumeLine(_, _) -> Error(Nil)
+      AssumeLine(_, _) -> Error(Nil)
       RetainedAssumeLine(..) -> Error(Nil)
       CommentLine(_) -> Error(Nil)
       BlankLine -> Error(Nil)
@@ -978,15 +977,15 @@ pub fn extract_annotations(file: GradedFile) -> List(EffectAnnotation) {
 pub fn line_path(line: GradedLine) -> Result(String, Nil) {
   case line {
     AnnotationLine(annotation, _) -> Ok(annotation.function)
-    TypeFieldLine(tf, _) -> Ok(type_field_path(tf))
-    ExternalLine(ext, _) -> Ok(external_sort_key(ext))
+    FieldAssumeLine(tf, _) -> Ok(type_field_path(tf))
+    AssumeLine(ext, _) -> Ok(external_sort_key(ext))
     RetainedAssumeLine(path:, ..) -> Ok(retained_bare_path(path))
     CommentLine(_) | BlankLine -> Error(Nil)
   }
 }
 
 // A retained line's path with its unparsed bound-list text stripped — the
-// bare name before the paren group, which is what a bounded `ExternalLine`'s
+// bare name before the paren group, which is what a bounded `AssumeLine`'s
 // sort key spells too, so the two shapes of a bounded `assume` line sort and
 // are reported alike. Rendering is untouched: the retained line itself keeps
 // its verbatim text.
@@ -1001,8 +1000,8 @@ fn retained_bare_path(path: String) -> String {
 pub fn line_unknown_clauses(line: GradedLine) -> List(UnknownClause) {
   case line {
     AnnotationLine(_, clauses)
-    | TypeFieldLine(_, clauses)
-    | ExternalLine(_, clauses)
+    | FieldAssumeLine(_, clauses)
+    | AssumeLine(_, clauses)
     | RetainedAssumeLine(unknown_clauses: clauses, ..) -> clauses
     CommentLine(_) | BlankLine -> []
   }
@@ -1033,20 +1032,20 @@ pub fn extract_effects(file: GradedFile) -> List(EffectAnnotation) {
 }
 
 // Extract type field annotations from a parsed file.
-pub fn extract_type_fields(file: GradedFile) -> List(TypeFieldAnnotation) {
+pub fn extract_type_fields(file: GradedFile) -> List(FieldAnnotation) {
   list.filter_map(file.lines, fn(line) {
     case line {
-      TypeFieldLine(tf, _) -> Ok(tf)
+      FieldAssumeLine(tf, _) -> Ok(tf)
       _ -> Error(Nil)
     }
   })
 }
 
 // Extract external annotations from a parsed file.
-pub fn extract_externals(file: GradedFile) -> List(ExternalAnnotation) {
+pub fn extract_externals(file: GradedFile) -> List(AssumeAnnotation) {
   list.filter_map(file.lines, fn(line) {
     case line {
-      ExternalLine(external_annotation, _) -> Ok(external_annotation)
+      AssumeLine(external_annotation, _) -> Ok(external_annotation)
       _ -> Error(Nil)
     }
   })
@@ -1074,7 +1073,7 @@ pub fn external_function_names(file: GradedFile) -> set.Set(String) {
 // clause by the target it parsed as — the ones naming no function included.
 pub fn assume_returns(
   file: GradedFile,
-) -> List(#(ExternalAnnotation, EffectTerm)) {
+) -> List(#(AssumeAnnotation, EffectTerm)) {
   list.filter_map(extract_externals(file), fn(ext) {
     case ext.returns {
       Some(operator) -> Ok(#(ext, operator))
@@ -1097,7 +1096,7 @@ pub fn assume_returns_names(file: GradedFile) -> set.Set(String) {
 // function is stated once and the two cannot drift apart.
 fn declaring_function_names(
   file: GradedFile,
-  claims: fn(ExternalAnnotation) -> Bool,
+  claims: fn(AssumeAnnotation) -> Bool,
 ) -> set.Set(String) {
   extract_externals(file)
   |> list.filter_map(fn(ext) {
@@ -1116,8 +1115,8 @@ fn declaring_function_names(
 pub fn module_external_modules(file: GradedFile) -> set.Set(String) {
   list.filter_map(extract_externals(file), fn(ext) {
     case ext.target, ext.effects {
-      ModuleExternal, Some(_) -> Ok(ext.module)
-      ModuleExternal, None | FunctionExternal(_), _ -> Error(Nil)
+      ModuleAssume, Some(_) -> Ok(ext.module)
+      ModuleAssume, None | FunctionAssume(_), _ -> Error(Nil)
     }
   })
   |> set.from_list()
@@ -1282,8 +1281,8 @@ pub fn merge_inferred(
       case line {
         AnnotationLine(a, [_, ..]) if a.kind == Effects -> Ok(a.function)
         AnnotationLine(..)
-        | TypeFieldLine(..)
-        | ExternalLine(..)
+        | FieldAssumeLine(..)
+        | AssumeLine(..)
         | RetainedAssumeLine(..)
         | CommentLine(_)
         | BlankLine -> Error(Nil)
@@ -1319,8 +1318,8 @@ pub fn merge_inferred(
       case line {
         AnnotationLine(a, _) if a.kind == Effects -> Ok(a.function)
         AnnotationLine(_, _) -> Error(Nil)
-        TypeFieldLine(_, _) -> Error(Nil)
-        ExternalLine(_, _) -> Error(Nil)
+        FieldAssumeLine(_, _) -> Error(Nil)
+        AssumeLine(_, _) -> Error(Nil)
         RetainedAssumeLine(..) -> Error(Nil)
         CommentLine(_) -> Error(Nil)
         BlankLine -> Error(Nil)
@@ -1342,12 +1341,12 @@ pub fn merge_inferred(
         AnnotationLine(a, unknown_clauses) if a.kind == Effects ->
           dict.get(inferred_map, a.function)
           |> result.map(AnnotationLine(_, unknown_clauses))
-        ExternalLine(e, unknown_clauses) ->
+        AssumeLine(e, unknown_clauses) ->
           case
             surviving_external(e, stale_externals, stale_returns_clauses),
             unknown_clauses
           {
-            Ok(external), _ -> Ok(ExternalLine(external, unknown_clauses))
+            Ok(external), _ -> Ok(AssumeLine(external, unknown_clauses))
             Error(Nil), [] -> Error(Nil)
             // Both declarations went stale, but the line still carries a clause
             // only a later version can judge. What it keys is gone; what it
@@ -1372,10 +1371,10 @@ pub fn merge_inferred(
 // or `Error(Nil)` where nothing it claimed survives. The record rather than the
 // line, so the call site keeps what the line retained.
 fn surviving_external(
-  external: ExternalAnnotation,
+  external: AssumeAnnotation,
   stale_externals: set.Set(String),
   stale_returns_clauses: set.Set(String),
-) -> Result(ExternalAnnotation, Nil) {
+) -> Result(AssumeAnnotation, Nil) {
   case external_line_name(external) {
     Error(Nil) -> Ok(external)
     Ok(name) -> {
@@ -1389,7 +1388,7 @@ fn surviving_external(
       }
       case effects, returns {
         None, None -> Error(Nil)
-        _, _ -> Ok(ExternalAnnotation(..external, effects:, returns:))
+        _, _ -> Ok(AssumeAnnotation(..external, effects:, returns:))
       }
     }
   }
@@ -1397,10 +1396,10 @@ fn surviving_external(
 
 // The `<module>.<function>` a per-function external names, or `Error(Nil)` for
 // a module-level one.
-fn external_line_name(external: ExternalAnnotation) -> Result(String, Nil) {
+fn external_line_name(external: AssumeAnnotation) -> Result(String, Nil) {
   case external.target {
-    FunctionExternal(_) -> Ok(external_sort_key(external))
-    ModuleExternal -> Error(Nil)
+    FunctionAssume(_) -> Ok(external_sort_key(external))
+    ModuleAssume -> Error(Nil)
   }
 }
 
@@ -1481,11 +1480,11 @@ fn statement_parts(line: GradedLine) -> #(String, List(String)) {
       annotation_head(annotation),
       clause_list(annotation.returns, unknown_clauses),
     )
-    TypeFieldLine(tf, unknown_clauses) -> #(
+    FieldAssumeLine(tf, unknown_clauses) -> #(
       type_field_head(tf),
       clause_list(None, unknown_clauses),
     )
-    ExternalLine(ext, unknown_clauses) -> #(
+    AssumeLine(ext, unknown_clauses) -> #(
       external_head(ext),
       clause_list(ext.returns, unknown_clauses),
     )
@@ -1562,7 +1561,7 @@ pub fn format_sorted(file: GradedFile) -> String {
   let assume_lines =
     sorted_section(file.lines, fn(line) {
       case line {
-        ExternalLine(..) | TypeFieldLine(..) | RetainedAssumeLine(..) ->
+        AssumeLine(..) | FieldAssumeLine(..) | RetainedAssumeLine(..) ->
           line_path(line)
         _ -> Error(Nil)
       }
@@ -1642,12 +1641,12 @@ fn format_operator(term: EffectTerm) -> String {
   }
 }
 
-// Render a TypeFieldAnnotation back to its .graded line format.
-pub fn format_type_field(tf: TypeFieldAnnotation) -> String {
-  inline_statement(statement_parts(TypeFieldLine(tf, [])))
+// Render a FieldAnnotation back to its .graded line format.
+pub fn format_type_field(tf: FieldAnnotation) -> String {
+  inline_statement(statement_parts(FieldAssumeLine(tf, [])))
 }
 
-fn type_field_head(tf: TypeFieldAnnotation) -> String {
+fn type_field_head(tf: FieldAnnotation) -> String {
   "assume " <> type_field_path(tf) <> " : " <> format_effect_term(tf.effects)
 }
 
@@ -1655,7 +1654,7 @@ fn type_field_head(tf: TypeFieldAnnotation) -> String {
 // files when the module is present, the bare form used in cache files
 // otherwise. A sort key, the rendered name in `format_type_field`, and the name
 // the spec lint reports a dead line by, so all three spell one path one way.
-pub fn type_field_path(tf: TypeFieldAnnotation) -> String {
+pub fn type_field_path(tf: FieldAnnotation) -> String {
   let prefix = case tf.module {
     Some(module) -> module <> "."
     None -> ""
@@ -1663,13 +1662,13 @@ pub fn type_field_path(tf: TypeFieldAnnotation) -> String {
   prefix <> tf.type_name <> "." <> tf.field
 }
 
-// Render an ExternalAnnotation back to its `.graded` line format, always on one
+// Render an AssumeAnnotation back to its `.graded` line format, always on one
 // line — see `format_annotation`.
-pub fn format_external(external_annotation: ExternalAnnotation) -> String {
-  inline_statement(statement_parts(ExternalLine(external_annotation, [])))
+pub fn format_external(external_annotation: AssumeAnnotation) -> String {
+  inline_statement(statement_parts(AssumeLine(external_annotation, [])))
 }
 
-fn external_head(external_annotation: ExternalAnnotation) -> String {
+fn external_head(external_annotation: AssumeAnnotation) -> String {
   let effects_clause = case external_annotation.effects {
     Some(effects) -> " : " <> format_effect_set(effects)
     None -> ""
@@ -1681,7 +1680,7 @@ fn external_head(external_annotation: ExternalAnnotation) -> String {
 // effects clause. Shared with `merge_inferred`'s stale-conversion site, which
 // rebuilds a `RetainedAssumeLine` from a semantic line and must keep the bounds
 // in the retained path.
-fn external_path(external_annotation: ExternalAnnotation) -> String {
+fn external_path(external_annotation: AssumeAnnotation) -> String {
   external_sort_key(external_annotation)
   <> bound_list(external_annotation.params)
 }
@@ -1689,7 +1688,7 @@ fn external_path(external_annotation: ExternalAnnotation) -> String {
 // The qualified name (`module` or `module.function`) an external annotation
 // targets. Used both as a sort key and as the rendered name in
 // `format_external`.
-fn external_sort_key(external_annotation: ExternalAnnotation) -> String {
+fn external_sort_key(external_annotation: AssumeAnnotation) -> String {
   case external_qualified_name(external_annotation) {
     Error(Nil) -> external_annotation.module
     Ok(qualified) -> types.dotted_name(qualified)
@@ -1701,11 +1700,11 @@ fn external_sort_key(external_annotation: ExternalAnnotation) -> String {
 // back together, so every reader that keys by that name — and `external_sort_key`,
 // which renders it — agrees on the shape.
 pub fn external_qualified_name(
-  external_annotation: ExternalAnnotation,
+  external_annotation: AssumeAnnotation,
 ) -> Result(QualifiedName, Nil) {
   case external_annotation.target {
-    ModuleExternal -> Error(Nil)
-    FunctionExternal(function) ->
+    ModuleAssume -> Error(Nil)
+    FunctionAssume(function) ->
       Ok(types.QualifiedName(external_annotation.module, function))
   }
 }

--- a/src/graded/internal/answer.gleam
+++ b/src/graded/internal/answer.gleam
@@ -15,7 +15,7 @@ import graded/internal/annotation
 import graded/internal/effect_term
 import graded/internal/effects
 import graded/internal/types.{
-  type EffectTerm, type ParamBound, EffectAnnotation, TypeFieldAnnotation,
+  type EffectTerm, type ParamBound, EffectAnnotation, FieldAnnotation,
 }
 
 // The answer
@@ -119,7 +119,7 @@ pub fn render_graded(answer: EffectAnswer) -> String {
       <> graded_source(module, source)
       <> graded_fallback(source_fallback(source))
     TypeFieldAnswer(module:, type_name:, field:, term:, origin:) ->
-      annotation.format_type_field(TypeFieldAnnotation(
+      annotation.format_type_field(FieldAnnotation(
         module:,
         type_name:,
         field:,
@@ -149,7 +149,7 @@ fn effects_line(
 fn graded_source(module: String, source: AnswerSource) -> String {
   "\n// "
   <> case source {
-    Entry(entry: types.ModuleExternalEntry(..), ..) ->
+    Entry(entry: types.ModuleAssumeEntry(..), ..) ->
       "resolved via module-level `assume` for " <> module
     Entry(entry: types.FunctionEntry(origin:), ..) ->
       "resolved from " <> effects.describe_origin(origin)
@@ -376,7 +376,7 @@ fn detail_lines(
   // a module-level external declares none itself, but a running fallback body
   // under it does, and the assumption holds however the entry was reached.
   let source_lines = case source {
-    Entry(entry: types.ModuleExternalEntry(..), ..) -> [
+    Entry(entry: types.ModuleAssumeEntry(..), ..) -> [
       "  source: module-level `assume` for `" <> module <> "`",
       "          used when no per-function entry exists",
     ]

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -24,15 +24,15 @@ import graded/internal/types.{
   type LookupOrigin, type ParamBound, type QualifiedName, type ResolvedCall,
   type UnknownReason, type Violation, type Warning, AliasedBoundVariableWarning,
   CallExplanation, DotlessReturnsClauseWarning, EffectAnnotation, Effects,
-  FieldNotAnnotated, NoKnownEffects, ParamBound, QualifiedName,
-  ReceiverTypeUnresolved, RefusedDeclaredReturn, StaleFunctionExternalWarning,
-  StaleReturnsClauseWarning, TUnion, TVar, TypeLine,
-  UnboundExternalTermVariableWarning, UnbuiltExternal,
+  FieldAssumeOrigin, FieldNotAnnotated, NoKnownEffects, ParamBound,
+  QualifiedName, ReceiverTypeUnresolved, RefusedDeclaredReturn,
+  StaleFunctionAssumeWarning, StaleReturnsClauseWarning, TUnion, TVar,
+  UnboundAssumeTermVariableWarning, UnbuiltExternal,
   UnclosedReturnsClauseWarning, UndeclaredExternal, UngroundReturnsClauseWarning,
-  UnknownClauseWarning, UnmatchedCheckWarning, UnmatchedFieldBoundWarning,
-  UnmatchedFunctionExternalWarning, UnmatchedModuleExternalWarning,
-  UnmatchedParamBoundWarning, UnmatchedReturnsClauseWarning,
-  UnmatchedTypeFieldWarning, UnresolvedFieldValue, UntraceableArgument,
+  UnknownClauseWarning, UnmatchedCheckWarning, UnmatchedFieldAssumeWarning,
+  UnmatchedFieldBoundWarning, UnmatchedFunctionAssumeWarning,
+  UnmatchedModuleAssumeWarning, UnmatchedParamBoundWarning,
+  UnmatchedReturnsClauseWarning, UnresolvedFieldValue, UntraceableArgument,
   UntraceableProducer, UntraceableReceiver, UntrackedEffectWarning,
   UnverifiedCheckShapeWarning, UnverifiedReturnsClauseWarning, Violation,
 }
@@ -1704,22 +1704,22 @@ pub fn format_warning(file: String, warning: Warning) -> String {
       <> ": warning: the `where returns` clause on check "
       <> function
       <> " is not verified — nothing weighs a check's returned operator. The effects budget on the same line still is, so the check is live; an `assume` line is the trusted form for the clause"
-    UnmatchedTypeFieldWarning(name:) ->
+    UnmatchedFieldAssumeWarning(name:) ->
       file
       <> ": warning: assume "
       <> name
       <> " names no field of any project type — check the module qualifier; the field resolves to [Unknown]"
-    StaleFunctionExternalWarning(function:) ->
+    StaleFunctionAssumeWarning(function:) ->
       file
       <> ": warning: assume "
       <> function
       <> " names a function of this package with a Gleam body — the line declares no foreign code and is ignored; the body is walked instead. There is no replacement: fix the source, or widen the check budget"
-    UnmatchedFunctionExternalWarning(function:) ->
+    UnmatchedFunctionAssumeWarning(function:) ->
       file
       <> ": warning: assume "
       <> function
       <> " names no dependency, catalog, or project function — check the module qualifier; the declaration covers nothing"
-    UnmatchedModuleExternalWarning(module:) ->
+    UnmatchedModuleAssumeWarning(module:) ->
       file
       <> ": warning: assume "
       <> module
@@ -1748,7 +1748,7 @@ pub fn format_warning(file: String, warning: Warning) -> String {
       <> " has variable(s) "
       <> quoted_names(free_vars)
       <> " the line's bounds do not scope — nothing binds an unscoped variable at a call site, so the clause is ignored. Name the variable in the line's bound list, or spell out the concrete effects"
-    UnboundExternalTermVariableWarning(function:, free_vars:) ->
+    UnboundAssumeTermVariableWarning(function:, free_vars:) ->
       file
       <> ": warning: assume "
       <> function
@@ -7087,7 +7087,7 @@ fn resolve_unproven_field(
             Resolution(
               term: field_effect.effects,
               reason: None,
-              origin: Some(TypeLine(source:)),
+              origin: Some(FieldAssumeOrigin(source:)),
               fallback: types.NoFallback,
             )
           #(substituted(looked_up, term), memo)

--- a/src/graded/internal/config.gleam
+++ b/src/graded/internal/config.gleam
@@ -240,3 +240,15 @@ pub fn module_path_for_source(
   }
   filepath.strip_extension(relative)
 }
+
+// What went wrong reading a `gleam.toml`, as prose. The one renderer, so the
+// public error a caller reads and the message the CLI prints cannot fork.
+pub fn describe_error(error: ConfigError) -> String {
+  case error {
+    TomlReadError(path:, cause:) ->
+      "could not read " <> path <> ": " <> simplifile.describe_error(cause)
+    MissingPackageName(path:) ->
+      "no `name` field in " <> path <> ", or it is not a string"
+    TomlParseError(path:) -> path <> " is not valid TOML"
+  }
+}

--- a/src/graded/internal/effects.gleam
+++ b/src/graded/internal/effects.gleam
@@ -13,14 +13,14 @@ import graded/internal/annotation
 import graded/internal/config
 import graded/internal/effect_term
 import graded/internal/types.{
-  type ArgumentValue, type EffectAnnotation, type EffectSet, type EffectTerm,
-  type ExternalAnnotation, type FactorySignature, type LookupOrigin,
-  type ParamBound, type QualifiedName, type ReturnProvenance,
-  type TypeFieldAnnotation, type TypeFieldEffect, type UpdateSignature, Catalog,
-  Check, CommittedSpec, ConstructorRef, DependencySpec, Effects,
-  FunctionExternal, FunctionRef, ModuleExternal, ModuleExternalOrigin,
-  PathDependency, PathDependencyInferred, ProjectInferred, QualifiedName,
-  TypeFieldEffect, TypeLine, UserExternal,
+  type ArgumentValue, type AssumeAnnotation, type EffectAnnotation,
+  type EffectSet, type EffectTerm, type FactorySignature, type FieldAnnotation,
+  type LookupOrigin, type ParamBound, type QualifiedName, type ReturnProvenance,
+  type TypeFieldEffect, type UpdateSignature, Catalog, Check, CommittedSpec,
+  ConstructorRef, DependencySpec, Effects, FieldAssumeOrigin, FunctionAssume,
+  FunctionRef, ModuleAssume, ModuleAssumeOrigin, PathDependency,
+  PathDependencyInferred, ProjectInferred, QualifiedName, TypeFieldEffect,
+  UserAssume,
 }
 import simplifile
 import tom
@@ -185,7 +185,7 @@ pub type BundledCatalog {
     functions: Dict(QualifiedName, #(EffectTerm, LookupOrigin)),
     modules: Dict(String, #(EffectTerm, LookupOrigin)),
     param_bounds: Dict(QualifiedName, List(ParamBound)),
-    type_fields: List(#(TypeFieldAnnotation, LookupOrigin)),
+    type_fields: List(#(FieldAnnotation, LookupOrigin)),
   )
 }
 
@@ -309,7 +309,7 @@ pub fn lookup_type_field(
 // module; a bare one by "".
 pub fn with_type_fields(
   knowledge_base: KnowledgeBase,
-  type_fields: List(TypeFieldAnnotation),
+  type_fields: List(FieldAnnotation),
   origin: LookupOrigin,
 ) -> KnowledgeBase {
   with_sourced_type_fields(
@@ -322,7 +322,7 @@ pub fn with_type_fields(
 // the file it was read from. A later entry wins on a clash.
 fn with_sourced_type_fields(
   knowledge_base: KnowledgeBase,
-  type_fields: List(#(TypeFieldAnnotation, LookupOrigin)),
+  type_fields: List(#(FieldAnnotation, LookupOrigin)),
 ) -> KnowledgeBase {
   let merged =
     list.fold(type_fields, knowledge_base.type_fields, fn(accumulator, entry) {
@@ -350,9 +350,9 @@ fn with_sourced_type_fields(
 // Function-level externals are added to all_effects.
 //
 // `origin` is the source of these declarations: this project's spec passes
-// `UserExternal`, the bundled catalog passes `Catalog(package)`. A
+// `UserAssume`, the bundled catalog passes `Catalog(package)`. A
 // function-level insert records it beside the effect; a module-level one
-// records it wrapped in `ModuleExternalOrigin`, which names both the kind of
+// records it wrapped in `ModuleAssumeOrigin`, which names both the kind of
 // line and the file it sits in.
 //
 // A declaring line's bound list rides the same fold, at the same precedence:
@@ -362,7 +362,7 @@ fn with_sourced_type_fields(
 // bounds, whose variable names need not match it.
 pub fn with_externals(
   knowledge_base: KnowledgeBase,
-  externals: List(ExternalAnnotation),
+  externals: List(AssumeAnnotation),
   origin: LookupOrigin,
 ) -> KnowledgeBase {
   let #(function_externals, module_externals) =
@@ -396,7 +396,7 @@ type ExternalTiers =
 // anywhere. The function tier folds the same selection the bounds loader
 // folds (`declaring_function_externals`), each dict keeping the last entry.
 fn split_externals(
-  externals: List(ExternalAnnotation),
+  externals: List(AssumeAnnotation),
   origin: LookupOrigin,
 ) -> ExternalTiers {
   let function_externals =
@@ -414,10 +414,10 @@ fn split_externals(
   let module_externals =
     list.fold(externals, dict.new(), fn(accumulator, external) {
       case external.target, external.effects {
-        ModuleExternal, Some(effects) ->
+        ModuleAssume, Some(effects) ->
           dict.insert(accumulator, external.module, #(
             effect_term.from_effect_set(effects),
-            ModuleExternalOrigin(source: origin),
+            ModuleAssumeOrigin(source: origin),
           ))
         _, _ -> accumulator
       }
@@ -431,11 +431,11 @@ fn split_externals(
 // the winning bounds come off the same line by construction rather than by
 // two rules kept in step.
 fn declaring_function_externals(
-  externals: List(ExternalAnnotation),
+  externals: List(AssumeAnnotation),
 ) -> List(#(QualifiedName, EffectSet, List(ParamBound))) {
   list.filter_map(externals, fn(external) {
     case external.target, external.effects {
-      FunctionExternal(function), Some(effects) ->
+      FunctionAssume(function), Some(effects) ->
         Ok(#(QualifiedName(external.module, function), effects, external.params))
       _, _ -> Error(Nil)
     }
@@ -467,7 +467,7 @@ fn raw_lookup(
     Ok(#(term, origin)) -> Some(#(term, types.FunctionEntry(origin:)))
     Error(Nil) ->
       case dict.get(knowledge_base.module_effects, name.module) {
-        Ok(#(term, origin)) -> Some(#(term, types.ModuleExternalEntry(origin:)))
+        Ok(#(term, origin)) -> Some(#(term, types.ModuleAssumeEntry(origin:)))
         Error(Nil) -> None
       }
   }
@@ -629,7 +629,7 @@ fn declared_param_bounds(
   origin: LookupOrigin,
 ) -> List(ParamBound) {
   case origin {
-    ModuleExternalOrigin(_) -> []
+    ModuleAssumeOrigin(_) -> []
     _ -> line_param_bounds(knowledge_base, name)
   }
 }
@@ -646,7 +646,7 @@ fn holds_only_inferred_bounds(
 ) -> Bool {
   line_param_bounds(knowledge_base, name) != []
   && case raw_declaration(knowledge_base, name) {
-    Some(#(_term, ModuleExternalOrigin(_))) -> True
+    Some(#(_term, ModuleAssumeOrigin(_))) -> True
     _ -> False
   }
 }
@@ -912,13 +912,13 @@ fn foreign_registry_callbacks(
 // function it would be silencing.
 pub fn suppresses_running_fallback(origin: LookupOrigin) -> Bool {
   case origin {
-    UserExternal | DependencySpec(_) | PathDependency(_) -> True
+    UserAssume | DependencySpec(_) | PathDependency(_) -> True
     Catalog(_)
-    | ModuleExternalOrigin(_)
+    | ModuleAssumeOrigin(_)
     | CommittedSpec
     | ProjectInferred
     | PathDependencyInferred(_)
-    | TypeLine(_) -> False
+    | FieldAssumeOrigin(_) -> False
   }
 }
 
@@ -1242,7 +1242,7 @@ pub fn is_dependency_foreign_function(
 pub fn origin_of(source: types.EffectSource) -> LookupOrigin {
   case source {
     types.FunctionEntry(origin:) -> origin
-    types.ModuleExternalEntry(origin:) -> origin
+    types.ModuleAssumeEntry(origin:) -> origin
   }
 }
 
@@ -1344,16 +1344,18 @@ pub fn declares_foreign_code(origin: LookupOrigin) -> Bool {
   case origin {
     // A dependency's spec speaks for foreign code as the catalog does, though
     // neither keys a function of the project module under analysis today.
-    UserExternal
+    UserAssume
     | Catalog(_)
-    | ModuleExternalOrigin(_)
+    | ModuleAssumeOrigin(_)
     | DependencySpec(_)
     | PathDependency(_) -> True
     // Inference over a spec-less path dependency's source is not a declaration:
     // it walked an `@external`'s body, which is exactly what no entry may speak
     // for. It ranks below the catalog for the same reason.
-    CommittedSpec | ProjectInferred | PathDependencyInferred(_) | TypeLine(_) ->
-      False
+    CommittedSpec
+    | ProjectInferred
+    | PathDependencyInferred(_)
+    | FieldAssumeOrigin(_) -> False
   }
 }
 
@@ -1626,10 +1628,11 @@ pub fn format_effect_set(effect_set: EffectSet) -> String {
 // reads from this one vocabulary.
 pub fn describe_origin(origin: LookupOrigin) -> String {
   case origin {
-    UserExternal -> "your spec's `assume` line"
-    ModuleExternalOrigin(source:) ->
+    UserAssume -> "your spec's `assume` line"
+    ModuleAssumeOrigin(source:) ->
       "a module-level `assume` in " <> describe_source_file(source)
-    TypeLine(source:) -> "a field `assume` in " <> describe_source_file(source)
+    FieldAssumeOrigin(source:) ->
+      "a field `assume` in " <> describe_source_file(source)
     CommittedSpec
     | ProjectInferred
     | DependencySpec(..)
@@ -1643,14 +1646,14 @@ pub fn describe_origin(origin: LookupOrigin) -> String {
 // Shared with the surfaces that name a *kind* of line and the file it sits in.
 pub fn describe_source_file(origin: LookupOrigin) -> String {
   case origin {
-    UserExternal | CommittedSpec -> "your spec"
+    UserAssume | CommittedSpec -> "your spec"
     ProjectInferred -> "in-memory inference"
     DependencySpec(package:) -> package <> "'s shipped spec"
     PathDependency(package:) -> "path dependency " <> package
     PathDependencyInferred(package:) ->
       "inference over path dependency " <> package <> "'s source"
     Catalog(package:) -> package <> "'s catalog entry"
-    ModuleExternalOrigin(source:) | TypeLine(source:) ->
+    ModuleAssumeOrigin(source:) | FieldAssumeOrigin(source:) ->
       describe_source_file(source)
   }
 }
@@ -2340,7 +2343,7 @@ pub fn load_spec_params_from_file(
 // its function tier from, so on a duplicate declaration the winning term and
 // the winning bounds come off the same line, never mixed across lines.
 fn external_bounds(
-  externals: List(ExternalAnnotation),
+  externals: List(AssumeAnnotation),
 ) -> Dict(QualifiedName, List(ParamBound)) {
   list.fold(declaring_function_externals(externals), dict.new(), fn(acc, entry) {
     let #(name, _effects, bounds) = entry
@@ -2372,8 +2375,8 @@ pub type DepSpec {
     // `where returns` clauses on the spec's `assume` lines, each scoped by
     // that line's own bound list.
     declared_returns: Dict(QualifiedName, ScopedClause),
-    type_fields: List(TypeFieldAnnotation),
-    externals: List(ExternalAnnotation),
+    type_fields: List(FieldAnnotation),
+    externals: List(AssumeAnnotation),
     modules: Set(String),
   )
 }
@@ -2622,9 +2625,9 @@ fn over_catalog(
 fn is_catalog_origin(origin: LookupOrigin) -> Bool {
   case origin {
     Catalog(..) -> True
-    ModuleExternalOrigin(source:) | TypeLine(source:) ->
+    ModuleAssumeOrigin(source:) | FieldAssumeOrigin(source:) ->
       is_catalog_origin(source)
-    UserExternal
+    UserAssume
     | CommittedSpec
     | ProjectInferred
     | DependencySpec(..)
@@ -2738,7 +2741,7 @@ type Dependencies {
     effects: Dict(QualifiedName, #(EffectTerm, LookupOrigin)),
     params: Dict(QualifiedName, List(ParamBound)),
     returns: Dict(QualifiedName, ReturnedOperator),
-    type_fields: List(#(TypeFieldAnnotation, LookupOrigin)),
+    type_fields: List(#(FieldAnnotation, LookupOrigin)),
     module_effects: Dict(String, #(EffectTerm, LookupOrigin)),
   )
 }
@@ -2856,7 +2859,7 @@ type CatalogAcc {
     // variable is left with nothing to bind it.
     ext_params: Dict(QualifiedName, List(ParamBound)),
     poly_params: Dict(QualifiedName, List(ParamBound)),
-    type_fields: List(#(TypeFieldAnnotation, LookupOrigin)),
+    type_fields: List(#(FieldAnnotation, LookupOrigin)),
   )
 }
 
@@ -2871,7 +2874,7 @@ pub fn load_catalog(
   Dict(QualifiedName, #(EffectTerm, LookupOrigin)),
   Dict(String, #(EffectTerm, LookupOrigin)),
   Dict(QualifiedName, List(ParamBound)),
-  List(#(TypeFieldAnnotation, LookupOrigin)),
+  List(#(FieldAnnotation, LookupOrigin)),
 ) {
   let installed_versions = manifest_versions(manifest_path)
   let catalog_files = bundled_catalog_files(catalog_dir) |> result.unwrap([])

--- a/src/graded/internal/lint.gleam
+++ b/src/graded/internal/lint.gleam
@@ -92,6 +92,17 @@ pub type DependencyName {
 pub type ModuleInfoMemo =
   Dict(String, Result(ModuleInfo, Nil))
 
+// Where the classifier reads types from, and what it has read so far. The two
+// sources never change across a pass and the memo does, so they travel
+// together rather than as three arguments through a mutual recursion.
+type Resolver {
+  Resolver(
+    index: Dict(String, #(String, glance.Module)),
+    dep_files: Dict(String, String),
+    memo: ModuleInfoMemo,
+  )
+}
+
 // Flag `check`/`type`/`external` spec lines whose target resolves nothing. A
 // `check` line names a function that must exist in some project module; a `type`
 // line names a `module.Type.field` that must be a callable (function-typed)
@@ -117,7 +128,6 @@ pub fn run_recording_lookups(
     index:,
     stale_externals:,
     stale_returns_clauses:,
-    catalog:,
     registry:,
     ..,
   ) = context
@@ -160,8 +170,6 @@ pub fn run_recording_lookups(
     [], [], [] -> dict.new()
     _, _, _ -> context.dependency_files()
   }
-  let dep_modules = set.from_list(dict.keys(dep_files))
-
   // The two declaring forms weigh a name by one rule, over one precomputation —
   // which reads the whole dependency tree, so it is built only where a
   // declaring line asks a question of it.
@@ -171,8 +179,7 @@ pub fn run_recording_lookups(
   {
     [], [] -> #([], [])
     _, _ -> {
-      let evidence =
-        spec_name_evidence(index, known_functions, dep_files, catalog, context)
+      let evidence = spec_name_evidence(known_functions, dep_files, context)
       #(
         external_warnings(externals, evidence, stale_externals),
         returns_clause_warnings(
@@ -190,26 +197,23 @@ pub fn run_recording_lookups(
   // from that channel's own output, so the two gates cannot drift.
   let dead_externals = dead_external_names(external_warnings)
 
-  // Resolving field `assume` lines also needs per-module type info; build it only when
-  // there are field `assume` lines to check.
-  let #(type_field_warnings, memo) = case type_fields {
-    [] -> #([], dict.new())
+  // Resolving field `assume` lines needs per-module type info, which the
+  // resolver builds on demand and keeps: only the modules a field line names,
+  // and whatever its alias chain reaches, are ever read.
+  let #(type_field_warnings, resolver) = case type_fields {
+    [] -> #([], Resolver(index:, dep_files:, memo: dict.new()))
     type_fields -> {
-      let project_infos = project_module_infos(index)
-      let #(memo, warnings) =
-        list.map_fold(type_fields, dict.new(), fn(memo, tf) {
-          let #(warning, memo) =
-            unmatched_type_field_warning(
-              tf,
-              index,
-              dep_modules,
-              project_infos,
-              dep_files,
-              memo,
-            )
-          #(memo, warning)
-        })
-      #(list.filter_map(warnings, fn(w) { w }), memo)
+      let #(resolver, warnings) =
+        list.map_fold(
+          type_fields,
+          Resolver(index:, dep_files:, memo: dict.new()),
+          fn(resolver, tf) {
+            let #(warning, resolver) =
+              unmatched_type_field_warning(tf, resolver)
+            #(resolver, warning)
+          },
+        )
+      #(list.filter_map(warnings, fn(w) { w }), resolver)
     }
   }
 
@@ -243,7 +247,7 @@ pub fn run_recording_lookups(
       unknown_clause_warnings,
       type_field_warnings,
     ]),
-    memo,
+    resolver.memo,
   )
 }
 
@@ -414,12 +418,11 @@ type SpecNameEvidence {
 // Existence only. A name that resolves but that graded cannot introspect is
 // exactly what a declaring line is for, and is never flagged.
 fn spec_name_evidence(
-  index: Dict(String, #(String, glance.Module)),
   known_functions: Set(String),
   dep_files: Dict(String, String),
-  catalog: effects.BundledCatalog,
   context: Context,
 ) -> SpecNameEvidence {
+  let Context(index:, catalog:, ..) = context
   // The catalog the knowledge base was assembled from, selected against *this*
   // project's manifest — so a line naming a catalogued function of a package
   // this project depends on resolves exactly as `check` resolves it.
@@ -582,33 +585,20 @@ fn returns_clause_warnings(
 //     so it's dead and flagged.
 fn unmatched_type_field_warning(
   tf: FieldAnnotation,
-  index: Dict(String, #(String, glance.Module)),
-  dep_modules: Set(String),
-  project_infos: Dict(String, ModuleInfo),
-  dep_files: Dict(String, String),
-  memo: ModuleInfoMemo,
-) -> #(Result(Warning, Nil), ModuleInfoMemo) {
-  let #(dead, memo) = case tf.module {
-    None -> #(True, memo)
+  resolver: Resolver,
+) -> #(Result(Warning, Nil), Resolver) {
+  let #(dead, resolver) = case tf.module {
+    None -> #(True, resolver)
     Some(module) -> {
-      let #(valid, memo) =
-        valid_type_field(
-          module,
-          tf,
-          index,
-          dep_modules,
-          project_infos,
-          dep_files,
-          memo,
-        )
-      #(!valid, memo)
+      let #(valid, resolver) = valid_type_field(module, tf, resolver)
+      #(!valid, resolver)
     }
   }
   case dead {
-    False -> #(Error(Nil), memo)
+    False -> #(Error(Nil), resolver)
     True -> #(
       Ok(UnmatchedFieldAssumeWarning(name: annotation.type_field_path(tf))),
-      memo,
+      resolver,
     )
   }
 }
@@ -620,30 +610,19 @@ fn unmatched_type_field_warning(
 fn valid_type_field(
   module: String,
   tf: FieldAnnotation,
-  index: Dict(String, #(String, glance.Module)),
-  dep_modules: Set(String),
-  project_infos: Dict(String, ModuleInfo),
-  dep_files: Dict(String, String),
-  memo: ModuleInfoMemo,
-) -> #(Bool, ModuleInfoMemo) {
-  case dict.get(index, module) {
+  resolver: Resolver,
+) -> #(Bool, Resolver) {
+  case dict.get(resolver.index, module) {
     Ok(#(_gleam_path, mod)) ->
       case lookup_labelled_field(mod, tf.type_name, tf.field) {
         Ok(field_type) -> {
-          let #(callable, memo) =
-            classify_field_type(
-              field_type,
-              module,
-              project_infos,
-              dep_files,
-              set.new(),
-              memo,
-            )
-          #(callable != NotCallable, memo)
+          let #(callable, resolver) =
+            classify_field_type(field_type, module, set.new(), resolver)
+          #(callable != NotCallable, resolver)
         }
-        Error(Nil) -> #(False, memo)
+        Error(Nil) -> #(False, resolver)
       }
-    Error(Nil) -> #(set.contains(dep_modules, module), memo)
+    Error(Nil) -> #(dict.has_key(resolver.dep_files, module), resolver)
   }
 }
 
@@ -696,19 +675,10 @@ pub type ModuleInfo {
 // Whether a field's declared type can be called. Three-valued so the lint flags
 // only what it can prove is non-callable, never guessing on a type it can't
 // resolve.
-pub type Callable {
+type Callable {
   Callable
   NotCallable
   UnknownCallable
-}
-
-fn project_module_infos(
-  index: Dict(String, #(String, glance.Module)),
-) -> Dict(String, ModuleInfo) {
-  dict.map_values(index, fn(_module_path, entry) {
-    let #(_gleam_path, module) = entry
-    module_info_from_glance(module)
-  })
 }
 
 fn module_info_from_glance(module: glance.Module) -> ModuleInfo {
@@ -754,17 +724,15 @@ fn last_segment(module_path: String) -> String {
 // is available (an uninstalled or otherwise unreadable module).
 fn lookup_module_info(
   module_path: String,
-  project_infos: Dict(String, ModuleInfo),
-  dep_files: Dict(String, String),
-  memo: ModuleInfoMemo,
-) -> #(Result(ModuleInfo, Nil), ModuleInfoMemo) {
-  case dict.get(memo, module_path) {
-    Ok(cached) -> #(cached, memo)
+  resolver: Resolver,
+) -> #(Result(ModuleInfo, Nil), Resolver) {
+  case dict.get(resolver.memo, module_path) {
+    Ok(cached) -> #(cached, resolver)
     Error(Nil) -> {
-      let info = case dict.get(project_infos, module_path) {
-        Ok(info) -> Ok(info)
+      let info = case dict.get(resolver.index, module_path) {
+        Ok(#(_gleam_path, module)) -> Ok(module_info_from_glance(module))
         Error(Nil) -> {
-          use file <- result.try(dict.get(dep_files, module_path))
+          use file <- result.try(dict.get(resolver.dep_files, module_path))
           use source <- result.try(
             simplifile.read(file) |> result.replace_error(Nil),
           )
@@ -774,7 +742,13 @@ fn lookup_module_info(
           Ok(module_info_from_glance(module))
         }
       }
-      #(info, dict.insert(memo, module_path, info))
+      #(
+        info,
+        Resolver(
+          ..resolver,
+          memo: dict.insert(resolver.memo, module_path, info),
+        ),
+      )
     }
   }
 }
@@ -786,46 +760,29 @@ fn lookup_module_info(
 fn classify_field_type(
   type_: glance.Type,
   module_path: String,
-  project_infos: Dict(String, ModuleInfo),
-  dep_files: Dict(String, String),
   seen: Set(String),
-  memo: ModuleInfoMemo,
-) -> #(Callable, ModuleInfoMemo) {
+  resolver: Resolver,
+) -> #(Callable, Resolver) {
   case type_ {
-    glance.FunctionType(..) -> #(Callable, memo)
+    glance.FunctionType(..) -> #(Callable, resolver)
     glance.NamedType(name:, module: None, ..) ->
-      classify_named_type(
-        name,
-        module_path,
-        project_infos,
-        dep_files,
-        seen,
-        memo,
-      )
+      classify_named_type(name, module_path, seen, resolver)
     glance.NamedType(name:, module: Some(qualifier), ..) -> {
-      let #(info, memo) =
-        lookup_module_info(module_path, project_infos, dep_files, memo)
+      let #(info, resolver) = lookup_module_info(module_path, resolver)
       case info {
         Ok(info) ->
           case dict.get(info.qualified_imports, qualifier) {
             Ok(real_module) ->
-              classify_named_type(
-                name,
-                real_module,
-                project_infos,
-                dep_files,
-                seen,
-                memo,
-              )
-            Error(Nil) -> #(UnknownCallable, memo)
+              classify_named_type(name, real_module, seen, resolver)
+            Error(Nil) -> #(UnknownCallable, resolver)
           }
-        Error(Nil) -> #(UnknownCallable, memo)
+        Error(Nil) -> #(UnknownCallable, resolver)
       }
     }
     // A type variable could be instantiated to a function; don't flag it.
-    glance.VariableType(..) -> #(UnknownCallable, memo)
+    glance.VariableType(..) -> #(UnknownCallable, resolver)
     // Tuples and holes are never callable.
-    _ -> #(NotCallable, memo)
+    _ -> #(NotCallable, resolver)
   }
 }
 
@@ -836,28 +793,23 @@ fn classify_field_type(
 fn classify_named_type(
   name: String,
   module_path: String,
-  project_infos: Dict(String, ModuleInfo),
-  dep_files: Dict(String, String),
   seen: Set(String),
-  memo: ModuleInfoMemo,
-) -> #(Callable, ModuleInfoMemo) {
+  resolver: Resolver,
+) -> #(Callable, Resolver) {
   let key = module_path <> "." <> name
   use <- bool.lazy_guard(when: set.contains(seen, key), return: fn() {
-    #(UnknownCallable, memo)
+    #(UnknownCallable, resolver)
   })
-  let #(info, memo) =
-    lookup_module_info(module_path, project_infos, dep_files, memo)
+  let #(info, resolver) = lookup_module_info(module_path, resolver)
   case info {
-    Error(Nil) -> #(UnknownCallable, memo)
+    Error(Nil) -> #(UnknownCallable, resolver)
     Ok(info) ->
       classify_in_module(
         name,
         module_path,
         info,
-        project_infos,
-        dep_files,
         set.insert(seen, key),
-        memo,
+        resolver,
       )
   }
 }
@@ -869,37 +821,20 @@ fn classify_in_module(
   name: String,
   module_path: String,
   info: ModuleInfo,
-  project_infos: Dict(String, ModuleInfo),
-  dep_files: Dict(String, String),
   seen: Set(String),
-  memo: ModuleInfoMemo,
-) -> #(Callable, ModuleInfoMemo) {
+  resolver: Resolver,
+) -> #(Callable, Resolver) {
   case dict.get(info.aliases, name) {
-    Ok(aliased) ->
-      classify_field_type(
-        aliased,
-        module_path,
-        project_infos,
-        dep_files,
-        seen,
-        memo,
-      )
+    Ok(aliased) -> classify_field_type(aliased, module_path, seen, resolver)
     Error(Nil) ->
       case
         set.contains(info.custom_types, name),
         dict.get(info.unqualified_types, name)
       {
-        True, _ -> #(NotCallable, memo)
+        True, _ -> #(NotCallable, resolver)
         False, Ok(#(real_module, original)) ->
-          classify_named_type(
-            original,
-            real_module,
-            project_infos,
-            dep_files,
-            seen,
-            memo,
-          )
-        False, Error(Nil) -> #(NotCallable, memo)
+          classify_named_type(original, real_module, seen, resolver)
+        False, Error(Nil) -> #(NotCallable, resolver)
       }
   }
 }

--- a/src/graded/internal/lint.gleam
+++ b/src/graded/internal/lint.gleam
@@ -26,14 +26,14 @@ import graded/internal/effect_term
 import graded/internal/effects
 import graded/internal/signatures.{type SignatureRegistry}
 import graded/internal/types.{
-  type EffectAnnotation, type EffectTerm, type GradedFile, type QualifiedName,
-  type TypeFieldAnnotation, type Warning, AliasedBoundVariableWarning,
-  DotlessReturnsClauseWarning, QualifiedName, StaleFunctionExternalWarning,
-  StaleReturnsClauseWarning, UnboundExternalTermVariableWarning,
+  type EffectAnnotation, type EffectTerm, type FieldAnnotation, type GradedFile,
+  type QualifiedName, type Warning, AliasedBoundVariableWarning,
+  DotlessReturnsClauseWarning, QualifiedName, StaleFunctionAssumeWarning,
+  StaleReturnsClauseWarning, UnboundAssumeTermVariableWarning,
   UnclosedReturnsClauseWarning, UngroundReturnsClauseWarning,
-  UnknownClauseWarning, UnmatchedCheckWarning, UnmatchedFunctionExternalWarning,
-  UnmatchedModuleExternalWarning, UnmatchedReturnsClauseWarning,
-  UnmatchedTypeFieldWarning, UnverifiedCheckShapeWarning,
+  UnknownClauseWarning, UnmatchedCheckWarning, UnmatchedFieldAssumeWarning,
+  UnmatchedFunctionAssumeWarning, UnmatchedModuleAssumeWarning,
+  UnmatchedReturnsClauseWarning, UnverifiedCheckShapeWarning,
   UnverifiedReturnsClauseWarning,
 }
 import simplifile
@@ -256,7 +256,7 @@ pub fn run_recording_lookups(
 // registry-synthesized bounds and is left alone, and to lines the existence
 // channel has not flagged — a stale or unmatched line's one fix is removal.
 fn unbound_term_variable_warnings(
-  externals: List(types.ExternalAnnotation),
+  externals: List(types.AssumeAnnotation),
   dead: Set(String),
 ) -> List(Warning) {
   list.filter_map(externals, fn(external) {
@@ -282,7 +282,7 @@ fn unbound_term_variable_warnings(
         case unbound {
           [] -> Error(Nil)
           free_vars ->
-            Ok(UnboundExternalTermVariableWarning(
+            Ok(UnboundAssumeTermVariableWarning(
               function: types.dotted_name(qualified),
               free_vars:,
             ))
@@ -303,7 +303,7 @@ fn unbound_term_variable_warnings(
 // each channel's binding stays what it is. A machine-written
 // self-referential list never aliases, so the shape is hand-written.
 fn aliased_bound_variable_warnings(
-  externals: List(types.ExternalAnnotation),
+  externals: List(types.AssumeAnnotation),
   effects_lines: List(EffectAnnotation),
   dead: Set(String),
 ) -> List(Warning) {
@@ -490,7 +490,7 @@ fn spec_name_evidence(
 //   - a module-level line whose module is neither a dependency nor a project
 //     module.
 fn external_warnings(
-  externals: List(types.ExternalAnnotation),
+  externals: List(types.AssumeAnnotation),
   evidence: SpecNameEvidence,
   stale: Set(String),
 ) -> List(Warning) {
@@ -503,15 +503,15 @@ fn external_warnings(
       Ok(qualified) -> {
         let name = types.dotted_name(qualified)
         case set.contains(stale, name), evidence.defines(qualified) {
-          True, _ -> Ok(StaleFunctionExternalWarning(function: name))
-          False, False -> Ok(UnmatchedFunctionExternalWarning(function: name))
+          True, _ -> Ok(StaleFunctionAssumeWarning(function: name))
+          False, False -> Ok(UnmatchedFunctionAssumeWarning(function: name))
           False, True -> Error(Nil)
         }
       }
       Error(Nil) ->
         case evidence.module_placed(external.module) {
           True -> Error(Nil)
-          False -> Ok(UnmatchedModuleExternalWarning(module: external.module))
+          False -> Ok(UnmatchedModuleAssumeWarning(module: external.module))
         }
     }
   })
@@ -522,8 +522,8 @@ fn external_warnings(
 fn dead_external_names(warnings: List(Warning)) -> Set(String) {
   list.filter_map(warnings, fn(warning) {
     case warning {
-      StaleFunctionExternalWarning(function:)
-      | UnmatchedFunctionExternalWarning(function:) -> Ok(function)
+      StaleFunctionAssumeWarning(function:)
+      | UnmatchedFunctionAssumeWarning(function:) -> Ok(function)
       _ -> Error(Nil)
     }
   })
@@ -542,7 +542,7 @@ fn dead_external_names(warnings: List(Warning)) -> Set(String) {
 // One warning per clause, so a clause that is dead twice over is reported by
 // the first rule that catches it.
 fn returns_clause_warnings(
-  declared: List(#(types.ExternalAnnotation, EffectTerm)),
+  declared: List(#(types.AssumeAnnotation, EffectTerm)),
   evidence: SpecNameEvidence,
   stale: Set(String),
 ) -> List(Warning) {
@@ -581,7 +581,7 @@ fn returns_clause_warnings(
 //   - qualified at an unknown module (neither project nor dependency): a typo,
 //     so it's dead and flagged.
 fn unmatched_type_field_warning(
-  tf: TypeFieldAnnotation,
+  tf: FieldAnnotation,
   index: Dict(String, #(String, glance.Module)),
   dep_modules: Set(String),
   project_infos: Dict(String, ModuleInfo),
@@ -607,7 +607,7 @@ fn unmatched_type_field_warning(
   case dead {
     False -> #(Error(Nil), memo)
     True -> #(
-      Ok(UnmatchedTypeFieldWarning(name: annotation.type_field_path(tf))),
+      Ok(UnmatchedFieldAssumeWarning(name: annotation.type_field_path(tf))),
       memo,
     )
   }
@@ -619,7 +619,7 @@ fn unmatched_type_field_warning(
 // passes untouched; any other module is a typo.
 fn valid_type_field(
   module: String,
-  tf: TypeFieldAnnotation,
+  tf: FieldAnnotation,
   index: Dict(String, #(String, glance.Module)),
   dep_modules: Set(String),
   project_infos: Dict(String, ModuleInfo),

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -280,14 +280,14 @@ pub type EffectAnnotation {
   )
 }
 
-// Effect annotation for a type's field (e.g., `type Handler.on_click : [Dom]`).
+// Effect annotation for a type's field (e.g. `assume myapp.Handler.on_click : [Dom]`).
 //
 // `module` is `Some(...)` when the annotation comes from a spec file (one
 // file per package, qualified names like `myapp.Handler.on_click`) and
 // `None` when it comes from a per-module cache file (bare names scoped to
 // the file's module by location).
-pub type TypeFieldAnnotation {
-  TypeFieldAnnotation(
+pub type FieldAnnotation {
+  FieldAnnotation(
     module: Option(String),
     type_name: String,
     field: String,
@@ -295,7 +295,7 @@ pub type TypeFieldAnnotation {
   )
 }
 
-// Whether a type field's effect was hand-written on a `type Type.field : [...]`
+// Whether a type field's effect was hand-written on an `assume m.Type.field : [...]`
 // line (`Declared`) or inferred from a construction site (`Inferred`). A field
 // call on a parameter/opaque receiver consults only `Declared` lines — an
 // inferred, nominal-type-keyed entry never resolves such a receiver, since it
@@ -357,7 +357,7 @@ pub type UnknownReason {
 pub type LookupOrigin {
   // A per-function declaring line in this project's spec: an
   // `assume` line, with or without a `where returns` clause.
-  UserExternal
+  UserAssume
   // A committed `effects` line in this project's spec.
   CommittedSpec
   // In-memory inference over this project's source, this run.
@@ -375,12 +375,12 @@ pub type LookupOrigin {
   Catalog(package: String)
   // An `assume <module>` line answered for a name nothing else keys.
   // `source` is the file that declares it. Named apart from
-  // `ExternalTarget.ModuleExternal`, which shares this module's namespace.
-  ModuleExternalOrigin(source: LookupOrigin)
+  // `AssumeTarget.ModuleAssume`, which shares this module's namespace.
+  ModuleAssumeOrigin(source: LookupOrigin)
   // A hand-written field `assume` line resolved a field call. `source` is the file that
   // declares it. Set only by the field path, never stored beside a function
   // entry.
-  TypeLine(source: LookupOrigin)
+  FieldAssumeOrigin(source: LookupOrigin)
 }
 
 // Which of the knowledge base's two maps answered a function lookup. Reported
@@ -391,9 +391,9 @@ pub type EffectSource {
   // `origin` names the source that wrote it.
   FunctionEntry(origin: LookupOrigin)
   // The function's module carries `assume <module> : [...]`. Reached
-  // only when nothing keys the function itself, so a per-function external or a
+  // only when nothing keys the function itself, so a per-function `assume` or a
   // catalog line for it takes precedence; it carries no per-function bounds.
-  ModuleExternalEntry(origin: LookupOrigin)
+  ModuleAssumeEntry(origin: LookupOrigin)
 }
 
 // A type field's resolved effect in the knowledge base. `effects` is the field
@@ -446,11 +446,11 @@ pub type ForeignFunction {
 }
 
 // Whether an external targets a whole module or a specific function.
-pub type ExternalTarget {
+pub type AssumeTarget {
   // `assume gleam/list : []` — the entire module is pure.
-  ModuleExternal
+  ModuleAssume
   // `assume gleam/httpc.send : [Http]` — a specific function.
-  FunctionExternal(name: String)
+  FunctionAssume(name: String)
 }
 
 // A trusted declaration (`assume gleam/httpc.send : [Http]`).
@@ -472,10 +472,10 @@ pub type ExternalTarget {
 //
 // `returns` carries the `where returns` clause, meaningful for a function
 // target; a clause on a module path is a lint.
-pub type ExternalAnnotation {
-  ExternalAnnotation(
+pub type AssumeAnnotation {
+  AssumeAnnotation(
     module: String,
-    target: ExternalTarget,
+    target: AssumeTarget,
     params: List(ParamBound),
     effects: Option(EffectSet),
     returns: Option(EffectTerm),
@@ -500,14 +500,8 @@ pub type GradedLine {
     annotation: EffectAnnotation,
     unknown_clauses: List(UnknownClause),
   )
-  TypeFieldLine(
-    type_field: TypeFieldAnnotation,
-    unknown_clauses: List(UnknownClause),
-  )
-  ExternalLine(
-    external: ExternalAnnotation,
-    unknown_clauses: List(UnknownClause),
-  )
+  FieldAssumeLine(field: FieldAnnotation, unknown_clauses: List(UnknownClause))
+  AssumeLine(assume: AssumeAnnotation, unknown_clauses: List(UnknownClause))
   // An `assume` line whose every clause is one this version does not know, so
   // it carries no semantics at all: it keys nothing and is retained for its
   // clauses alone. One variant for all three path shapes — function, module and
@@ -875,26 +869,26 @@ pub type Warning {
   // nothing and the field call silently degrades to `[Unknown]`, so it's
   // flagged. `name` is the annotation as written (`Opts.on_change` when
   // unqualified, `myapp/opts.Opts.on_change` when qualified).
-  UnmatchedTypeFieldWarning(name: String)
+  UnmatchedFieldAssumeWarning(name: String)
   // A per-function `assume <module>.<function>` line naming one of
   // this package's own ordinary Gleam functions — a body graded can see and
   // every caller runs. The syntax declares foreign code, so the line describes
   // nothing the body does not; it is ignored and the body is walked instead.
   // Scoped to modules the project index holds: declaring a *dependency*
   // function with a visible body is the line's documented use.
-  StaleFunctionExternalWarning(function: String)
+  StaleFunctionAssumeWarning(function: String)
   // A per-function `assume <module>.<function>` line whose name
   // resolves nowhere — no dependency, no catalog entry, no project module. The
   // declaration then covers nothing, so it is a typo rather than a budget.
-  UnmatchedFunctionExternalWarning(function: String)
+  UnmatchedFunctionAssumeWarning(function: String)
   // A module-level `assume <module>` line whose module is neither an
   // installed dependency, a path dependency, nor a project module. Same
   // reasoning one tier up: the declaration governs no module at all.
-  UnmatchedModuleExternalWarning(module: String)
+  UnmatchedModuleAssumeWarning(module: String)
   // A `where returns` clause on an `assume <module>.<function>` line naming
   // one of this package's
   // own ordinary Gleam functions. The same rule as
-  // `StaleFunctionExternalWarning` one channel over: the body is visible, so
+  // `StaleFunctionAssumeWarning` one channel over: the body is visible, so
   // every caller resolves what it hands back for itself and the line declares
   // nothing. It is ignored and the body walked instead.
   StaleReturnsClauseWarning(function: String)
@@ -918,7 +912,7 @@ pub type Warning {
   // so no call site can ever bind it and resolution stays conservative.
   // Scoped to lines with an explicit bound list: a boundless polymorphic
   // assume resolves through registry-synthesized bounds and is not a defect.
-  UnboundExternalTermVariableWarning(function: String, free_vars: List(String))
+  UnboundAssumeTermVariableWarning(function: String, free_vars: List(String))
   // A bound whose payload names a *different* bound's parameter, on a line
   // whose effects term or `where returns` clause uses that variable. The two
   // binding channels then disagree: the term binds the variable through the

--- a/test/annotation_test.gleam
+++ b/test/annotation_test.gleam
@@ -8,10 +8,10 @@ import gleeunit/should
 import graded/internal/annotation
 import graded/internal/effect_term
 import graded/internal/types.{
-  type EffectTerm, AnnotationLine, BlankLine, Check, CommentLine,
-  EffectAnnotation, Effects, ExternalAnnotation, ExternalLine, FunctionExternal,
-  ModuleExternal, ParamBound, Polymorphic, RetainedAssumeLine, Specific, TAbs,
-  TApp, TLabels, TUnion, TVar, TypeFieldAnnotation, TypeFieldLine, UnknownClause,
+  type EffectTerm, AnnotationLine, AssumeAnnotation, AssumeLine, BlankLine,
+  Check, CommentLine, EffectAnnotation, Effects, FieldAnnotation,
+  FieldAssumeLine, FunctionAssume, ModuleAssume, ParamBound, Polymorphic,
+  RetainedAssumeLine, Specific, TAbs, TApp, TLabels, TUnion, TVar, UnknownClause,
   Wildcard,
 }
 import qcheck
@@ -377,7 +377,7 @@ pub fn parse_type_field_multiple_effects_test() {
 
 pub fn format_type_field_test() {
   let tf =
-    TypeFieldAnnotation(
+    FieldAnnotation(
       module: None,
       type_name: "Handler",
       field: "on_click",
@@ -389,7 +389,7 @@ pub fn format_type_field_test() {
 
 pub fn format_type_field_qualified_test() {
   let tf =
-    TypeFieldAnnotation(
+    FieldAnnotation(
       module: Some("myapp/router"),
       type_name: "Handler",
       field: "on_click",
@@ -426,7 +426,7 @@ pub fn parse_external_test() {
   let assert Ok(file) = annotation.parse_file(input)
   let assert [ext] = annotation.extract_externals(file)
   ext.module |> should.equal("gleam/http/request")
-  ext.target |> should.equal(FunctionExternal("send"))
+  ext.target |> should.equal(FunctionAssume("send"))
   ext.effects |> should.equal(Some(Specific(set.from_list(["Http"]))))
 }
 
@@ -435,15 +435,15 @@ pub fn parse_external_pure_test() {
   let assert Ok(file) = annotation.parse_file(input)
   let assert [ext] = annotation.extract_externals(file)
   ext.module |> should.equal("gleam/json")
-  ext.target |> should.equal(FunctionExternal("decode"))
+  ext.target |> should.equal(FunctionAssume("decode"))
   ext.effects |> should.equal(Some(Specific(set.new())))
 }
 
 pub fn format_external_test() {
   let ext =
-    ExternalAnnotation(
+    AssumeAnnotation(
       "gleam/httpc",
-      FunctionExternal("send"),
+      FunctionAssume("send"),
       params: [],
       effects: Some(Specific(set.from_list(["Http"]))),
       returns: None,
@@ -461,7 +461,7 @@ pub fn parse_assume_module_test() {
   let assert Ok(file) = annotation.parse_file("assume gleam/io : [Stdout]")
   let assert [ext] = annotation.extract_externals(file)
   ext.module |> should.equal("gleam/io")
-  ext.target |> should.equal(ModuleExternal)
+  ext.target |> should.equal(ModuleAssume)
   ext.effects |> should.equal(Some(Specific(set.from_list(["Stdout"]))))
 }
 
@@ -470,7 +470,7 @@ pub fn parse_assume_function_test() {
     annotation.parse_file("assume gleam/http/request.send : [Http]")
   let assert [ext] = annotation.extract_externals(file)
   ext.module |> should.equal("gleam/http/request")
-  ext.target |> should.equal(FunctionExternal("send"))
+  ext.target |> should.equal(FunctionAssume("send"))
   ext.effects |> should.equal(Some(Specific(set.from_list(["Http"]))))
 }
 
@@ -520,7 +520,7 @@ pub fn parse_assume_function_with_bounds_test() {
   let assert Ok(file) = annotation.parse_file("assume m/ffi.each(f: [f]) : [f]")
   let assert [ext] = annotation.extract_externals(file)
   ext.module |> should.equal("m/ffi")
-  ext.target |> should.equal(FunctionExternal("each"))
+  ext.target |> should.equal(FunctionAssume("each"))
   ext.params |> should.equal([ParamBound("f", TVar("f"))])
   ext.effects
   |> should.equal(Some(Polymorphic(set.new(), set.from_list(["f"]))))
@@ -1087,7 +1087,7 @@ pub fn type_field_roundtrip_test() {
   use tf <- qcheck.given(generators.type_field_gen())
   let formatted = annotation.format_type_field(tf)
   let assert Ok(file) = annotation.parse_file(formatted)
-  let assert [TypeFieldLine(parsed, _)] = file.lines
+  let assert [FieldAssumeLine(parsed, _)] = file.lines
   parsed |> should.equal(tf)
 }
 
@@ -1095,7 +1095,7 @@ pub fn external_roundtrip_test() {
   use ext <- qcheck.given(generators.external_gen())
   let formatted = annotation.format_external(ext)
   let assert Ok(file) = annotation.parse_file(formatted)
-  let assert [ExternalLine(parsed, _)] = file.lines
+  let assert [AssumeLine(parsed, _)] = file.lines
   parsed |> should.equal(ext)
 }
 
@@ -1174,10 +1174,10 @@ pub fn merge_inferred_drops_effect_for_external_test() {
   // functions are kept.
   let file =
     types.GradedFile(lines: [
-      ExternalLine(
-        ExternalAnnotation(
+      AssumeLine(
+        AssumeAnnotation(
           module: "app",
-          target: FunctionExternal("ffi"),
+          target: FunctionAssume("ffi"),
           params: [],
           effects: Some(types.Specific(set.new())),
           returns: None,
@@ -1233,10 +1233,10 @@ fn inferred_line(
 }
 
 fn module_assume(module: String) -> types.GradedLine {
-  ExternalLine(
-    ExternalAnnotation(
+  AssumeLine(
+    AssumeAnnotation(
       module:,
-      target: ModuleExternal,
+      target: ModuleAssume,
       params: [],
       effects: Some(types.Specific(set.new())),
       returns: None,
@@ -1246,10 +1246,10 @@ fn module_assume(module: String) -> types.GradedLine {
 }
 
 fn function_assume(module: String, function: String) -> types.GradedLine {
-  ExternalLine(
-    ExternalAnnotation(
+  AssumeLine(
+    AssumeAnnotation(
       module:,
-      target: FunctionExternal(function),
+      target: FunctionAssume(function),
       params: [],
       effects: Some(types.Specific(set.new())),
       returns: None,
@@ -1298,10 +1298,10 @@ pub fn merge_inferred_composes_the_two_assume_channels_test() {
   merged_effects(
     types.GradedFile(lines: [
       module_assume("db"),
-      ExternalLine(
-        ExternalAnnotation(
+      AssumeLine(
+        AssumeAnnotation(
           module: "db",
-          target: FunctionExternal("make"),
+          target: FunctionAssume("make"),
           params: [],
           effects: None,
           returns: Some(TLabels(set.from_list(["Net"]))),
@@ -1336,10 +1336,10 @@ pub fn merge_inferred_keeps_a_declared_returns_clause_test() {
   // A declaration is preserved in place and never regenerated, and the inferred
   // clause for the same name is dropped: one name, one answer.
   let declared =
-    ExternalLine(
-      ExternalAnnotation(
+    AssumeLine(
+      AssumeAnnotation(
         module: "app",
-        target: FunctionExternal("make"),
+        target: FunctionAssume("make"),
         params: [],
         effects: None,
         returns: Some(TLabels(set.from_list(["Net"]))),
@@ -1396,10 +1396,10 @@ pub fn merge_inferred_keeps_an_unmatched_returns_clause_test() {
   // still the author's line, so the stale-removal path does not reach it.
   let file =
     types.GradedFile(lines: [
-      ExternalLine(
-        ExternalAnnotation(
+      AssumeLine(
+        AssumeAnnotation(
           module: "app",
-          target: FunctionExternal("make"),
+          target: FunctionAssume("make"),
           params: [],
           effects: None,
           returns: Some(TLabels(set.from_list(["Net"]))),
@@ -1417,10 +1417,10 @@ pub fn merge_inferred_rewrites_a_stale_returns_clause_test() {
   // written on the function's `effects` line.
   let file =
     types.GradedFile(lines: [
-      ExternalLine(
-        ExternalAnnotation(
+      AssumeLine(
+        AssumeAnnotation(
           module: "app",
-          target: FunctionExternal("make"),
+          target: FunctionAssume("make"),
           params: [],
           effects: None,
           returns: Some(TLabels(set.from_list(["Net"]))),
@@ -1465,10 +1465,10 @@ pub fn merge_inferred_keeps_the_two_stale_channels_apart_test() {
   // anything about.
   let file =
     types.GradedFile(lines: [
-      ExternalLine(
-        ExternalAnnotation(
+      AssumeLine(
+        AssumeAnnotation(
           module: "app",
-          target: FunctionExternal("make"),
+          target: FunctionAssume("make"),
           params: [],
           effects: None,
           returns: Some(TLabels(set.from_list(["Net"]))),
@@ -1523,10 +1523,10 @@ pub fn merge_inferred_keeps_bounds_on_a_stale_conversion_test() {
   // path rather than being dropped by the conversion.
   let file =
     types.GradedFile(lines: [
-      ExternalLine(
-        ExternalAnnotation(
+      AssumeLine(
+        AssumeAnnotation(
           module: "app",
-          target: FunctionExternal("make"),
+          target: FunctionAssume("make"),
           params: [ParamBound("cb", TVar("cb"))],
           effects: Some(Polymorphic(set.new(), set.from_list(["cb"]))),
           returns: None,
@@ -1548,10 +1548,10 @@ pub fn a_bounded_external_still_suppresses_the_inferred_line_test() {
   // Suppression keys off the effects claim's presence, not the bound list.
   let file =
     types.GradedFile(lines: [
-      ExternalLine(
-        ExternalAnnotation(
+      AssumeLine(
+        AssumeAnnotation(
           module: "m/ffi",
-          target: FunctionExternal("each"),
+          target: FunctionAssume("each"),
           params: [ParamBound("f", TVar("f"))],
           effects: Some(Polymorphic(set.new(), set.from_list(["f"]))),
           returns: None,
@@ -1576,10 +1576,10 @@ pub fn a_clause_only_bounded_line_does_not_suppress_the_inferred_line_test() {
   // A clause-only line claims nothing on the effects channel, bounds or not,
   // so the inferred `effects` line survives beside it.
   let declared =
-    ExternalLine(
-      ExternalAnnotation(
+    AssumeLine(
+      AssumeAnnotation(
         module: "m/ffi",
-        target: FunctionExternal("wrap"),
+        target: FunctionAssume("wrap"),
         params: [ParamBound("cb", TVar("cb"))],
         effects: None,
         returns: Some(TVar("cb")),
@@ -1802,7 +1802,7 @@ pub fn declared_returns_clause_round_trip_test() {
   let assert Ok(file) = annotation.parse_file(line)
   let assert [declared] = annotation.extract_externals(file)
   declared.module |> should.equal("app/ffi")
-  declared.target |> should.equal(FunctionExternal("make_client"))
+  declared.target |> should.equal(FunctionAssume("make_client"))
   declared.returns |> should.equal(Some(TLabels(set.from_list(["Net"]))))
   annotation.format_file(file) |> should.equal(line)
 }
@@ -1975,7 +1975,7 @@ pub fn a_module_assume_with_only_an_unknown_clause_is_retained_test() {
 }
 
 pub fn a_field_assume_with_only_an_unknown_clause_is_retained_test() {
-  // `TypeFieldAnnotation.effects` is a bare term, so a field line cannot claim
+  // `FieldAnnotation.effects` is a bare term, so a field line cannot claim
   // nothing — and fabricating `[]` would flip *keys nothing* into *is pure*.
   let line = "assume m.Handler.on_click where future : [X]"
   let assert Ok(file) = annotation.parse_file(line)

--- a/test/answer_test.gleam
+++ b/test/answer_test.gleam
@@ -4,8 +4,8 @@ import gleeunit/should
 import graded/internal/answer
 import graded/internal/types.{
   Catalog, CommittedSpec, Declared, DependencySpec, FunctionEntry,
-  ModuleExternalEntry, ModuleExternalOrigin, ParamBound, TAbs, TLabels, TUnion,
-  TVar, UserExternal,
+  ModuleAssumeEntry, ModuleAssumeOrigin, ParamBound, TAbs, TLabels, TUnion, TVar,
+  UserAssume,
 }
 
 // Rendering one lookup
@@ -141,7 +141,7 @@ pub fn a_module_level_external_states_its_precedence_test() {
     bounds: [],
     term: labels(["Time"]),
     source: answer.Entry(
-      ModuleExternalEntry(origin: ModuleExternalOrigin(source: UserExternal)),
+      ModuleAssumeEntry(origin: ModuleAssumeOrigin(source: UserAssume)),
       types.NoFallback,
     ),
   )
@@ -259,7 +259,7 @@ pub fn the_graded_renderer_writes_spec_syntax_test() {
 pub fn the_graded_renderer_comments_the_source_test() {
   // The same vocabulary as prose, inside a comment, so the whole answer still
   // parses as `.graded`.
-  from(UserExternal)
+  from(UserAssume)
   |> answer.render(answer.Graded)
   |> should.equal(
     "effects app.run : [Stdout]\n// resolved from your spec's `assume` line",

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -556,7 +556,7 @@ pub fn run(items) {
 fn check_source_with_type_fields(
   source: String,
   annotations: List(EffectAnnotation),
-  type_fields: List(types.TypeFieldAnnotation),
+  type_fields: List(types.FieldAnnotation),
 ) -> List(types.Violation) {
   let assert Ok(module) = glance.module(source)
   let kb =
@@ -579,7 +579,7 @@ fn check_source_with_type_fields(
 pub fn field_call_typed_with_registry_test() {
   let source = "pub fn view(handler: Handler) { handler.on_click(event) }"
   let type_fields = [
-    types.TypeFieldAnnotation(
+    types.FieldAnnotation(
       module: None,
       type_name: "Handler",
       field: "on_click",
@@ -606,7 +606,7 @@ pub fn field_call_typed_with_registry_test() {
 fn check_source_with_girard(
   source: String,
   annotations: List(EffectAnnotation),
-  type_fields: List(types.TypeFieldAnnotation),
+  type_fields: List(types.FieldAnnotation),
 ) -> List(types.Violation) {
   let assert Ok(module) = glance.module(source)
   let module_types = girard_types(module)
@@ -646,9 +646,9 @@ pub fn run(msg: String) -> Nil {
 }
 "
 
-fn validator_to_error_stdout() -> List(types.TypeFieldAnnotation) {
+fn validator_to_error_stdout() -> List(types.FieldAnnotation) {
   [
-    types.TypeFieldAnnotation(
+    types.FieldAnnotation(
       module: None,
       type_name: "Validator",
       field: "to_error",
@@ -811,9 +811,9 @@ pub fn run_external(config: Config, message: String) -> Nil {
   }
 }
 
-fn box_run_stdout() -> List(types.TypeFieldAnnotation) {
+fn box_run_stdout() -> List(types.FieldAnnotation) {
   [
-    types.TypeFieldAnnotation(
+    types.FieldAnnotation(
       module: None,
       type_name: "Box",
       field: "run",
@@ -826,7 +826,7 @@ fn box_run_stdout() -> List(types.TypeFieldAnnotation) {
 // public function's inferred effect set by name.
 fn infer_effects_with_girard(
   source: String,
-  type_fields: List(types.TypeFieldAnnotation),
+  type_fields: List(types.FieldAnnotation),
 ) -> dict.Dict(String, types.EffectSet) {
   let assert Ok(module) = glance.module(source)
   checker.infer(
@@ -934,7 +934,7 @@ pub fn wired_producer_call_field_uses_module_types_test() {
 pub fn field_call_violates_check_test() {
   let source = "pub fn view(handler: Handler) { handler.on_click(event) }"
   let type_fields = [
-    types.TypeFieldAnnotation(
+    types.FieldAnnotation(
       module: None,
       type_name: "Handler",
       field: "on_click",
@@ -1324,11 +1324,10 @@ pub fn caller() -> Nil {
 fn check_source_with_externals(
   source: String,
   annotations: List(EffectAnnotation),
-  externals: List(types.ExternalAnnotation),
+  externals: List(types.AssumeAnnotation),
 ) -> List(types.Violation) {
   let assert Ok(module) = glance.module(source)
-  let kb =
-    effects.with_externals(knowledge_base(), externals, types.UserExternal)
+  let kb = effects.with_externals(knowledge_base(), externals, types.UserAssume)
   let #(violations, _warnings) =
     checker.check(
       module,
@@ -1349,9 +1348,9 @@ pub fn external_resolves_effects_test() {
     "import gleam/httpc
 pub fn fetch() { httpc.send(request) }"
   let externals = [
-    types.ExternalAnnotation(
+    types.AssumeAnnotation(
       "gleam/httpc",
-      types.FunctionExternal("send"),
+      types.FunctionAssume("send"),
       params: [],
       effects: Some(Specific(set.from_list(["Http"]))),
       returns: None,
@@ -1375,9 +1374,9 @@ pub fn external_violates_check_test() {
     "import gleam/httpc
 pub fn fetch() { httpc.send(request) }"
   let externals = [
-    types.ExternalAnnotation(
+    types.AssumeAnnotation(
       "gleam/httpc",
-      types.FunctionExternal("send"),
+      types.FunctionAssume("send"),
       params: [],
       effects: Some(Specific(set.from_list(["Http"]))),
       returns: None,
@@ -1480,9 +1479,9 @@ pub fn read_clock() { now() }"
 // FFI idiom: an `@external` binding paired with a same-module wrapper.
 pub fn external_same_module_resolves_declared_effects_test() {
   let externals = [
-    types.ExternalAnnotation(
+    types.AssumeAnnotation(
       "ffi_mod",
-      types.FunctionExternal("now"),
+      types.FunctionAssume("now"),
       params: [],
       effects: Some(Specific(set.from_list(["Time"]))),
       returns: None,
@@ -1491,7 +1490,7 @@ pub fn external_same_module_resolves_declared_effects_test() {
   infer_external_wrapper(effects.with_externals(
     knowledge_base(),
     externals,
-    types.UserExternal,
+    types.UserAssume,
   ))
   |> should.equal(Specific(set.from_list(["Time"])))
 }
@@ -3306,7 +3305,7 @@ pub fn infer_operator_param_threads_all_callbacks_test() {
     effects.with_externals(
       knowledge_base(),
       [fs_read_external()],
-      types.UserExternal,
+      types.UserAssume,
     )
   let source =
     "
@@ -3343,7 +3342,7 @@ pub fn infer_operator_param_non_adjacent_callbacks_test() {
     effects.with_externals(
       knowledge_base(),
       [fs_read_external()],
-      types.UserExternal,
+      types.UserAssume,
     )
   let source =
     "
@@ -4484,10 +4483,10 @@ pub fn caller() -> Nil {
 }
 
 // A `fs.read : [FileSystem]` external for second-order operator tests.
-fn fs_read_external() -> types.ExternalAnnotation {
-  types.ExternalAnnotation(
+fn fs_read_external() -> types.AssumeAnnotation {
+  types.AssumeAnnotation(
     "fs",
-    types.FunctionExternal("read"),
+    types.FunctionAssume("read"),
     params: [],
     effects: Some(Specific(set.from_list(["FileSystem"]))),
     returns: None,
@@ -4507,7 +4506,7 @@ fn second_order_violations(
     effects.with_externals(
       knowledge_base(),
       [fs_read_external()],
-      types.UserExternal,
+      types.UserAssume,
     )
   let registry = signatures.from_glance_module("app", module)
   let ann =
@@ -5254,7 +5253,7 @@ pub fn format_warning_unground_returns_clause_test() {
 }
 
 pub fn format_warning_unbound_external_term_variable_test() {
-  types.UnboundExternalTermVariableWarning(function: "ffi.each", free_vars: [
+  types.UnboundAssumeTermVariableWarning(function: "ffi.each", free_vars: [
     "x",
   ])
   |> checker.format_warning("proj.graded", _)
@@ -5597,7 +5596,7 @@ pub fn format_violation_states_a_reason_and_an_origin_together_test() {
     QualifiedName("<field>", "repo.find"),
     Specific(set.from_list(["Unknown"])),
     Some(types.FieldNotAnnotated("dep/repo", "Repo")),
-    Some(types.ModuleExternalOrigin(source: types.UserExternal)),
+    Some(types.ModuleAssumeOrigin(source: types.UserAssume)),
   )
   |> should.equal(
     "src/app.gleam: run calls field `find` on `repo` of type `dep/repo.Repo`, which has no effect annotation for that field, with unresolved effects [Unknown] (from a module-level `assume` in your spec) but declared []",
@@ -6111,7 +6110,7 @@ pub fn run(repo: Repo) -> Nil {
   repo.find(\"x\")
 }"
   let type_fields = [
-    types.TypeFieldAnnotation(
+    types.FieldAnnotation(
       module: None,
       type_name: "Repo",
       field: "find",
@@ -6121,7 +6120,7 @@ pub fn run(repo: Repo) -> Nil {
   let assert [violation] =
     check_source_with_type_fields(source, [pure_check("run")], type_fields)
   violation.explanation.origin
-  |> should.equal(Some(types.TypeLine(source: types.CommittedSpec)))
+  |> should.equal(Some(types.FieldAssumeOrigin(source: types.CommittedSpec)))
   checker.format_violation("src/app.gleam", violation)
   |> should.equal(
     "src/app.gleam: run calls field `find` on `repo` with effects [Storage] (from a field `assume` in your spec) but declared []",

--- a/test/effect_cli_test.gleam
+++ b/test/effect_cli_test.gleam
@@ -62,7 +62,7 @@ pub fn a_committed_effects_line_does_not_answer_for_an_external_test() {
     graded.run_effect_formatted(
       fixtures,
       "external_budget.stale_inferred",
-      answer.Prose,
+      graded.Prose,
     )
   prose
   |> should.equal(
@@ -461,7 +461,7 @@ pub fn a_path_dependency_answer_names_the_dependency_test() {
 
 fn prose(name: String) -> String {
   let assert Ok(output) =
-    graded.run_effect_formatted(fixtures, name, answer.Prose)
+    graded.run_effect_formatted(fixtures, name, graded.Prose)
   output
 }
 
@@ -515,9 +515,9 @@ fn out_of_reach_outputs(name: String, body: String) -> #(String, String) {
       ),
     ])
   let assert Ok(prose_output) =
-    graded.run_effect_formatted(project, "dep/ffi.run", answer.Prose)
+    graded.run_effect_formatted(project, "dep/ffi.run", graded.Prose)
   let assert Ok(graded_output) =
-    graded.run_effect_formatted(project, "dep/ffi.run", answer.Graded)
+    graded.run_effect_formatted(project, "dep/ffi.run", graded.Graded)
   cleanup(project)
   #(prose_output, graded_output)
 }
@@ -588,7 +588,7 @@ pub fn op() -> Nil {
       ),
     ])
   let assert Ok(prose_output) =
-    graded.run_effect_formatted(project, "raw.op", answer.Prose)
+    graded.run_effect_formatted(project, "raw.op", graded.Prose)
   prose_output
   |> should.equal(
     "raw.op has effects [Disk, Unknown]; part of them could not be determined
@@ -596,7 +596,7 @@ pub fn op() -> Nil {
   plus its Gleam fallback body, which runs on the targets its `@external` declares no implementation for: [Disk]",
   )
   let assert Ok(graded_output) =
-    graded.run_effect_formatted(project, "raw.op", answer.Graded)
+    graded.run_effect_formatted(project, "raw.op", graded.Graded)
   graded_output
   |> should_parse
   |> should.equal(
@@ -619,7 +619,7 @@ pub fn graded_format_still_round_trips_test() {
   // The parseable contract now belongs to `--format=graded`, and holds for the
   // provenance-carrying answers too.
   let assert Ok(output) =
-    graded.run_effect_formatted(fixtures, "fake_clock.now", answer.Graded)
+    graded.run_effect_formatted(fixtures, "fake_clock.now", graded.Graded)
   should_parse(output)
   |> should.equal(
     "effects fake_clock.now : [Time]\n// resolved via module-level `assume` for fake_clock",
@@ -632,9 +632,9 @@ pub fn the_formats_agree_on_the_effect_set_test() {
   ["impure_view.view", "fake_clock.now", "external_same_module.read_clock"]
   |> list.each(fn(name) {
     let assert Ok(graded_output) =
-      graded.run_effect_formatted(fixtures, name, answer.Graded)
+      graded.run_effect_formatted(fixtures, name, graded.Graded)
     let assert Ok(prose_output) =
-      graded.run_effect_formatted(fixtures, name, answer.Prose)
+      graded.run_effect_formatted(fixtures, name, graded.Prose)
     let assert Ok(effect_set) = string.split_once(graded_output, " : ")
     let assert Ok(#(rendered, _)) =
       string.split_once(effect_set.1 <> "\n", "\n")
@@ -882,7 +882,10 @@ pub fn effect_over_an_unparseable_spec_errors_test() {
   |> should.equal(
     Error(graded.GradedParseError(
       root <> "/proj.graded",
-      annotation.InvalidLine(2, "not a graded line"),
+      annotation.describe_parse_error(annotation.InvalidLine(
+        2,
+        "not a graded line",
+      )),
     )),
   )
   cleanup(root)

--- a/test/effects_test.gleam
+++ b/test/effects_test.gleam
@@ -517,10 +517,10 @@ fn external(
   module: String,
   function: String,
   labels: List(String),
-) -> types.ExternalAnnotation {
-  types.ExternalAnnotation(
+) -> types.AssumeAnnotation {
+  types.AssumeAnnotation(
     module:,
-    target: types.FunctionExternal(function),
+    target: types.FunctionAssume(function),
     params: [],
     effects: Some(Specific(set.from_list(labels))),
     returns: None,
@@ -530,10 +530,10 @@ fn external(
 fn module_external(
   module: String,
   labels: List(String),
-) -> types.ExternalAnnotation {
-  types.ExternalAnnotation(
+) -> types.AssumeAnnotation {
+  types.AssumeAnnotation(
     module:,
-    target: types.ModuleExternal,
+    target: types.ModuleAssume,
     params: [],
     effects: Some(Specific(set.from_list(labels))),
     returns: None,
@@ -580,10 +580,10 @@ pub fn function_external_records_its_origin_test() {
   effects.with_externals(
     effects.new_knowledge_base(),
     [external("app", "now", ["Time"])],
-    types.UserExternal,
+    types.UserAssume,
   )
   |> origin_of(QualifiedName("app", "now"))
-  |> should.equal(option.Some(types.UserExternal))
+  |> should.equal(option.Some(types.UserAssume))
 }
 
 pub fn inferred_entry_records_its_origin_test() {
@@ -629,8 +629,8 @@ pub fn a_module_external_names_the_file_that_declared_it_test() {
   effects.lookup(kb, QualifiedName("fake_clock", "now"))
   |> should.equal(effects.Known(
     effect_term.from_effect_set(Specific(set.from_list(["Time"]))),
-    types.ModuleExternalEntry(
-      origin: types.ModuleExternalOrigin(source: types.Catalog("fake_clock_pkg")),
+    types.ModuleAssumeEntry(
+      origin: types.ModuleAssumeOrigin(source: types.Catalog("fake_clock_pkg")),
     ),
   ))
 }
@@ -951,8 +951,8 @@ pub fn a_dependency_module_external_resolves_test() {
   |> effects.lookup(QualifiedName("dep/internal", "anything"))
   |> should.equal(effects.Known(
     effect_term.from_effect_set(Specific(set.from_list(["Db"]))),
-    types.ModuleExternalEntry(
-      origin: types.ModuleExternalOrigin(source: types.DependencySpec("dep")),
+    types.ModuleAssumeEntry(
+      origin: types.ModuleAssumeOrigin(source: types.DependencySpec("dep")),
     ),
   ))
 }
@@ -988,12 +988,10 @@ pub fn a_user_external_beats_a_dependency_external_test() {
   )
   |> effects.with_externals(
     [external("dep/ffi", "now", ["Mocked"])],
-    types.UserExternal,
+    types.UserAssume,
   )
   |> entry_of(QualifiedName("dep/ffi", "now"))
-  |> should.equal(
-    Ok(#(Specific(set.from_list(["Mocked"])), types.UserExternal)),
-  )
+  |> should.equal(Ok(#(Specific(set.from_list(["Mocked"])), types.UserAssume)))
 }
 
 pub fn a_dependency_external_beats_the_catalog_test() {
@@ -1111,13 +1109,10 @@ pub fn a_path_dep_spec_yields_to_a_user_external_test() {
     ),
   ]
   let declaration =
-    types.ExternalAnnotation(
-      ..external("dep", "run", ["Mocked"]),
-      params: bounds,
-    )
+    types.AssumeAnnotation(..external("dep", "run", ["Mocked"]), params: bounds)
   let kb =
     effects.new_knowledge_base()
-    |> effects.with_externals([declaration], types.UserExternal)
+    |> effects.with_externals([declaration], types.UserAssume)
     |> effects.with_path_dep_spec(
       dep_spec(
         "build/eff_path_dep_under_user",
@@ -1127,9 +1122,7 @@ pub fn a_path_dep_spec_yields_to_a_user_external_test() {
       types.PathDependency("dep"),
     )
   entry_of(kb, QualifiedName("dep", "run"))
-  |> should.equal(
-    Ok(#(Specific(set.from_list(["Mocked"])), types.UserExternal)),
-  )
+  |> should.equal(Ok(#(Specific(set.from_list(["Mocked"])), types.UserAssume)))
   effects.lookup_param_bounds(kb, QualifiedName("dep", "run"))
   |> should.equal(bounds)
 }
@@ -1151,21 +1144,21 @@ pub fn a_path_dep_module_external_overrides_only_the_catalogs_test() {
     )
     |> effects.with_externals(
       [module_external("dep/declared", ["Mocked"])],
-      types.UserExternal,
+      types.UserAssume,
     )
     |> effects.with_path_dep_spec(spec, types.PathDependency("dep"))
   entry_of(kb, QualifiedName("dep/catalogued", "anything"))
   |> should.equal(
     Ok(#(
       Specific(set.from_list(["Time"])),
-      types.ModuleExternalOrigin(source: types.PathDependency("dep")),
+      types.ModuleAssumeOrigin(source: types.PathDependency("dep")),
     )),
   )
   entry_of(kb, QualifiedName("dep/declared", "anything"))
   |> should.equal(
     Ok(#(
       Specific(set.from_list(["Mocked"])),
-      types.ModuleExternalOrigin(source: types.UserExternal),
+      types.ModuleAssumeOrigin(source: types.UserAssume),
     )),
   )
 }
@@ -1178,7 +1171,7 @@ pub fn a_path_dep_function_entry_beats_a_module_external_test() {
     effects.new_knowledge_base()
     |> effects.with_externals(
       [module_external("dep/ffi", ["Mocked"])],
-      types.UserExternal,
+      types.UserAssume,
     )
     |> effects.with_path_dep_spec(
       dep_spec(
@@ -1196,7 +1189,7 @@ pub fn a_path_dep_function_entry_beats_a_module_external_test() {
   // Every other function in the module still answers from the consumer's line.
   origin_of(kb, QualifiedName("dep/ffi", "later"))
   |> should.equal(
-    option.Some(types.ModuleExternalOrigin(source: types.UserExternal)),
+    option.Some(types.ModuleAssumeOrigin(source: types.UserAssume)),
   )
 }
 
@@ -1402,13 +1395,13 @@ pub fn type_fields_distinguish_modules_test() {
     effects.with_type_fields(
       knowledge_base(),
       [
-        types.TypeFieldAnnotation(
+        types.FieldAnnotation(
           option.Some("app/a"),
           "Validator",
           "f",
           effect_term.from_effect_set(Specific(set.from_list(["Http"]))),
         ),
-        types.TypeFieldAnnotation(
+        types.FieldAnnotation(
           option.Some("app/b"),
           "Validator",
           "f",
@@ -1819,7 +1812,7 @@ pub fn a_module_assume_does_not_bury_a_clause_on_the_same_module_test() {
   |> should.equal(
     Ok(#(
       Specific(set.new()),
-      types.ModuleExternalOrigin(types.DependencySpec("db")),
+      types.ModuleAssumeOrigin(types.DependencySpec("db")),
     )),
   )
 }
@@ -2247,7 +2240,7 @@ pub fn a_duplicate_declaration_wins_term_and_bounds_together_test() {
     effects.empty_knowledge_base()
     |> effects.with_externals(
       annotation.extract_externals(file),
-      types.UserExternal,
+      types.UserAssume,
     )
   let name = QualifiedName("m", "f")
   let assert effects.Known(term, _source) = effects.lookup(base, name)
@@ -2297,15 +2290,15 @@ fn bodyless_external_base(
   )
   |> effects.with_externals(
     [
-      types.ExternalAnnotation(
+      types.AssumeAnnotation(
         module: higher_order_ffi.module,
-        target: types.FunctionExternal(higher_order_ffi.function),
+        target: types.FunctionAssume(higher_order_ffi.function),
         params:,
         effects: Some(Specific(set.from_list(["Time"]))),
         returns: None,
       ),
     ],
-    types.UserExternal,
+    types.UserAssume,
   )
   |> effects.with_foreign_functions(
     dict.from_list([
@@ -2431,7 +2424,7 @@ pub fn a_declared_gleam_function_widens_on_the_value_channel_alone_test() {
     effects.new_knowledge_base()
     |> effects.with_externals(
       [module_external("dep/list", [])],
-      types.ModuleExternalOrigin(types.CommittedSpec),
+      types.ModuleAssumeOrigin(types.CommittedSpec),
     )
     |> effects.with_callback_params(dict.from_list([#(name, ["with"])]))
   let assert effects.Known(term, _source) = effects.lookup_declared(base, name)

--- a/test/format_cli_test.gleam
+++ b/test/format_cli_test.gleam
@@ -72,10 +72,11 @@ pub fn format_stdin_is_idempotent_over_returns_clauses_test() {
 // A spec still on a retired spelling is refused by name, with the rewrite —
 // which is the migration instruction an editor shows.
 pub fn format_stdin_reports_a_retired_spelling_test() {
-  let error =
+  let assert graded.GradedParseError(path:, message:) =
     graded.run_format_stdin("external effects m/ffi.send : [Http]")
     |> should.be_error
-  annotation.describe_parse_error(error)
+  path |> should.equal("<stdin>")
+  message
   |> should.equal(
     "1: external effects m/ffi.send : [Http]\n  `external effects <path> : <effects>` is retired; write `assume <path> : <effects>`",
   )
@@ -99,6 +100,12 @@ pub fn format_stdin_fails_on_unparseable_input_test() {
 pub fn format_stdin_names_the_rejected_line_test() {
   graded.run_format_stdin("effects m.f : []\n" <> bad_spec)
   |> should.equal(
-    Error(annotation.InvalidLine(2, "@@@ not a valid graded line @@@")),
+    Error(graded.GradedParseError(
+      "<stdin>",
+      annotation.describe_parse_error(annotation.InvalidLine(
+        2,
+        "@@@ not a valid graded line @@@",
+      )),
+    )),
   )
 }

--- a/test/format_test.gleam
+++ b/test/format_test.gleam
@@ -4,8 +4,8 @@ import gleam/string
 import gleeunit/should
 import graded/internal/annotation
 import graded/internal/types.{
-  AnnotationLine, BlankLine, Check, CommentLine, Effects, ExternalLine,
-  RetainedAssumeLine, TypeFieldLine,
+  AnnotationLine, AssumeLine, BlankLine, Check, CommentLine, Effects,
+  FieldAssumeLine, RetainedAssumeLine,
 }
 import qcheck
 
@@ -147,8 +147,8 @@ pub fn format_sorted_section_order_test() {
 fn section_index(line: types.GradedLine) -> Int {
   case line {
     CommentLine(_) -> 0
-    ExternalLine(_, _) -> 1
-    TypeFieldLine(_, _) -> 1
+    AssumeLine(_, _) -> 1
+    FieldAssumeLine(_, _) -> 1
     RetainedAssumeLine(..) -> 1
     AnnotationLine(a, _) ->
       case a.kind {

--- a/test/generators.gleam
+++ b/test/generators.gleam
@@ -4,11 +4,11 @@ import gleam/option.{None, Some}
 import gleam/set
 import graded/internal/effect_term
 import graded/internal/types.{
-  type EffectSet, type EffectTerm, AnnotationLine, BlankLine, Check, CommentLine,
-  EffectAnnotation, Effects, ExternalAnnotation, ExternalLine, FunctionExternal,
-  GradedFile, ModuleExternal, ParamBound, Polymorphic, RetainedAssumeLine,
-  Specific, TAbs, TApp, TLabels, TTop, TUnion, TVar, TypeFieldAnnotation,
-  TypeFieldLine, UnknownClause, Wildcard,
+  type EffectSet, type EffectTerm, AnnotationLine, AssumeAnnotation, AssumeLine,
+  BlankLine, Check, CommentLine, EffectAnnotation, Effects, FieldAnnotation,
+  FieldAssumeLine, FunctionAssume, GradedFile, ModuleAssume, ParamBound,
+  Polymorphic, RetainedAssumeLine, Specific, TAbs, TApp, TLabels, TTop, TUnion,
+  TVar, UnknownClause, Wildcard,
 }
 import qcheck
 
@@ -249,7 +249,7 @@ pub fn annotation_gen() -> qcheck.Generator(types.EffectAnnotation) {
   EffectAnnotation(kind:, function:, params:, effects:, returns:)
 }
 
-pub fn type_field_gen() -> qcheck.Generator(types.TypeFieldAnnotation) {
+pub fn type_field_gen() -> qcheck.Generator(types.FieldAnnotation) {
   let type_name_gen =
     qcheck.from_generators(qcheck.return("Handler"), [
       qcheck.return("Request"),
@@ -265,12 +265,12 @@ pub fn type_field_gen() -> qcheck.Generator(types.TypeFieldAnnotation) {
     first_order_term_gen(),
     fn(tf, effects) {
       let #(type_name, field) = tf
-      TypeFieldAnnotation(module: None, type_name:, field:, effects:)
+      FieldAnnotation(module: None, type_name:, field:, effects:)
     },
   )
 }
 
-pub fn external_gen() -> qcheck.Generator(types.ExternalAnnotation) {
+pub fn external_gen() -> qcheck.Generator(types.AssumeAnnotation) {
   let module_name_gen =
     qcheck.from_generators(qcheck.return("gleam/io"), [
       qcheck.return("gleam/list"),
@@ -278,8 +278,8 @@ pub fn external_gen() -> qcheck.Generator(types.ExternalAnnotation) {
       qcheck.return("simplifile"),
     ])
   let target_gen =
-    qcheck.from_generators(qcheck.return(ModuleExternal), [
-      qcheck.map(function_name_gen(), FunctionExternal),
+    qcheck.from_generators(qcheck.return(ModuleAssume), [
+      qcheck.map(function_name_gen(), FunctionAssume),
     ])
   // Never both absent: a line carrying neither clause claims nothing and is not
   // a line the parser reads back.
@@ -298,12 +298,12 @@ pub fn external_gen() -> qcheck.Generator(types.ExternalAnnotation) {
   // A bound list rides a function path alone — on a module path it is a parse
   // error, so the generator never pairs the two.
   use params <- qcheck.bind(case target {
-    ModuleExternal -> qcheck.return([])
-    FunctionExternal(_) -> params_gen()
+    ModuleAssume -> qcheck.return([])
+    FunctionAssume(_) -> params_gen()
   })
   use clauses <- qcheck.map(clauses_gen)
   let #(effects, returns) = clauses
-  ExternalAnnotation(module:, target:, params:, effects:, returns:)
+  AssumeAnnotation(module:, target:, params:, effects:, returns:)
 }
 
 // One clause this version does not read. The keys cover the dotted and numeric
@@ -366,9 +366,9 @@ pub fn graded_file_gen() -> qcheck.Generator(types.GradedFile) {
       [
         #(
           1,
-          qcheck.map2(type_field_gen(), unknown_clauses_gen(), TypeFieldLine),
+          qcheck.map2(type_field_gen(), unknown_clauses_gen(), FieldAssumeLine),
         ),
-        #(1, qcheck.map2(external_gen(), unknown_clauses_gen(), ExternalLine)),
+        #(1, qcheck.map2(external_gen(), unknown_clauses_gen(), AssumeLine)),
         #(1, retained_assume_gen()),
         #(1, qcheck.map(comment_gen, CommentLine)),
         #(1, qcheck.return(BlankLine)),

--- a/test/infer_cli_test.gleam
+++ b/test/infer_cli_test.gleam
@@ -153,7 +153,10 @@ pub fn dry_run_over_an_unparseable_spec_errors_test() {
   |> should.equal(
     Error(graded.GradedParseError(
       root <> "/proj.graded",
-      annotation.InvalidLine(2, "this line is not a graded annotation"),
+      annotation.describe_parse_error(annotation.InvalidLine(
+        2,
+        "this line is not a graded annotation",
+      )),
     )),
   )
   simplifile.read(root <> "/proj.graded") |> should.equal(Ok(existing))
@@ -484,7 +487,10 @@ pub fn infer_over_an_unparseable_spec_writes_nothing_test() {
   |> should.equal(
     Error(graded.GradedParseError(
       root <> "/proj.graded",
-      annotation.InvalidLine(2, "not a graded line"),
+      annotation.describe_parse_error(annotation.InvalidLine(
+        2,
+        "not a graded line",
+      )),
     )),
   )
   simplifile.read(root <> "/proj.graded") |> should.equal(Ok(before))

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -24,7 +24,7 @@ import support
 // their [] budgets, while impure and transitively impure callers fail them.
 
 pub fn pure_view_passes_test() {
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let pure_result =
     list.find(results, fn(r) { r.file == "test/fixtures/pure_view.gleam" })
   let assert Ok(r) = pure_result
@@ -36,7 +36,7 @@ pub fn let_bound_view_passes_test() {
   // mapped over a list. The view is pure, so the `check view : []` invariant
   // must pass — the let-bound closure resolves to its body effect, not
   // `[Unknown]`.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let result =
     list.find(results, fn(r) { r.file == "test/fixtures/let_bound_view.gleam" })
   let assert Ok(r) = result
@@ -51,7 +51,7 @@ pub fn recursive_fn_arg_resolves_pure_test() {
   // info active (as here), the operator-lift path reaches the recursive
   // reference; before the fix it leaked a phantom variable that became
   // [Unknown], failing the `check walk : []` budget.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let result =
     list.find(results, fn(r) {
       r.file == "test/fixtures/recursive_fn_arg.gleam"
@@ -73,7 +73,7 @@ pub fn recursive_returned_operator_resolves_pure_test() {
   // and the second-order one (`pick_cb`/`run_cb`, returning a callback-taking
   // `fn(fn() -> Nil) -> Nil`) — the latter exercises the neutral operator's
   // binder over the callback position rather than a ground pure.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let result =
     list.find(results, fn(r) {
       r.file == "test/fixtures/recursive_returned_operator.gleam"
@@ -83,7 +83,7 @@ pub fn recursive_returned_operator_resolves_pure_test() {
 }
 
 pub fn impure_view_fails_test() {
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let impure_result =
     list.find(results, fn(r) { r.file == "test/fixtures/impure_view.gleam" })
   let assert Ok(r) = impure_result
@@ -94,7 +94,7 @@ pub fn impure_view_fails_test() {
 }
 
 pub fn transitive_violation_detected_test() {
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let trans_result =
     list.find(results, fn(r) { r.file == "test/fixtures/transitive.gleam" })
   let assert Ok(r) = trans_result
@@ -111,7 +111,7 @@ pub fn validator_flow_violation_detected_test() {
   // validator_flow.run constructs a Validator locally and calls its
   // field. The field is wired to io.println so the run function's
   // effects are [Stdout] — the check budget of [] must fail.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let validator_result =
     list.find(results, fn(r) { r.file == "test/fixtures/validator_flow.gleam" })
   let assert Ok(r) = validator_result
@@ -126,7 +126,7 @@ pub fn factory_field_violation_detected_test() {
   // that wires the field to its parameter. With no `type` annotation, factory
   // field provenance resolves v.to_error to io.println's [Stdout], so the []
   // check budget must fail. (B1: the escape-hatch annotation is unnecessary.)
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let factory_result =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_field.gleam" })
   let assert Ok(r) = factory_result
@@ -144,7 +144,7 @@ pub fn inline_construction_field_resolves_through_construction_test() {
   // construction provenance yields the precise [Stdout] — not the conservative
   // [Unknown] of an untraceable receiver. Reporting it as [] would be unsound,
   // so the [] budget must still fail, now with actual [Stdout].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/inline_construction_field.gleam"
@@ -163,7 +163,7 @@ pub fn field_union_polymorphic_on_param_receiver_test() {
   // bound `p.run` and, with no bound supplied on the `check` line, grounds to
   // [Unknown]. A caller that supplies a concrete `Parser` (a proven construction)
   // resolves it precisely instead.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let union_result =
     list.find(results, fn(r) { r.file == "test/fixtures/field_union.gleam" })
   let assert Ok(r) = union_result
@@ -184,7 +184,7 @@ pub fn external_is_unknown_test() {
   // `run` — which calls it — inherits that. Against a `[]` budget this must be a
   // violation with actual `[Unknown]`. Without the fix the FFI (and its caller)
   // would be `[]` and the check would pass — a soundness hole.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let ffi_result =
     list.find(results, fn(r) { r.file == "test/fixtures/ffi_external.gleam" })
   let assert Ok(r) = ffi_result
@@ -201,7 +201,7 @@ pub fn external_same_module_declared_effects_test() {
   // `[Unknown]` an undeclared external yields. `read_clock` calls `now()` bare,
   // so against a `[]` budget the actual must be the declared `[Time]`. Without
   // the fix the local path bypassed the knowledge base and reported `[Unknown]`.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let same_module_result =
     list.find(results, fn(r) {
       r.file == "test/fixtures/external_same_module.gleam"
@@ -220,7 +220,7 @@ pub fn check_line_on_an_external_checks_its_declaration_test() {
   // nothing declares carries `[Unknown]`, which exceeds it too — including the
   // one whose pure-looking Gleam fallback body would otherwise pass it. A budget
   // that covers the declaration passes.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/external_budget.gleam" })
   r.violations
@@ -246,7 +246,7 @@ pub fn a_committed_effects_line_does_not_declare_an_external_test() {
   // Inference over a body says nothing about foreign code, so the line declares
   // nothing and the budget is checked against `[Unknown]`; trusting its `[]`
   // would pass a budget no declaration backs.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/external_budget.gleam" })
   let assert Ok(stale) =
@@ -264,7 +264,7 @@ pub fn a_caller_of_an_external_is_charged_what_declares_it_test() {
   // line does not answer for the external, so it may not answer for a call into
   // it either: the caller is charged the same `[Unknown]`, not the `[]` that
   // would let a budget pass on the strength of a line nothing backs.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/external_budget.gleam" })
   let assert Ok(wrapper) =
@@ -287,7 +287,7 @@ pub fn a_caller_of_an_external_is_charged_what_declares_it_test() {
       "import ffi\n\npub fn wrapper() -> Nil {\n  ffi.clock()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -303,7 +303,7 @@ pub fn an_external_passed_as_a_value_is_charged_what_declares_it_test() {
   // the same declaration a direct call goes through, so both carry `[Unknown]`.
   // Walking the bodyless `@external` instead would lift it to `[]` and let a
   // budget pass here that `wrapper`'s direct call fails.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/external_budget.gleam" })
   let assert Ok(callback) =
@@ -345,7 +345,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -382,7 +382,7 @@ pub fn a_bounded_assume_charges_the_arguments_effects_test() {
       "import ffi\n\npub fn run() -> Nil {\n  ffi.each(ffi.disk_read)\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -412,7 +412,7 @@ pub fn a_decoupled_bound_name_still_binds_test() {
       "import ffi\n\npub fn run() -> Nil {\n  ffi.map(ffi.disk_read)\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -445,7 +445,7 @@ pub fn a_ground_budget_on_an_assume_is_inert_test() {
       "import ffi\n\npub fn run() -> Nil {\n  ffi.each(ffi.log)\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r.violations |> should.equal([])
@@ -478,7 +478,7 @@ pub fn a_dependency_specs_bounded_assume_substitutes_test() {
         ),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -540,7 +540,7 @@ pub fn a_consumer_assume_overrides_a_dependency_bound_list_test() {
         ),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -593,7 +593,7 @@ pub fn go_impure() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -658,7 +658,7 @@ pub fn both_pure() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -691,7 +691,7 @@ pub fn a_declared_clause_closed_by_its_bounds_binds_test() {
       "import ffi\n\npub fn run() -> Nil {\n  let f = ffi.wrap(ffi.disk_read)\n  f()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -723,7 +723,7 @@ pub fn a_clause_only_bounded_declaration_binds_test() {
       "import ffi\n\npub fn run() -> Nil {\n  let f = ffi.wrap(ffi.disk_read)\n  f()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   // The producer call itself reports its own undeclared-external row; the
@@ -758,7 +758,7 @@ pub fn a_decoupled_bound_scoping_a_clause_binds_by_parameter_name_test() {
       "import ffi\n\npub fn run() -> Nil {\n  let f = ffi.wrap(ffi.disk_read)\n  f()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -795,7 +795,7 @@ pub fn an_aliased_payload_does_not_capture_a_clause_variable_test() {
       "import ffi\n\npub fn run() -> Nil {\n  let f = ffi.wrap(ffi.disk_read, ffi.noop)\n  f()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -824,7 +824,7 @@ pub fn an_unscoped_declared_clause_is_dropped_test() {
       "import ffi\n\npub fn run() -> Nil {\n  let f = ffi.wrap(fn() { Nil })\n  f()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -853,7 +853,7 @@ pub fn a_dotted_variable_in_a_declared_clause_is_dropped_test() {
       "import ffi\n\npub fn run() -> Nil {\n  let f = ffi.wrap(fn() { Nil })\n  f()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -885,7 +885,7 @@ pub fn differing_bounds_on_the_two_channels_each_bind_their_own_test() {
       "import ffi\n\npub fn run() -> Nil {\n  let f = ffi.wrap(ffi.disk_read)\n  f()\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert Ok(direct) =
@@ -934,7 +934,7 @@ pub fn run() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ffi.gleam" })
   let assert [violation] = r.violations
@@ -969,7 +969,7 @@ pub fn a_dependency_specs_declared_decorator_binds_test() {
         ),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -1005,7 +1005,7 @@ pub fn a_closed_clause_with_a_decoupled_bound_binds_by_parameter_name_test() {
         #("dep/ffi.gleam", support.foreign_fn("disk_read", "() -> Nil")),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -1039,7 +1039,7 @@ fn sink() -> Nil
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert [violation] = r.violations
@@ -1096,7 +1096,7 @@ pub fn calls_built_field() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   r.violations |> should.equal([])
@@ -1152,7 +1152,7 @@ pub fn calls_built_field() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   r.violations |> should.equal([])
@@ -1197,7 +1197,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -1235,7 +1235,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   // The declaration stands: no violation against the budget it states, and no
   // lint calling the line stale.
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
@@ -1292,7 +1292,7 @@ pub fn calls_it() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let disk = types.Specific(set.from_list(["Disk"]))
 
   let assert Ok(same_module) =
@@ -1351,7 +1351,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   // Both walks of `a`'s body agree — the summary its callers are charged
   // through, and the walk its own `check` line performs.
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
@@ -1400,7 +1400,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   // `c` itself is unchanged: an ordinary caller is compiled for both targets,
   // so it pays the declaration on one and that same body on the other.
@@ -1451,7 +1451,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert Ok(violation) =
@@ -1505,7 +1505,7 @@ pub fn uses_impure() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert [violation] = r.violations
@@ -1558,7 +1558,7 @@ pub fn go() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -1616,7 +1616,7 @@ pub fn go_impure() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -1693,7 +1693,7 @@ pub fn go_swapped() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -1751,7 +1751,7 @@ pub fn go_impure() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -1807,7 +1807,7 @@ pub fn go_impure() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert [violation] = r.violations
@@ -1868,7 +1868,7 @@ pub fn via_helper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   // Directly, and re-bound through a helper whose own walk left the share
@@ -1937,7 +1937,7 @@ pub fn via_operator() -> Nil {
     #("c.gleam", "import d\n\npub fn go() -> Nil {\n  d.go()\n}\n"),
     #("d.gleam", "import c\n\npub fn go() -> Nil {\n  c.go()\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) = list.find(results, fn(r) { r.file == root <> "/b.gleam" })
   ["direct", "via_operator"]
   |> list.each(fn(function) {
@@ -1999,7 +1999,7 @@ pub fn via_operator() -> Nil {
     #("c.gleam", "import d\n\npub fn go() -> Nil {\n  d.go()\n}\n"),
     #("d.gleam", "import c\n\npub fn go() -> Nil {\n  c.go()\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) = list.find(results, fn(r) { r.file == root <> "/b.gleam" })
   ["direct", "via_operator"]
   |> list.each(fn(function) {
@@ -2046,7 +2046,7 @@ pub fn disk() -> Nil
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert [violation] = r.violations
@@ -2092,7 +2092,7 @@ pub fn disk() -> Nil
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert [violation] = r.violations
@@ -2145,7 +2145,7 @@ pub fn uses() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r.violations |> should.equal([])
@@ -2194,7 +2194,7 @@ pub fn via_operator() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -2248,7 +2248,7 @@ pub fn fallback_disk() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -2318,7 +2318,7 @@ pub fn via_field() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   ["via_operator", "via_field"]
@@ -2386,7 +2386,7 @@ pub fn via_field() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   ["direct", "via_operator", "via_field"]
@@ -2439,7 +2439,7 @@ pub fn via_operator() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -2479,7 +2479,7 @@ pub fn via_sibling() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert Ok(violation) =
@@ -2526,7 +2526,7 @@ pub fn via_operator() -> Nil {
       ),
     ],
   )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -2601,7 +2601,7 @@ pub fn cross_module_value() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let charged =
     results
     |> list.flat_map(fn(r) { r.violations })
@@ -2676,7 +2676,7 @@ pub fn hands_over_a_called_callback() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) = list.find(results, fn(r) { r.file == root <> "/m.gleam" })
   ["hands_over_an_uncalled_callback", "hands_over_a_called_callback"]
   |> list.each(fn(function) {
@@ -2727,7 +2727,7 @@ pub fn quiet_go() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r.warnings
@@ -2785,7 +2785,7 @@ pub fn direct() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -2847,7 +2847,7 @@ pub fn qualified() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   [#("app.gleam", "qualified"), #("ext.gleam", "sibling")]
   |> list.each(fn(expected) {
     let #(file, function) = expected
@@ -2907,7 +2907,7 @@ pub fn via_helper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -2985,7 +2985,7 @@ pub fn via_poly() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   [
@@ -3037,7 +3037,7 @@ pub fn strict() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -3126,7 +3126,7 @@ pub fn via_factory() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let total = types.Specific(set.from_list(["Disk", "Unknown"]))
@@ -3192,7 +3192,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "wrapper" })
@@ -3250,7 +3250,7 @@ pub fn calls_b() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let total = types.Specific(set.from_list(["Disk", "Unknown"]))
@@ -3312,7 +3312,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "wrapper" })
@@ -3370,7 +3370,7 @@ pub fn calls_it() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(caller) =
     list.find(results, fn(r) { r.file == root <> "/other.gleam" })
   let assert [calls_it] = caller.violations
@@ -3431,7 +3431,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let disk = types.Specific(set.from_list(["Disk"]))
@@ -3498,7 +3498,7 @@ pub fn uses_impure() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   // The pure callback is not charged for the fallback's call to it.
@@ -3606,7 +3606,7 @@ pub fn a_module_external_resolves_from_catalog_functions_test() {
     ),
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   // Only the module that really resolves nowhere is flagged.
   results
   |> list.flat_map(fn(r) { r.warnings })
@@ -3661,7 +3661,7 @@ pub fn uses() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [v] = r.violations
@@ -3711,7 +3711,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "wrapper" })
@@ -3800,7 +3800,7 @@ pub fn wrapper() -> Nil {
     ),
   ])
   // What the caller is charged.
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "wrapper" })
@@ -3872,7 +3872,7 @@ fn sink() -> Nil
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   r.violations |> should.equal([])
@@ -3891,7 +3891,7 @@ pub fn foreign_value_channels_are_opaque_test() {
   // Five channels, each paired in the fixture with the same shape written as
   // ordinary Gleam. Only the foreign half exceeds the budget the pair shares —
   // the rule refuses foreign values, not values.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/foreign_values.gleam" })
   r.violations
@@ -3980,7 +3980,7 @@ pub fn calls_via_provenance() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r.violations
@@ -4025,7 +4025,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -4072,7 +4072,7 @@ pub fn plain_wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -4129,7 +4129,7 @@ pub fn via_value() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   // `wrapper`'s `[Time]` budget holds — the walked body's `[Unknown]` is no
@@ -4203,7 +4203,7 @@ pub fn wrapper() -> Nil {
   ])
   // The external's own budget covers declaration and body; the caller's
   // covers the declaration alone. Both hold.
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   // The caller's `why` names the suppression; the external's own does not —
   // its line reports the declaration with the body as a contributor beside
@@ -4264,7 +4264,7 @@ pub fn uses() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   // The producer call pays the catalog's term unioned with the walked body's
@@ -4314,7 +4314,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -4377,7 +4377,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -4416,7 +4416,7 @@ pub fn wrapper() -> Nil {
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -4472,7 +4472,7 @@ pub fn wrapper() -> Nil {
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -4564,7 +4564,7 @@ pub fn tick() -> Nil {
     ..sources
   ])
 
-  let assert Ok(results) = graded.run(defaulted)
+  let assert Ok(results) = graded.check_project(defaulted)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
 
@@ -4585,7 +4585,7 @@ pub fn tick() -> Nil {
   caller |> string.contains("Disk") |> should.be_false()
 
   // And every one of them reads as the named-target package does, word for word.
-  let assert Ok(named_results) = graded.run(named)
+  let assert Ok(named_results) = graded.check_project(named)
   named_results
   |> list.flat_map(fn(r) { r.violations })
   |> should.equal([])
@@ -4632,7 +4632,7 @@ pub fn wrapper() -> Nil {
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(own) =
     list.find(results, fn(r) { r.file == root <> "/ffi.gleam" })
   let assert [own_violation] = own.violations
@@ -4719,7 +4719,7 @@ pub fn tock() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
 
@@ -4846,7 +4846,7 @@ pub fn calls_built_field() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r.violations
@@ -4888,7 +4888,7 @@ pub fn calls_wrapped() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -4928,7 +4928,7 @@ pub fn calls_returned_operator() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   // The producer call is charged [Unknown] too — nothing this build compiles
@@ -4998,7 +4998,7 @@ pub fn calls_covered() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r.violations |> should.equal([])
@@ -5038,7 +5038,7 @@ pub fn caller() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
 
   let assert Ok(Nil) = graded.run_infer(root)
@@ -5083,7 +5083,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -5157,7 +5157,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -5199,7 +5199,7 @@ pub fn caller() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
 
   let assert Ok(preview) = graded.run_infer_dry_run(root)
@@ -5252,7 +5252,7 @@ pub fn caller() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -5297,7 +5297,7 @@ pub fn make() -> fn() -> Nil
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -5340,7 +5340,7 @@ assume ffi.fold(g: [g]) : [g]
         <> support.foreign_fn("fold", "(g: fn() -> Nil) -> Nil"),
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   // `ffi.fold`'s term variable is covered by its bound's payload, so the term
   // oracle stays silent for it.
   results
@@ -5396,7 +5396,7 @@ effects app.twin(cb: [e], other: [cb]) : [cb] where returns : [cb]
       "pub fn twin(cb: fn() -> Nil, other: fn() -> Nil) -> fn() -> Nil {\n  other()\n  cb\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -5443,7 +5443,7 @@ effects app.twin(other: [cb], cb: [cb]) : [cb] where returns : [cb]
       "pub fn twin(other: fn() -> Nil, cb: fn() -> Nil) -> fn() -> Nil {\n  other()\n  cb\n}\n",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -5470,7 +5470,7 @@ assume nowhere.gone(cb: [cb]) : [zz]
     ),
     #("app.gleam", "pub fn local(cb: fn() -> Nil) -> Nil {\n  cb()\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -5571,7 +5571,7 @@ pub fn caller() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ffi.gleam" })
   support.cleanup(root)
@@ -5627,7 +5627,7 @@ pub fn shout() -> Nil
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   // Neither caller pays more than the declaration.
   let assert Ok(caller) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
@@ -5682,7 +5682,7 @@ pub fn wrapper() -> Nil {
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -5891,7 +5891,7 @@ pub fn every_surface_charges_one_name_one_set_test() {
   |> list.each(fn(configuration) {
     let #(root, toml, rows) = configuration
     support.write_fixture(root, [#("gleam.toml", toml), ..matrix_sources()])
-    let assert Ok(results) = graded.run(root)
+    let assert Ok(results) = graded.check_project(root)
     list.each(rows, check_matrix_row(root, results, _))
     support.cleanup(root)
   })
@@ -6161,7 +6161,7 @@ pub fn j() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   // The JavaScript caller reaches the foreign implementation and fails; the
   // Erlang one reaches the fallback and passes. One violation, and it is that
   // one -- neither answer stands in for the other.
@@ -6231,7 +6231,7 @@ pub fn w() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   // And what `infer` publishes for it says the same.
   let assert Ok(answered) = graded.run_effect(root, "ext.w")
@@ -6271,7 +6271,7 @@ pub fn w() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   let assert Ok(answered) = graded.run_effect(root, "dep/ffi.run")
   answered |> string.contains("Disk") |> should.be_false()
@@ -6304,7 +6304,7 @@ pub fn w() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -6352,7 +6352,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -6395,7 +6395,7 @@ pub fn a() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -6443,7 +6443,7 @@ pub fn wrapper() -> Nil {
   ])
   // What the caller is charged: the declared term alone, so the `[Time]`
   // budget holds.
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r.violations |> should.equal([])
@@ -6488,7 +6488,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -6535,7 +6535,7 @@ pub fn make() -> fn() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root <> "/proj")
+  let assert Ok(results) = graded.check_project(root <> "/proj")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/proj/src/app.gleam" })
   { r.violations != [] } |> should.be_true()
@@ -6593,7 +6593,7 @@ pub fn run() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root <> "/proj")
+  let assert Ok(results) = graded.check_project(root <> "/proj")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/proj/src/app.gleam" })
   let assert [violation] = r.violations
@@ -6606,7 +6606,7 @@ pub fn one_helper_called_twice_is_reported_once_test() {
   // Two calls into one helper collect that helper's single site twice, and both
   // copies say the same thing. `why` prints one line for it, so `check` reports
   // one violation for it.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/why_target.gleam" })
   r.violations
@@ -6628,7 +6628,7 @@ pub fn opaque_receiver_violation_detected_test() {
   // and the `assume opaque_receiver.Validator.to_error : [Stdout]` annotation
   // resolves the field call, so the [] check budget must fail. This is the
   // milestone-3b case that 0.6.0's same-function value flow could not handle.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let opaque_result =
     list.find(results, fn(r) { r.file == "test/fixtures/opaque_receiver.gleam" })
   let assert Ok(r) = opaque_result
@@ -6647,7 +6647,7 @@ pub fn field_bound_resolves_untraceable_receiver_test() {
   // `check field_bound.caller(v.to_error: [Stdout]) : []` line resolves the
   // field call to [Stdout], so the [] budget must fail with that precise
   // effect (not the [Unknown] graded would otherwise fall back to).
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let field_bound_result =
     list.find(results, fn(r) { r.file == "test/fixtures/field_bound.gleam" })
   let assert Ok(r) = field_bound_result
@@ -6664,7 +6664,7 @@ pub fn opaque_fn_typed_field_discharges_via_bound_test() {
   // becomes a synthetic field-effect variable rather than [Unknown]. The
   // `check opaque_field.exec(r.run: [Stdout]) : []` field bound discharges that
   // variable to [Stdout], so the [] budget must fail with the precise [Stdout].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/opaque_field.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "exec" })
@@ -6678,7 +6678,7 @@ pub fn opaque_fn_typed_field_unbound_is_unknown_test() {
   // concretizes to [Unknown] — the soundness floor — and the [] budget fails
   // with [Unknown], never silently []. This is the invariant the polymorphic
   // field-bound feature must never violate.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/opaque_field.gleam" })
   let assert Ok(v) =
@@ -6815,7 +6815,7 @@ pub fn factory_forward_resolves_through_factory_test() {
   // parameter. The `check ...caller(resolver: [Stdout]) : []` bound discharges
   // it to [Stdout], so the [] budget fails with the precise effect — not the
   // [Unknown] an untraced factory return would collapse to.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "caller" })
@@ -6826,7 +6826,7 @@ pub fn factory_forward_resolves_through_factory_test() {
 pub fn factory_forward_resolves_through_inline_constructor_test() {
   // Same forwarding for an inline *constructor* argument
   // (`inner(Options(resolver: resolver))`).
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6838,7 +6838,7 @@ pub fn factory_forward_resolves_through_inline_constructor_test() {
 pub fn factory_forward_resolves_through_labeled_factory_test() {
   // Labeled factory wiring (`inner(make_options(resolver: resolver))`) routes
   // through the factory's parameter label to the same field, so it forwards too.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6851,7 +6851,7 @@ pub fn factory_forward_resolves_through_shorthand_factory_test() {
   // Shorthand labeled wiring (`make_options(resolver:)`) is sugar for
   // `make_options(resolver: resolver)`, so its value is the `resolver` variable
   // and it forwards the same way — not the [Unknown] an opaque shorthand gives.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6869,7 +6869,7 @@ pub fn factory_forward_marker_survives_sibling_source_test() {
   // it to [Stdout]. The sibling `relay` source belongs to a *different*
   // construction site and no longer pollutes this receiver: the nominal index is
   // never consulted for a parameter receiver, so [Unknown] is gone.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6884,7 +6884,7 @@ pub fn factory_forward_resolves_through_factory_alias_test() {
   // the constructed field wiring, so `o.resolver` re-keys onto the caller's
   // `resolver` parameter and the `resolver: [Stdout]` bound discharges it — the
   // [] budget fails with [Stdout], not the [Unknown] an opaque alias gave before.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6897,7 +6897,7 @@ pub fn factory_forward_resolves_through_constructor_alias_test() {
   // factory_forward.caller_ctor_alias binds an inline constructor before passing
   // it (`let o = Options(resolver: resolver); inner(o)`). The constructor wiring
   // forwards the same way, so the bound discharges to [Stdout].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6911,7 +6911,7 @@ pub fn factory_forward_resolves_through_nested_construction_test() {
   // (`inner_holder(make_holder(make_options(resolver)))`). Each hop's field
   // wiring is traced in turn, so `holder.options.resolver` re-keys onto the
   // caller's `resolver` and the bound discharges to [Stdout].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6925,7 +6925,7 @@ pub fn factory_forward_computed_alias_stays_unknown_test() {
   // (`let o = get_options(make_options(resolver)); inner(o)`). The binding is an
   // opaque call result, not a traceable construction, so forwarding doesn't
   // apply and the field call concretizes to [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6940,7 +6940,7 @@ pub fn factory_forward_shadowed_alias_stays_unknown_test() {
   // get_options(o); inner(o)`). The shadowing binding clears the stale factory
   // provenance, so the field call concretizes to [Unknown] — proving a
   // reassignment can never leave a forwarded effect understated.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -6955,7 +6955,7 @@ pub fn factory_forward_computed_receiver_resolves_test() {
   // `get_options` returns its parameter, so return-value provenance forwards the
   // factory-wired `resolver` onto the caller's `resolver` and the bound
   // discharges it to [Stdout] — where before Phase 1 it collapsed to [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/factory_forward.gleam" })
   let assert Ok(v) =
@@ -7012,7 +7012,7 @@ pub fn nested_field_resolves_via_type_line_test() {
   // [Disk]` line resolves it, and the [] budget fails with the precise [Disk].
   // Before nested extraction this collapsed to a computed application
   // ([Unknown]).
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/nested_field.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "via_type" })
@@ -7024,7 +7024,7 @@ pub fn nested_field_discharges_via_dotted_bound_test() {
   // (`check nested_field.via_bound(o.inner.run: [Stdout]) : []`). The nested
   // `o.inner.run` field call carries the dotted path `o.inner` as its object, so
   // the bound matches and discharges to [Stdout], winning over the field `assume` line.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/nested_field.gleam" })
   let assert Ok(v) =
@@ -7038,7 +7038,7 @@ pub fn nested_field_unbound_is_unknown_test() {
   // field `assume` line and no field bound. The synthetic field-effect variable can't be
   // discharged, so it concretizes to [Unknown] — the soundness floor — and the
   // [] budget fails with [Unknown], never silently [].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/nested_field.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "unbound" })
@@ -7082,7 +7082,7 @@ fn run_project_with_spec(
   spec: String,
 ) -> List(types.CheckResult) {
   write_project(root, [#("proj.gleam", source)], spec)
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
 }
 
@@ -7135,7 +7135,7 @@ pub fn check_over_an_unreadable_spec_errors_test() {
   let assert Ok(Nil) = simplifile.delete(root <> "/proj.graded")
   let assert Ok(Nil) = simplifile.create_directory(root <> "/proj.graded")
 
-  graded.run(root)
+  graded.check_project(root)
   |> should.equal(
     Error(graded.FileReadError(root <> "/proj.graded", simplifile.Eisdir)),
   )
@@ -7260,7 +7260,7 @@ pub fn provenance_cross_module_getter_resolves_test() {
     ],
     "check app.caller(config.options.resolver: [Stdout]) : []\n",
   )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "caller" })
@@ -7296,7 +7296,7 @@ pub fn provenance_cross_module_getter_over_construction_resolves_test() {
     ],
     "check app.caller(resolver: [Stdout]) : []\n",
   )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "caller" })
@@ -7332,7 +7332,7 @@ pub fn provenance_cross_module_rebuild_resolves_test() {
     ],
     "check app.caller(resolver: [Stdout]) : []\n",
   )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "caller" })
@@ -7368,7 +7368,7 @@ pub fn provenance_cross_module_labeled_resolves_test() {
     ],
     "check app.caller(resolver: [Stdout]) : []\n",
   )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "caller" })
@@ -7643,7 +7643,7 @@ pub fn nested_field_pipe_target_resolves_test() {
   // captured (resolved by `assume pipe_field.Inner.run : [Disk]`) and the []
   // budget fails with [Disk]. Before the fix the pipe target fell through to the
   // generic walker, dropped the effect, and the budget passed unsoundly.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/pipe_field.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "via_pipe" })
@@ -7732,7 +7732,7 @@ pub fn nested_field_resolves_cross_module_type_line_test() {
         <> "assume svc.OrganizationService.create : [Storage, Time]\n",
     )
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/handler.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "handle" })
@@ -7753,7 +7753,7 @@ pub fn closure_field_effect_from_construction_test() {
   // A record field wired to an *inline closure* at construction resolves to the
   // closure body's effect ([Stdout]) without a hand-written `type` annotation —
   // previously this fell back to [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let closure_result =
     list.find(results, fn(r) { r.file == "test/fixtures/closure_field.gleam" })
   let assert Ok(r) = closure_result
@@ -7768,7 +7768,7 @@ pub fn operator_typed_closure_field_test() {
   // An *operator-typed* field (a closure that calls its own callback) is lifted
   // to `λnext. [next]` and applied at the field call `m.wrap(io.println)`,
   // resolving to the supplied callback's [Stdout] — previously [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let operator_result =
     list.find(results, fn(r) { r.file == "test/fixtures/operator_field.gleam" })
   let assert Ok(r) = operator_result
@@ -7785,7 +7785,7 @@ pub fn inferred_field_effect_from_construction_test() {
   // (`Logger(emit: io.println)`) per receiver, so `l.emit()` resolves to the
   // precise [Stdout] — the in-package construction is proven for this receiver,
   // not borrowed from the nominal index.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let inferred_result =
     list.find(results, fn(r) { r.file == "test/fixtures/inferred_field.gleam" })
   let assert Ok(r) = inferred_result
@@ -7801,7 +7801,7 @@ pub fn local_field_value_resolved_test() {
   // record field and binds the receiver from a call (`let l = make()`). Tier 2's
   // call-result provenance grounds `make`'s return construction per receiver, so
   // `l.emit()` resolves the wired same-module function to the precise [Stdout].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let local_result =
     list.find(results, fn(r) { r.file == "test/fixtures/local_field.gleam" })
   let assert Ok(r) = local_result
@@ -7985,7 +7985,7 @@ effects dep.with_resolver : []
 ",
     )
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -8017,7 +8017,7 @@ pub fn builder_field_whole_caller_union_test() {
   // separate effect — nuance #2) with the overridden field call's [Stdout]. The
   // two surface as separate per-call violations against the [] budget; together
   // they cover the whole-caller union.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/builder_field.gleam" })
   let union =
@@ -8034,7 +8034,7 @@ pub fn builder_field_whole_caller_union_test() {
 
 // The reported effect of `function`'s violation in one `test/fixtures` file.
 fn fixture_actual(file: String, function: String) -> types.EffectSet {
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/" <> file })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == function })
@@ -8190,7 +8190,7 @@ pub fn named_fn_arg_resolves_test() {
   // function's real effect, so the [] budget fails with the precise [Stdout] —
   // not the [Unknown] graded fell back to before (inline closures already
   // resolved; named references did not).
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/named_fn_arg.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -8203,7 +8203,7 @@ pub fn labeled_callback_resolves_test() {
   // [Stdout]) with a Gleam label (`with:`). Argument-to-parameter matching now
   // binds the labelled argument, so the parameter's effect variable discharges
   // to [Stdout] instead of leaking unresolved into the fully-applied caller.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/labeled_callback.gleam"
@@ -8219,7 +8219,7 @@ pub fn record_update_field_walked_test() {
   // only if the extractor walks the updated field values, not just the base
   // record. Without that, the [Stdout] is silently dropped and `run` wrongly
   // resolves to [].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/record_update.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -8232,7 +8232,7 @@ pub fn shadowed_param_resolves_through_bound_test() {
   // same-module function of the same name (handler : [Stdout]). The forwarded
   // argument must resolve through the param bound ([]), not by lifting the
   // shadowed function — so the [] budget holds and `run` has no violation.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/shadow_param.gleam" })
   list.any(r.violations, fn(v) { v.function == "run" }) |> should.be_false()
@@ -8243,7 +8243,7 @@ pub fn aliased_param_call_resolves_through_bound_test() {
   // and calls the alias directly. The call must resolve through the parameter's
   // bound ([]), not the shadowed same-module `handler` nor [Unknown], so the []
   // budget holds and `run_alias` has no violation.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == "test/fixtures/shadow_param.gleam" })
   list.any(r.violations, fn(v) { v.function == "run_alias" })
@@ -8278,7 +8278,7 @@ pub fn infer_then_check_round_trip_test() {
   { list.length(all) > list.length(checks) } |> should.be_true()
 
   // Check still catches violations via the spec's check annotations.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let impure_result =
     list.find(results, fn(r) { r.file == "test/fixtures/impure_view.gleam" })
   let assert Ok(r) = impure_result
@@ -8321,7 +8321,7 @@ pub fn run_resolves_deps_from_target_dir_test() {
       "effects dep.fetch : [Http]\n",
     )
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/proj.gleam" })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -8401,7 +8401,7 @@ pub fn path_dep_hof_param_discharges_from_source_test() {
   let app_root = "build/pd_src_app"
   setup_path_dep_project(app_root, "pd_src_dep", False)
 
-  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(results) = graded.check_project(app_root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
 
@@ -8427,7 +8427,7 @@ pub fn path_dep_hof_param_discharges_from_spec_test() {
   let app_root = "build/pd_spec_app"
   setup_path_dep_project(app_root, "pd_spec_dep", True)
 
-  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(results) = graded.check_project(app_root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
 
@@ -8508,7 +8508,7 @@ fn run_path_dep_project(
   let assert Ok(Nil) = simplifile.write(app_root <> "/app.graded", spec)
   let assert Ok(Nil) = simplifile.write(app_root <> "/app.gleam", app_src)
 
-  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(results) = graded.check_project(app_root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
   r
@@ -8781,7 +8781,7 @@ pub fn path_dep_cross_module_positional_discharges_test() {
       "import dep/b\n\npub fn caller() -> Int {\n  b.run()\n}\n",
     )
 
-  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(results) = graded.check_project(app_root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
   list.any(r.violations, fn(v) { v.function == "caller" })
@@ -8814,7 +8814,7 @@ fn run_project_module_fixture(
   let root = "build/" <> name <> "_proj"
   write_project(root, [#("app.gleam", app_src), ..modules], spec)
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   r
@@ -9026,7 +9026,7 @@ pub fn path_dep_ships_type_field_test() {
         <> "pub fn use_field(r: Repo) -> Int {\n  r.find(\"x\")\n}\n",
     )
 
-  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(results) = graded.check_project(app_root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
   let assert Ok(v) =
@@ -9071,7 +9071,7 @@ pub fn installed_dep_ships_type_field_test() {
         <> "pub fn use_field(r: Repo) -> Int {\n  r.find(\"x\")\n}\n",
     )
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert Ok(v) =
@@ -9095,7 +9095,7 @@ pub fn provenance_passthrough_resolves_test() {
   // (`Passthrough`), so `o.resolver` forwards onto the caller's `resolver` and
   // the `resolver: [Stdout]` bound discharges it — the [] budget fails with
   // [Stdout], not the [Unknown] an untraced call result would collapse to.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_passthrough.gleam"
@@ -9110,7 +9110,7 @@ pub fn provenance_getter_resolves_test() {
   // to `inner`. `get_options` returns `config.options` (a `Path`), so `o.resolver`
   // forwards through the getter's path onto the caller's `resolver` and the
   // bound discharges it to [Stdout].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_getter.gleam"
@@ -9128,7 +9128,7 @@ pub fn provenance_rebuild_resolves_test() {
   // resolved as a forwarding field variable — never by the nominal index — so the
   // rebuild's sibling receiver-path wiring no longer leaks a conservative
   // [Unknown]. The result is the precise [Stdout] alone.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_rebuild.gleam"
@@ -9147,7 +9147,7 @@ pub fn provenance_partial_build_resolves_test() {
   // `inner`'s parameter receiver keeps the field call polymorphic, so the sibling
   // receiver-path wiring no longer leaks an [Unknown] — the precise [Stdout]
   // stands alone.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_partial.gleam"
@@ -9163,7 +9163,7 @@ pub fn provenance_shorthand_build_resolves_test() {
   // resolver` — so the `Build` provenance keeps the parameter-rooted `resolver`
   // field and `o.resolver` forwards onto the caller's `resolver`, discharging to
   // [Stdout]. Classifying the shorthand field as opaque left it [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_shorthand.gleam"
@@ -9181,7 +9181,7 @@ pub fn provenance_labeled_resolves_test() {
   // through, `o.resolver` re-keys onto the caller's `resolver`, and the bound
   // discharges to [Stdout] — where before the labeled call site widened to
   // [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_labeled.gleam"
@@ -9235,7 +9235,7 @@ pub fn provenance_binding_resolves_test() {
   // constructed `Options` forwards through, `o.resolver` re-keys onto the
   // caller's `resolver`, and the bound discharges to [Stdout] — proving
   // provenance survives the binding rather than widening at it.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_binding.gleam"
@@ -9252,7 +9252,7 @@ pub fn provenance_recursion_resolves_test() {
   // through, converging to a `Passthrough`. The constructed `Options` forwards
   // through, `o.resolver` re-keys onto the caller's `resolver`, and the bound
   // discharges to [Stdout] — where a naive walk widened on the recursion.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_recursion.gleam"
@@ -9268,7 +9268,7 @@ pub fn provenance_branch_resolves_test() {
   // `Passthrough`s. The join grounds each branch and forwards `o.resolver` onto
   // the caller's `resolver` through both, discharging the bound to [Stdout] —
   // where before value-level joins it was [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_branch.gleam"
@@ -9285,7 +9285,7 @@ pub fn provenance_branch_of_paths_resolves_test() {
   // forwards `o.resolver` onto the caller's `resolver`, discharging the bound to
   // [Stdout] — where `classify_case_options` gates path branches, the receiver
   // would collapse to [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_branch_path.gleam"
@@ -9302,7 +9302,7 @@ pub fn provenance_branch_of_builds_resolves_test() {
   // the caller's `resolver` (discharging to [Stdout]). `inner`'s parameter
   // receiver keeps the field call polymorphic, so the branches' receiver-path
   // wiring no longer leaks an [Unknown] — the precise [Stdout] stands alone.
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_branch_build.gleam"
@@ -9316,7 +9316,7 @@ pub fn provenance_computed_deep_stays_unknown_test() {
   // provenance_computed_deep.caller passes `deep(resolver)` to `inner`. `deep`'s
   // return is a nested call (`get(make(resolver))`), whose provenance is
   // `Opaque` (no helper-call composition in Phase 1), so it stays [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_computed_deep.gleam"
@@ -9330,7 +9330,7 @@ pub fn provenance_external_stays_unknown_test() {
   // provenance_external.caller passes `load_options(resolver)` to `inner`.
   // `load_options` is an external with no visible body, so its provenance can't
   // be traced and the field call concretizes to [Unknown].
-  let assert Ok(results) = graded.run("test/fixtures")
+  let assert Ok(results) = graded.check_project("test/fixtures")
   let assert Ok(r) =
     list.find(results, fn(r) {
       r.file == "test/fixtures/provenance_external.gleam"
@@ -9385,7 +9385,7 @@ pub fn a_scoped_run_charges_what_the_whole_package_run_charges_test() {
   scoped_package(root)
   let scoped = root <> "/src/sub"
 
-  let assert Ok(results) = graded.run(scoped)
+  let assert Ok(results) = graded.check_project(scoped)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == scoped <> "/inner.gleam" })
   let assert [violation] = r.violations
@@ -9418,7 +9418,7 @@ pub fn a_scoped_run_reads_the_same_result_from_an_absolute_path_test() {
   let assert Ok(cwd) = simplifile.current_directory()
   let absolute = filepath.join(cwd, root <> "/src/sub")
 
-  let assert Ok(results) = graded.run(absolute)
+  let assert Ok(results) = graded.check_project(absolute)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == absolute <> "/inner.gleam" })
   let assert [violation] = r.violations
@@ -9440,7 +9440,7 @@ pub fn equivalent_spellings_of_a_scope_read_alike_test() {
 
   [scoped, scoped <> "/", scoped <> "//", "./" <> scoped, root <> "/src/./sub"]
   |> list.each(fn(spelling) {
-    let assert Ok(results) = graded.run(spelling)
+    let assert Ok(results) = graded.check_project(spelling)
     let assert Ok(r) =
       list.find(results, fn(r) { r.file == scoped <> "/inner.gleam" })
     let assert [violation] = r.violations
@@ -9508,7 +9508,7 @@ pub fn now() -> Nil
     #("app.gleam", "import ffi\n\npub fn go() -> Nil {\n  ffi.now()\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -9556,7 +9556,7 @@ pub fn a_stale_project_external_is_ignored_everywhere_test() {
   stale_external_project(root)
   let disk = types.Specific(set.from_list(["Disk"]))
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(own) =
     list.find(results, fn(r) { r.file == root <> "/m.gleam" })
   let assert [violation] = own.violations
@@ -9610,7 +9610,7 @@ pub fn write() -> Nil
     #("caller.gleam", "import m\n\npub fn go() -> Nil {\n  m.logs()\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(caller) =
     list.find(results, fn(r) { r.file == root <> "/caller.gleam" })
   let assert [call] = caller.violations
@@ -9627,7 +9627,7 @@ pub fn a_stale_project_external_warns_once_test() {
   let root = "build/stale_external_warning"
   stale_external_project(root)
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([types.StaleFunctionExternalWarning(function: "m.logs")])
@@ -9672,7 +9672,7 @@ pub fn a_dependency_external_over_a_visible_body_is_untouched_test() {
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
@@ -9688,7 +9688,7 @@ pub fn a_module_level_external_over_a_project_module_is_untouched_test() {
     #("m.gleam", "pub fn logs() -> Nil {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
   let assert Ok(r) = list.find(results, fn(r) { r.file == root <> "/m.gleam" })
   let assert [violation] = r.violations
@@ -9732,7 +9732,7 @@ pub fn shout() -> Nil
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) = list.find(results, fn(r) { r.file == root <> "/m.gleam" })
   let assert [violation] = r.violations
   violation.function |> should.equal("logs")
@@ -9764,7 +9764,7 @@ pub fn a_catalogued_modules_uncatalogued_function_is_not_flagged_test() {
     ),
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
   support.cleanup(root)
 }
@@ -9792,7 +9792,7 @@ assume m.go : []
     ),
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   // The dependency lines are silent; the project ones are unchanged — `m` was
   // parsed, so it defines what it defines, and `m.go`'s Gleam body is right
   // there for the stale lint to name.
@@ -9831,7 +9831,7 @@ assume here/io.typo : [Disk]
     ),
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -9876,7 +9876,7 @@ assume dep/io : [Disk]
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -9913,7 +9913,7 @@ pub fn a_parsed_dependency_source_outranks_the_catalog_in_the_lint_test() {
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -9934,7 +9934,7 @@ pub fn an_external_on_an_unreadable_dependency_is_not_flagged_test() {
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
   support.cleanup(root)
 }
@@ -9961,7 +9961,7 @@ pub fn a_stale_duplicate_dependency_copy_does_not_answer_for_a_name_test() {
     #("dep/src/dep/mod.gleam", "pub fn reads() -> Nil {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root <> "/proj")
+  let assert Ok(results) = graded.check_project(root <> "/proj")
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -9992,7 +9992,7 @@ pub fn a_stale_copy_does_not_stand_in_for_an_unreadable_one_test() {
     #("dep/src/dep/mod.gleam", "pub fn ( not gleam\n"),
   ])
 
-  let assert Ok(results) = graded.run(root <> "/proj")
+  let assert Ok(results) = graded.check_project(root <> "/proj")
   results |> list.flat_map(fn(r) { r.warnings }) |> should.equal([])
   support.cleanup(root)
 }
@@ -10029,7 +10029,7 @@ pub fn writes() -> Nil
     #("dep/src/dep/mod.gleam", "pub fn writes() -> Nil {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root <> "/proj")
+  let assert Ok(results) = graded.check_project(root <> "/proj")
   results |> list.flat_map(fn(r) { r.violations }) |> should.equal([])
   support.cleanup(root)
 }
@@ -10051,7 +10051,7 @@ pub fn an_external_on_a_function_less_dependency_module_is_flagged_test() {
     #("m.gleam", "pub fn go() -> Nil {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
@@ -10108,7 +10108,7 @@ pub fn declared_go() -> Nil {
     ),
   ])
 
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   // Only the declared external is quoted, and it is quoted with what declares it.
@@ -10187,7 +10187,7 @@ pub fn pass_loud() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   r.warnings
@@ -10268,7 +10268,7 @@ pub fn pass_erlang_only() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   r.warnings
@@ -10331,7 +10331,7 @@ pub fn strict() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/governed.gleam" })
 
@@ -10420,7 +10420,7 @@ pub fn running() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/ext.gleam" })
   r.warnings
@@ -10493,7 +10493,7 @@ pub fn caller() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -10596,7 +10596,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(app_root)
+  let assert Ok(results) = graded.check_project(app_root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == app_root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -10649,7 +10649,7 @@ pub fn wrapper() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/app.gleam" })
   let assert [violation] = r.violations
@@ -10674,11 +10674,14 @@ pub fn a_returns_clause_on_a_field_path_is_refused_test() {
 ",
     ),
   ])
-  graded.run(root)
+  graded.check_project(root)
   |> should.equal(
     Error(graded.GradedParseError(
       root <> "/proj.graded",
-      annotation.InvalidLine(1, "assume app.Handler.run where returns : [Net]"),
+      annotation.describe_parse_error(annotation.InvalidLine(
+        1,
+        "assume app.Handler.run where returns : [Net]",
+      )),
     )),
   )
   support.cleanup(root)
@@ -10694,11 +10697,14 @@ pub fn check_over_an_unparseable_spec_errors_test() {
   let root = "/tmp/graded_check_unparseable"
   let _ = support.write_unparseable_spec_project(root)
 
-  graded.run(root)
+  graded.check_project(root)
   |> should.equal(
     Error(graded.GradedParseError(
       root <> "/proj.graded",
-      annotation.InvalidLine(2, "not a graded line"),
+      annotation.describe_parse_error(annotation.InvalidLine(
+        2,
+        "not a graded line",
+      )),
     )),
   )
   support.cleanup(root)
@@ -10756,7 +10762,7 @@ pub fn caller() -> Nil {
       dependency_spec: clause,
       dependency_sources: [#("dep/wrap.gleam", dep_source)],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(violation) =
     results
     |> list.flat_map(fn(result) { result.violations })
@@ -10879,7 +10885,7 @@ pub fn caller() -> Nil {
     #("dep/dep.graded", dependency_spec),
     #("dep/src/" <> module <> ".gleam", dep_source),
   ])
-  let assert Ok(results) = graded.run(root <> "/proj")
+  let assert Ok(results) = graded.check_project(root <> "/proj")
   let assert Ok(violation) =
     results
     |> list.flat_map(fn(result) { result.violations })
@@ -11049,7 +11055,7 @@ pub fn run() -> Nil {
   // At check time the two channels answer from their own sources: `db.make`'s
   // own [Disk] is suppressed by the module declaration, while the closure it
   // returns still resolves to [Stdout] through the clause on the kept line.
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert [violation] = list.flat_map(results, fn(r) { r.violations })
   violation.function |> should.equal("run")
   violation.explanation.actual
@@ -11078,7 +11084,7 @@ fn clause_lint_warnings(
     #("proj.graded", spec),
     #("proj.gleam", source),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let warnings = list.flat_map(results, fn(r) { r.warnings })
   support.cleanup(root)
   warnings
@@ -11165,7 +11171,7 @@ pub fn wrap(f: fn() -> Nil) -> fn() -> Nil {
 ",
     ),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([types.UnverifiedReturnsClauseWarning(function: "proj.wrap")])
@@ -11210,7 +11216,7 @@ pub fn caller() -> Nil {
       dependency_spec: dependency_spec,
       dependency_sources: [#("dep/store.gleam", dependency_source)],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let violations = list.flat_map(results, fn(result) { result.violations })
   // The query agrees with what `check` charged, whichever path answered it.
   let assert Ok(answered) = graded.run_effect(root, "dep/store.insert")
@@ -11336,7 +11342,7 @@ pub fn insert(r: Runner) -> Nil {
         ),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   support.cleanup(root)
   list.flat_map(results, fn(result) { result.violations })
 }
@@ -11431,7 +11437,7 @@ pub fn insert(r: " <> annotation <> ") -> Nil {
 "),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   support.cleanup(root)
   list.flat_map(results, fn(result) { result.violations })
 }
@@ -11525,7 +11531,7 @@ pub fn scribble() -> Nil
 ",
       ),
     ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let violations = list.flat_map(results, fn(result) { result.violations })
   support.cleanup(root)
   violations
@@ -11737,7 +11743,7 @@ pub fn tick() -> Nil {
         ),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { r.file == root <> "/proj.gleam" })
   ["direct", "via_operator"]
@@ -11798,11 +11804,66 @@ pub fn helper() -> Nil {
         ),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert [violation] = list.flat_map(results, fn(r) { r.violations })
   violation.function |> should.equal("caller")
   violation.explanation.actual
   |> types.contains_unknown
+  |> should.be_true
+  support.cleanup(root)
+}
+
+// The public check result
+//
+// `run` hands back what `main` prints: per module, its rendered warnings and
+// its rendered violations. Both halves, and both rendered by the one renderer
+// the CLI reads, so a caller and the terminal cannot disagree.
+
+pub fn the_public_report_renders_the_structured_result_test() {
+  let root = "build/public_report"
+  write_project(
+    root,
+    [
+      #(
+        "proj.gleam",
+        "import gleam/io
+
+pub fn shout() -> Nil {
+  io.println(\"x\")
+}
+",
+      ),
+    ],
+    "check proj.shout : []\ncheck proj.missing : []\n",
+  )
+
+  let assert Ok(reports) = graded.run(root)
+  let assert Ok(structured) = graded.check_project(root)
+
+  // One report per structured result, in the same order and under the same
+  // file, holding exactly what the checker's own renderers produce.
+  list.map(reports, fn(report) { report.file })
+  |> should.equal(list.map(structured, fn(result) { result.file }))
+  list.zip(reports, structured)
+  |> list.each(fn(pair) {
+    let #(report, result) = pair
+    report.violations
+    |> should.equal(
+      list.map(result.violations, checker.format_violation(result.file, _)),
+    )
+    report.warnings
+    |> should.equal(
+      list.map(result.warnings, checker.format_warning(result.file, _)),
+    )
+  })
+
+  // And both halves are really there: a dead `check` line earns a warning
+  // against the spec file, the live one a violation against the source.
+  list.flat_map(reports, fn(report) { report.warnings })
+  |> list.any(string.contains(_, "proj.missing"))
+  |> should.be_true
+  list.flat_map(reports, fn(report) { report.violations })
+  |> list.any(string.contains(_, "shout"))
   |> should.be_true
   support.cleanup(root)
 }

--- a/test/integration_test.gleam
+++ b/test/integration_test.gleam
@@ -3610,7 +3610,7 @@ pub fn a_module_external_resolves_from_catalog_functions_test() {
   // Only the module that really resolves nowhere is flagged.
   results
   |> list.flat_map(fn(r) { r.warnings })
-  |> should.equal([types.UnmatchedModuleExternalWarning(module: "nowhere/mod")])
+  |> should.equal([types.UnmatchedModuleAssumeWarning(module: "nowhere/mod")])
   support.cleanup(root)
 }
 
@@ -5346,7 +5346,7 @@ assume ffi.fold(g: [g]) : [g]
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.UnboundExternalTermVariableWarning(function: "ffi.each", free_vars: [
+    types.UnboundAssumeTermVariableWarning(function: "ffi.each", free_vars: [
       "x",
     ]),
     types.UngroundReturnsClauseWarning(function: "ffi.trace", free_vars: [
@@ -5474,8 +5474,8 @@ assume nowhere.gone(cb: [cb]) : [zz]
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.StaleFunctionExternalWarning(function: "app.local"),
-    types.UnmatchedFunctionExternalWarning(function: "nowhere.gone"),
+    types.StaleFunctionAssumeWarning(function: "app.local"),
+    types.UnmatchedFunctionAssumeWarning(function: "nowhere.gone"),
   ])
   support.cleanup(root)
 }
@@ -8666,7 +8666,7 @@ pub fn path_dep_shipped_module_external_resolves_test() {
   v.explanation.actual |> should.equal(types.Specific(set.from_list(["Time"])))
   v.explanation.origin
   |> should.equal(
-    Some(types.ModuleExternalOrigin(source: types.PathDependency("dep"))),
+    Some(types.ModuleAssumeOrigin(source: types.PathDependency("dep"))),
   )
 }
 
@@ -8686,7 +8686,7 @@ pub fn consumer_module_external_beats_a_shipped_one_test() {
   v.explanation.actual
   |> should.equal(types.Specific(set.from_list(["Mocked"])))
   v.explanation.origin
-  |> should.equal(Some(types.ModuleExternalOrigin(source: types.UserExternal)))
+  |> should.equal(Some(types.ModuleAssumeOrigin(source: types.UserAssume)))
 }
 
 pub fn path_dep_module_external_propagates_through_wrapper_test() {
@@ -9630,7 +9630,7 @@ pub fn a_stale_project_external_warns_once_test() {
   let assert Ok(results) = graded.check_project(root)
   results
   |> list.flat_map(fn(r) { r.warnings })
-  |> should.equal([types.StaleFunctionExternalWarning(function: "m.logs")])
+  |> should.equal([types.StaleFunctionAssumeWarning(function: "m.logs")])
   support.cleanup(root)
 }
 
@@ -9799,8 +9799,8 @@ assume m.go : []
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.UnmatchedFunctionExternalWarning(function: "m.no_such"),
-    types.StaleFunctionExternalWarning(function: "m.go"),
+    types.UnmatchedFunctionAssumeWarning(function: "m.no_such"),
+    types.StaleFunctionAssumeWarning(function: "m.go"),
   ])
   support.cleanup(root)
 }
@@ -9835,7 +9835,7 @@ assume here/io.typo : [Disk]
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.UnmatchedFunctionExternalWarning(function: "here/io.typo"),
+    types.UnmatchedFunctionAssumeWarning(function: "here/io.typo"),
   ])
   support.cleanup(root)
 }
@@ -9880,11 +9880,11 @@ assume dep/io : [Disk]
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.UnmatchedFunctionExternalWarning(function: "m.no_such"),
-    types.UnmatchedModuleExternalWarning(module: "nowhere/mod"),
+    types.UnmatchedFunctionAssumeWarning(function: "m.no_such"),
+    types.UnmatchedModuleAssumeWarning(module: "nowhere/mod"),
     // `dep/io` is a real dependency module, but it defines `writes` and not
     // `typo`. The module tier would have waved the misspelling through.
-    types.UnmatchedFunctionExternalWarning(function: "dep/io.typo"),
+    types.UnmatchedFunctionAssumeWarning(function: "dep/io.typo"),
   ])
   support.cleanup(root)
 }
@@ -9917,7 +9917,7 @@ pub fn a_parsed_dependency_source_outranks_the_catalog_in_the_lint_test() {
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.UnmatchedFunctionExternalWarning(function: "gleam/list.typo"),
+    types.UnmatchedFunctionAssumeWarning(function: "gleam/list.typo"),
   ])
   support.cleanup(root)
 }
@@ -9965,7 +9965,7 @@ pub fn a_stale_duplicate_dependency_copy_does_not_answer_for_a_name_test() {
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.UnmatchedFunctionExternalWarning(function: "dep/mod.writes"),
+    types.UnmatchedFunctionAssumeWarning(function: "dep/mod.writes"),
   ])
   support.cleanup(root)
 }
@@ -10055,7 +10055,7 @@ pub fn an_external_on_a_function_less_dependency_module_is_flagged_test() {
   results
   |> list.flat_map(fn(r) { r.warnings })
   |> should.equal([
-    types.UnmatchedFunctionExternalWarning(function: "types_only/mod.whatever"),
+    types.UnmatchedFunctionAssumeWarning(function: "types_only/mod.whatever"),
   ])
   support.cleanup(root)
 }

--- a/test/lint_test.gleam
+++ b/test/lint_test.gleam
@@ -15,7 +15,7 @@ import graded/internal/annotation
 import graded/internal/effects
 import graded/internal/lint
 import graded/internal/signatures
-import graded/internal/types.{QualifiedName, UnmatchedTypeFieldWarning}
+import graded/internal/types.{QualifiedName, UnmatchedFieldAssumeWarning}
 
 // Fixture setup
 //
@@ -83,7 +83,7 @@ fn field_warnings(
   |> lint.run
   |> list.filter_map(fn(warning) {
     case warning {
-      UnmatchedTypeFieldWarning(name:) -> Ok(name)
+      UnmatchedFieldAssumeWarning(name:) -> Ok(name)
       _ -> Error(Nil)
     }
   })
@@ -294,6 +294,6 @@ pub fn a_dependency_that_lacks_the_name_is_flagged_test() {
   )
   |> lint.run
   |> should.equal([
-    types.UnmatchedFunctionExternalWarning(function: "dep/io.typo"),
+    types.UnmatchedFunctionAssumeWarning(function: "dep/io.typo"),
   ])
 }

--- a/test/pack_test.gleam
+++ b/test/pack_test.gleam
@@ -236,15 +236,17 @@ pub fn pack_refuses_a_spec_that_does_not_parse_test() {
   let assert Ok(before) = simplifile.read_bits(tarball)
 
   // The standard parse error, naming the file and the retired line.
-  let assert Error(graded.GradedParseError(path, cause)) =
+  let assert Error(graded.GradedParseError(path, message)) =
     graded.pack_project(root, None)
   string.ends_with(path, "dep.graded") |> should.be_true()
-  cause
-  |> should.equal(annotation.RetiredSpelling(
-    2,
-    "returns dep.make : [Stdout]",
-    annotation.RetiredReturns,
-  ))
+  message
+  |> should.equal(
+    annotation.describe_parse_error(annotation.RetiredSpelling(
+      2,
+      "returns dep.make : [Stdout]",
+      annotation.RetiredReturns,
+    )),
+  )
 
   // The tarball is untouched and the run left no scratch path behind: the spec
   // is refused before either is opened.
@@ -325,7 +327,7 @@ pub fn pack_consumer_resolves_injected_spec_test() {
 
   // packdep is not in the catalog, so `packdep.work` resolves to [Stdout] only
   // by reading the injected spec at build/packages/packdep/packdep.graded.
-  let assert Ok(results) = graded.run(consumer)
+  let assert Ok(results) = graded.check_project(consumer)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "src/main.gleam") })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })

--- a/test/release_test.gleam
+++ b/test/release_test.gleam
@@ -58,7 +58,7 @@ fn lint_warnings(
       "/tmp/graded_release_" <> name,
       list.append(project_files(), files),
     )
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let warnings = list.flat_map(results, fn(r) { r.warnings })
   cleanup(directory)
   warnings
@@ -265,7 +265,7 @@ pub fn a_dependency_spec_unknown_clause_is_silent_test() {
         ),
       ],
     )
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let warnings = list.flat_map(results, fn(r) { r.warnings })
   cleanup(root)
 

--- a/test/release_test.gleam
+++ b/test/release_test.gleam
@@ -19,7 +19,8 @@ import graded/internal/effect_term
 import graded/internal/effects
 import graded/internal/types.{
   type EffectSet, type Warning, Specific, UnknownClauseWarning,
-  UnmatchedCheckWarning, UnmatchedTypeFieldWarning, UnverifiedCheckShapeWarning,
+  UnmatchedCheckWarning, UnmatchedFieldAssumeWarning,
+  UnverifiedCheckShapeWarning,
 }
 import simplifile
 import support.{cleanup, write_fixture}
@@ -180,7 +181,7 @@ pub fn unqualified_check_and_type_lines_warn_test() {
       #("app.graded", "assume Opts.on_change : []\ncheck run : []\n"),
     ])
 
-  expect_warning(warnings, UnmatchedTypeFieldWarning(name: "Opts.on_change"))
+  expect_warning(warnings, UnmatchedFieldAssumeWarning(name: "Opts.on_change"))
   expect_warning(warnings, UnmatchedCheckWarning(function: "run"))
 }
 
@@ -290,7 +291,7 @@ pub fn mismatched_qualifier_warns_test() {
       #("app.graded", "assume opts.Opts.gone : []\ncheck opts.missing : []\n"),
     ])
 
-  expect_warning(warnings, UnmatchedTypeFieldWarning(name: "opts.Opts.gone"))
+  expect_warning(warnings, UnmatchedFieldAssumeWarning(name: "opts.Opts.gone"))
   expect_warning(warnings, UnmatchedCheckWarning(function: "opts.missing"))
 }
 
@@ -307,7 +308,7 @@ pub fn dependency_type_field_does_not_warn_test() {
     ),
     #("app.graded", "assume widgets/ui.Config.on_click : [Dom]\n"),
   ])
-  |> refute_warning(UnmatchedTypeFieldWarning(
+  |> refute_warning(UnmatchedFieldAssumeWarning(
     name: "widgets/ui.Config.on_click",
   ))
 }
@@ -323,7 +324,7 @@ pub fn unknown_module_qualifier_warns_test() {
     ),
     #("app.graded", "assume optz.Opts.on_change : []\n"),
   ])
-  |> expect_warning(UnmatchedTypeFieldWarning(name: "optz.Opts.on_change"))
+  |> expect_warning(UnmatchedFieldAssumeWarning(name: "optz.Opts.on_change"))
 }
 
 // A field declared through a module-local function alias (`callback: Handler`
@@ -343,7 +344,7 @@ pub type Widget {
     ),
     #("app.graded", "assume widget.Widget.callback : [Dom]\n"),
   ])
-  |> refute_warning(UnmatchedTypeFieldWarning(name: "widget.Widget.callback"))
+  |> refute_warning(UnmatchedFieldAssumeWarning(name: "widget.Widget.callback"))
 }
 
 // A field typed with a function alias imported from another project module
@@ -363,7 +364,7 @@ pub type Widget {
     ),
     #("app.graded", "assume widget.Widget.callback : [Dom]\n"),
   ])
-  |> refute_warning(UnmatchedTypeFieldWarning(name: "widget.Widget.callback"))
+  |> refute_warning(UnmatchedFieldAssumeWarning(name: "widget.Widget.callback"))
 }
 
 // A module-local alias that delegates to an imported alias
@@ -386,7 +387,7 @@ pub type Widget {
     ),
     #("app.graded", "assume widget.Widget.callback : [Dom]\n"),
   ])
-  |> refute_warning(UnmatchedTypeFieldWarning(name: "widget.Widget.callback"))
+  |> refute_warning(UnmatchedFieldAssumeWarning(name: "widget.Widget.callback"))
 }
 
 // A field whose type is a non-function type owned by an installed dependency
@@ -409,7 +410,7 @@ pub type Widget {
     ),
     #("app.graded", "assume widget.Widget.value : []\n"),
   ])
-  |> expect_warning(UnmatchedTypeFieldWarning(name: "widget.Widget.value"))
+  |> expect_warning(UnmatchedFieldAssumeWarning(name: "widget.Widget.value"))
 }
 
 // The dependency counterpart of the project case: a field typed with a
@@ -432,7 +433,7 @@ pub type Widget {
     ),
     #("app.graded", "assume widget.Widget.callback : [Dom]\n"),
   ])
-  |> refute_warning(UnmatchedTypeFieldWarning(name: "widget.Widget.callback"))
+  |> refute_warning(UnmatchedFieldAssumeWarning(name: "widget.Widget.callback"))
 }
 
 // A field `assume` line on a project type whose field isn't function-typed can never
@@ -443,7 +444,7 @@ pub fn non_function_field_annotation_warns_test() {
     #("rec.gleam", "pub type Rec {\n  Rec(count: Int)\n}\n"),
     #("app.graded", "assume rec.Rec.count : []\n"),
   ])
-  |> expect_warning(UnmatchedTypeFieldWarning(name: "rec.Rec.count"))
+  |> expect_warning(UnmatchedFieldAssumeWarning(name: "rec.Rec.count"))
 }
 
 // Bundled catalog file names

--- a/test/topo_test.gleam
+++ b/test/topo_test.gleam
@@ -508,7 +508,7 @@ fn with_logger(action: fn(fn(String) -> Nil) -> Nil) -> Nil {
 
   // `check` re-resolves the consumer by loading that line, flagging main.run's
   // precise [Stdout] against the [] budget (it would be [Unknown] without it).
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(main_result) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/main.gleam") })
   let assert [violation, ..] = main_result.violations
@@ -554,7 +554,7 @@ pub fn use_resolver() -> Nil {
     ])
 
   let assert Ok(Nil) = graded.run_infer(directory)
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(config_result) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/config.gleam") })
   let assert [violation, ..] = config_result.violations
@@ -608,7 +608,7 @@ pub fn use_resolver() -> Nil {
     ])
 
   let assert Ok(Nil) = graded.run_infer(directory)
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(factory_result) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/factory.gleam") })
   let assert [violation, ..] = factory_result.violations
@@ -668,7 +668,7 @@ pub fn use_runner() -> Nil {
   |> should.be_true()
   string.contains(spec, "Unknown") |> should.be_true()
 
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(factory_result) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/factory.gleam") })
   let assert [violation, ..] = factory_result.violations
@@ -717,7 +717,7 @@ pub fn use_run() -> Nil {
       #("app.graded", "check app/factory.use_run : []\n"),
     ])
   let assert Ok(Nil) = graded.run_infer(directory)
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/factory.gleam") })
   let assert [violation, ..] = r.violations
@@ -770,7 +770,7 @@ pub fn use_run() -> Nil {
       ),
     ])
   let assert Ok(Nil) = graded.run_infer(directory)
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/factory.gleam") })
   let assert [violation, ..] = r.violations
@@ -823,7 +823,7 @@ pub fn use_field() -> Nil {
       #("app.graded", "check app/c.use_field : []\n"),
     ])
   let assert Ok(Nil) = graded.run_infer(directory)
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(c_result) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/c.gleam") })
   let assert [violation, ..] = c_result.violations
@@ -880,7 +880,7 @@ pub fn use_field() -> Nil {
       ),
     ])
   let assert Ok(Nil) = graded.run_infer(directory)
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(c_result) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/c.gleam") })
   let assert [violation, ..] = c_result.violations
@@ -918,7 +918,7 @@ pub fn use_field(r: Rec) -> Nil {
       #("app.graded", "check app/factory.use_field : []\n"),
     ])
   let assert Ok(Nil) = graded.run_infer(directory)
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/factory.gleam") })
   let assert [violation, ..] = r.violations
@@ -962,7 +962,7 @@ pub fn run() -> Nil {
       #("app.graded", "check app/a.run : []\n"),
     ])
 
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(a_result) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/a.gleam") })
   let assert [violation, ..] = a_result.violations
@@ -1191,7 +1191,7 @@ pub fn run_resolves_absolute_path_dependency_test() {
       ),
     ])
 
-  let assert Ok(results) = graded.run(app_dir)
+  let assert Ok(results) = graded.check_project(app_dir)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "src/main.gleam") })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -1255,7 +1255,7 @@ pub fn caller(resolver: fn() -> Nil) -> Nil {
       ),
     ])
 
-  let assert Ok(results) = graded.run(app_dir)
+  let assert Ok(results) = graded.check_project(app_dir)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "src/main.gleam") })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "caller" })
@@ -1333,7 +1333,7 @@ pub fn run() -> Nil {
       ),
     ])
 
-  let assert Ok(results) = graded.run(app_dir)
+  let assert Ok(results) = graded.check_project(app_dir)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "src/main.gleam") })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -1635,7 +1635,7 @@ pub fn run() -> Nil {
 }
 
 fn field_module_actual(directory: String) -> EffectSet {
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/consumer.gleam") })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -1734,7 +1734,7 @@ pub fn run() -> Nil {
       #("app.graded", "check app/consumer.run : []\n"),
     ])
 
-  let assert Ok(results) = graded.run(directory)
+  let assert Ok(results) = graded.check_project(directory)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "app/consumer.gleam") })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "run" })
@@ -1816,7 +1816,7 @@ pub fn leak() -> Nil {
 
   // Pre-fix the module derived as `src/app`, so `check app.leak` matched no
   // module and no violation surfaced — a false-green exit. The check must run.
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(r) =
     list.find(results, fn(r) { string.ends_with(r.file, "src/app.gleam") })
   let assert Ok(v) = list.find(r.violations, fn(v) { v.function == "leak" })

--- a/test/why_cli_test.gleam
+++ b/test/why_cli_test.gleam
@@ -3,7 +3,6 @@ import gleam/string
 import gleeunit/should
 import graded
 import graded/internal/annotation
-import graded/internal/answer
 import graded/internal/checker
 import graded/internal/cli
 import simplifile
@@ -155,7 +154,7 @@ pub fn a_higher_order_function_explains_as_the_query_answers_it_test() {
     "  calls parameter `action` with effects [action]",
   ])
   let assert Ok(answered) =
-    graded.run_effect_formatted(fixtures, "why_target.forwards", answer.Graded)
+    graded.run_effect_formatted(fixtures, "why_target.forwards", graded.Graded)
   answered
   |> string.contains("effects why_target.forwards(action: [action]) : [action]")
   |> should.be_true()
@@ -207,7 +206,7 @@ pub fn an_external_agrees_with_the_violation_for_it_test() {
   // One vocabulary, as for an ordinary call: the clause `check` prints when an
   // external blows the budget on its own `check` line is the line `why` prints
   // for that external, phrase for phrase.
-  let assert Ok(results) = graded.run(fixtures)
+  let assert Ok(results) = graded.check_project(fixtures)
   let assert Ok(result) =
     list.find(results, fn(r) { r.file == fixtures <> "/external_budget.gleam" })
   let assert Ok(violation) =
@@ -292,7 +291,7 @@ pub fn a_module_external_explains_an_ordinary_function_test() {
   output |> string.contains("is an external") |> should.be_false()
   // The one answer, in each command's own words.
   let assert Ok(effect) =
-    graded.run_effect_formatted(root, "probe.helper", answer.Prose)
+    graded.run_effect_formatted(root, "probe.helper", graded.Prose)
   effect
   |> string.contains("probe.helper has effects [Disk]")
   |> should.be_true()
@@ -309,7 +308,7 @@ pub fn a_module_external_violation_uses_the_same_wording_test() {
     #("proj.graded", "assume probe : [Disk]\ncheck probe.helper : []\n"),
     #("probe.gleam", "pub fn helper() -> Nil {\n  Nil\n}\n"),
   ])
-  let assert Ok(results) = graded.run(root)
+  let assert Ok(results) = graded.check_project(root)
   let assert Ok(result) =
     list.find(results, fn(r) { r.file == root <> "/probe.gleam" })
   let assert [violation] = result.violations
@@ -340,7 +339,7 @@ pub fn a_function_with_no_contributors_says_so_test() {
 pub fn agrees_with_the_violation_for_the_same_call_test() {
   // One vocabulary: the clause `check` prints for a violating call is the line
   // `why` prints for it, phrase for phrase.
-  let assert Ok(results) = graded.run(fixtures)
+  let assert Ok(results) = graded.check_project(fixtures)
   let assert Ok(result) =
     list.find(results, fn(r) { r.file == fixtures <> "/impure_view.gleam" })
   let assert [violation] = result.violations
@@ -427,7 +426,10 @@ pub fn why_over_an_unparseable_spec_errors_test() {
   |> should.equal(
     Error(graded.GradedParseError(
       root <> "/proj.graded",
-      annotation.InvalidLine(2, "not a graded line"),
+      annotation.describe_parse_error(annotation.InvalidLine(
+        2,
+        "not a graded line",
+      )),
     )),
   )
   support.cleanup(root)


### PR DESCRIPTION
Stacked on #76 — review that one first; this PR's base is its branch.

A hex consumer had to import `graded/internal/*` to name anything the public API returns or takes: `run` gave back `types.CheckResult`, `run_effect_formatted` took `answer.Format`, `run_catalog` took `cli.CatalogRequest`, `run_format_stdin` returned `annotation.ParseError`, and `GradedError` embedded two more internal types.

**Flattened, not promoted.** Promoting the rich types would drag most of `types.gleam` public — `CheckResult` carries `Violation` carries `Resolution` carries `EffectTerm` — and freeze exactly the types FFI-4 and RET-1 will rework. The primary consumer is the CLI; the library API is secondary. So:

- **`run` returns `List(ModuleReport)`** — per module, its path plus the warning and violation lines graded prints for it. **Both halves**, because both are what `main` itself consumes: it prints warnings with their count *and* violations with theirs, and exits on violations alone. Dropping warnings would fork the CLI onto a second, richer runner, which defeats the point. The structured results stay behind `@internal check_project`, which `why` and graded's own tests read.
- **`Format`** (`Graded | Prose`) is declared in `graded.gleam` and mapped to `answer.Format` internally.
- **`run_catalog` goes `@internal`**, replaced by two thin public functions, `catalog_list()` and `catalog_show(package, version, directory)`.
- **`run_format_stdin` returns `Result(String, GradedError)`**, a parse failure arriving as `GradedParseError("<stdin>", message)`.
- **`GradedParseError` and `InvalidConfig` carry the rendered cause**, through the one renderer each kind already had (`annotation.describe_parse_error`, and a new `config.describe_error` beside it) — so the wording a caller reads and the wording the CLI prints cannot fork. `InvalidConfig` now says what was wrong with the manifest, where it previously named only the path.
- **`infer_path_dep` and `run_effect_from_project` are `@internal`** — both exist for graded's own tests.

Public doc comments were swept for internal-module names; the module doc now states the boundary outright.

**The gate.** A `pub fn` allowlist cannot see an allowed function acquiring an internal parameter type, and the package's own build happily imports its own internals — so `scripts/check_public_interface.py` inspects what a *consumer* sees: it walks `gleam export package-interface` for every type reference in the `graded` module and fails on any that resolves under `graded/internal`. It is a fifth CI step and a fifth line in CONTRIBUTING's pre-flight list. Verified to actually catch a leak: dropping `@internal` from `run_catalog` fails it with `graded.functions.run_catalog.parameters[0].type: graded/internal/cli`.

**Second commit: decision 7's rename.** `external effects` and `type` lines became `assume` in 0.15.0, but the types behind them kept the old spelling. `ExternalAnnotation` → `AssumeAnnotation`, `TypeFieldAnnotation` → `FieldAnnotation`, `ExternalTarget`/`ModuleExternal`/`FunctionExternal` → `AssumeTarget`/`ModuleAssume`/`FunctionAssume`, `GradedLine.ExternalLine`/`TypeFieldLine` → `AssumeLine`/`FieldAssumeLine`, `LookupOrigin.UserExternal`/`ModuleExternalOrigin`/`TypeLine` → `UserAssume`/`ModuleAssumeOrigin`/`FieldAssumeOrigin`, `ModuleExternalEntry` → `ModuleAssumeEntry`, and the four `External*Warning`s plus `UnmatchedTypeFieldWarning` to the `assume` spelling. Names that refer to Gleam's own `@external` attribute (`UndeclaredExternal`, `UnbuiltExternal`, `declares_external`) are correct as they are and stay. Internal-only: the spec syntax, the CLI's words and the public API are all unchanged.

**Note for whoever merges.** #72 adds an `InvalidConfig` test asserting a structured `config.TomlReadError` cause; once both land, that assertion becomes a string comparison. The version in `gleam.toml` is untouched — this repo bumps at release, and the entry sits under `[Unreleased]` as a breaking library-API change (minor, pre-1.0).

Gates: `gleam format --check`, `gleam build --warnings-as-errors`, `gleam test` (1331 passed), `glinter`, and the new interface check.

---

### Follow-up commit: `Thread one resolver through the field classifier`

A cleanup pass over this branch and #76, mostly against `lint.gleam` (−157/+86 overall).

- The classifier threaded `project_infos`, `dep_files` and the memo as three arguments through five mutually recursive functions; two of the three never change across the recursion. They travel as one `Resolver` now, so `valid_type_field` takes 3 arguments where it took 7.
- The eager `project_module_infos` fold goes with it. The memo #76 introduced already guarantees one build per module, so a project module becomes a `ModuleInfo` when a field line reaches it — rather than every module in the package being converted whenever the spec holds a single field line.
- `dep_modules` was a set derived from a dict that now travels beside it, built per pass to answer one membership test.
- `spec_name_evidence` took `index` and `catalog` as parameters beside the `Context` that holds both — the "travels whole" rule the `Context` doc states applies to it too.
- `Callable` was `pub` although nothing outside the module names it.
- In `graded.gleam`: `public_format` converted the CLI's decoded `answer.Format` up to the public `Format` so that `run_effect_formatted` could convert it straight back one line later. The CLI's decoder already answers in the renderer's own vocabulary, so `main` takes the internal path; `answer_format` stays, since that is the real public boundary.

Gates re-run after the cleanup: `format --check`, `build --warnings-as-errors`, `test` (1331 passed), `glinter`, and the interface check.
