### PR TITLE
Warn on an effects line no run can key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Sixteen modules, no circular dependencies. Only `src/graded.gleam` is the public
 | `src/graded/internal/typeinfo.gleam` | Hold girard's per-expression inferred types, keyed by `#(start, end)` span, for receiver-type lookup |
 | `src/graded/internal/signatures.gleam` | Glance-backed parameter signatures: fn-typed and operator (second-order) parameter detection, positions, for call-site substitution |
 | `src/graded/internal/topo.gleam` | Kahn's-algorithm topological sort over a string-keyed dependency graph |
-| `src/graded/internal/lint.gleam` | Spec-file lint: `check`/`assume`/field lines whose target resolves nothing, and `where returns` clauses their own line does not scope |
+| `src/graded/internal/lint.gleam` | Spec-file lint: `check`/`assume`/field lines whose target resolves nothing, `effects` lines whose path is not a function's, and `where returns` clauses their own line does not scope |
 | `src/graded/internal/pack.gleam` | Hex tarball patching for `graded pack`: pick the archive, inject the spec through a temporary file, verify, replace |
 | `src/graded/internal/diff.gleam` | Line diff between two renderings of a spec file, for `infer --dry-run` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `graded check` now warns about an `effects` line whose path is not
+  `module.function` — a field path (`myapp/ui.Handler.on_click`) or a bare
+  module path. Such a line resolves nothing and the next `graded infer` deletes
+  it, both silently until now. A field's effect is declared with an `assume`
+  line. An `effects` line naming a function that no longer exists is untouched:
+  that tier is regenerated from source.
+
 ### Changed
 
 - **Breaking (library API).** Every type the public API names is now defined in

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -314,7 +314,88 @@ pub fn caller() -> Nil {
 
 or declare the budget explicitly (`check app.caller : [_]`, or the precise set).
 
-## 5. External (FFI) and un-annotated precompiled code
+## 5. A function returned inside a tuple or `Result`
+
+graded traces a returned function when it *is* the return value. One returned
+**inside** a structure — a tuple element, an `Ok`, anything the caller has to
+destructure — has no position of its own to be filed under, so two things go
+wrong, from two independent causes.
+
+**An inline closure charges the function that builds it.** A producer that only
+*constructs* a closure is charged its latent effect, because there is nowhere
+else to put it:
+
+```gleam
+import app/ffi     // ffi.emit : [Stdout]
+
+pub fn connect(url: String) -> Result(fn(String) -> Nil, Nil) {
+  case url {
+    "" -> Error(Nil)
+    _ -> Ok(fn(msg) { ffi.emit(msg) })   // built here, called by whoever unwraps it
+  }
+}
+
+pub fn is_reachable(url: String) -> Bool {
+  case connect(url) {
+    Ok(_send) -> True                    // never calls `_send`
+    Error(_) -> False
+  }
+}
+```
+
+`connect` infers `[Stdout]` though it emits nothing, and `is_reachable` inherits
+it. That is an over-approximation, so nothing is understated — but it is the one
+limitation here that makes `check` report a violation naming a call the body does
+not make:
+
+```
+is_reachable calls app/ffi.emit with effects [Stdout] (from your spec's `assume` line) but declared []
+```
+
+**A structural position is `[Unknown]` once it is unpacked.** Nothing records
+which half a caller destructured out:
+
+```gleam
+pub fn make_pair() -> #(fn() -> Nil, fn() -> Nil) {
+  #(shout, quiet)      // shout : [Stdout], quiet : []
+}
+
+pub fn use_right() -> Nil {
+  let #(_l, r) = make_pair()
+  r()                  // [Unknown] — the tuple position has no path
+}
+```
+
+`use_left` and `use_right` infer the same set, though only one of them calls the
+impure half.
+
+**How to avoid it** — return a record with named function fields, filled with
+named functions rather than inline closures. The field gives the call a path
+graded resolves from the construction site, and a reference passed as a value
+costs the builder nothing:
+
+```gleam
+pub type Pair {
+  Pair(left: fn() -> Nil, right: fn() -> Nil)
+}
+
+pub fn make_pair() -> Pair {
+  Pair(left: shout, right: quiet)   // [] — references, not closures
+}
+
+pub fn use_right() -> Nil {
+  let pair = make_pair()
+  pair.right()                      // [] — resolves to `quiet`
+}
+```
+
+Each half of that fix stands alone: named functions in a tuple keep the producer
+pure but leave the unpacked call `[Unknown]`; inline closures in a record resolve
+the field but still charge the builder. If the shape is essential, widen the
+budget (`check app/pair.use_right : [_]`), which gives up the invariant for that
+function.
+
+## 6. External (FFI) and un-annotated precompiled code
 
 graded can't see across an `@external` boundary, so FFI functions are `[Unknown]`
 — even when the declaration carries a pure-looking Gleam fallback body, since the

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -70,6 +70,12 @@ effects myapp/router.handle_request : [Http, Stdout]
 Written by `graded infer` for every public function. Regenerated on each run — do
 not edit by hand. (The cache holds the same lines for private functions too.)
 
+The path is a function: `module.function`. A field path or a bare module path
+parses here and keys nothing — only `assume` takes those — so the line resolves
+nothing and the next `infer` drops it; `graded check` warns about the shape. A
+path naming a function that no longer exists draws no warning, since rewriting
+this tier from source is what `infer` does.
+
 ### `check` — enforced invariant
 
 ```

--- a/src/graded/internal/checker.gleam
+++ b/src/graded/internal/checker.gleam
@@ -29,12 +29,13 @@ import graded/internal/types.{
   StaleFunctionAssumeWarning, StaleReturnsClauseWarning, TUnion, TVar,
   UnboundAssumeTermVariableWarning, UnbuiltExternal,
   UnclosedReturnsClauseWarning, UndeclaredExternal, UngroundReturnsClauseWarning,
-  UnknownClauseWarning, UnmatchedCheckWarning, UnmatchedFieldAssumeWarning,
-  UnmatchedFieldBoundWarning, UnmatchedFunctionAssumeWarning,
-  UnmatchedModuleAssumeWarning, UnmatchedParamBoundWarning,
-  UnmatchedReturnsClauseWarning, UnresolvedFieldValue, UntraceableArgument,
-  UntraceableProducer, UntraceableReceiver, UntrackedEffectWarning,
-  UnverifiedCheckShapeWarning, UnverifiedReturnsClauseWarning, Violation,
+  UnkeyedEffectsShapeWarning, UnknownClauseWarning, UnmatchedCheckWarning,
+  UnmatchedFieldAssumeWarning, UnmatchedFieldBoundWarning,
+  UnmatchedFunctionAssumeWarning, UnmatchedModuleAssumeWarning,
+  UnmatchedParamBoundWarning, UnmatchedReturnsClauseWarning,
+  UnresolvedFieldValue, UntraceableArgument, UntraceableProducer,
+  UntraceableReceiver, UntrackedEffectWarning, UnverifiedCheckShapeWarning,
+  UnverifiedReturnsClauseWarning, Violation,
 }
 
 // Entry points
@@ -1701,6 +1702,11 @@ pub fn format_warning(file: String, warning: Warning) -> String {
       <> ": warning: check "
       <> name
       <> " is a shape nothing verifies yet — a check on a field keys nothing; an `assume` line is the trusted form"
+    UnkeyedEffectsShapeWarning(name:) ->
+      file
+      <> ": warning: effects "
+      <> name
+      <> " is not a function path — only `module.function` keys an effects line, so this one resolves nothing and the next `graded infer` drops it; `assume` is the line that takes a field or module path"
     UnverifiedReturnsClauseWarning(function:) ->
       file
       <> ": warning: the `where returns` clause on check "

--- a/src/graded/internal/lint.gleam
+++ b/src/graded/internal/lint.gleam
@@ -4,8 +4,8 @@
 // spec file rather than any source file: a `check` naming no project function,
 // an `assume` covering a body sitting in plain sight or naming nothing at all,
 // a field `assume` whose field cannot be called, a `where returns` clause its
-// own line does not scope. Such a line is silently dead, so it is surfaced as
-// a warning.
+// own line does not scope, an `effects` line whose path is not a function's.
+// Such a line is silently dead, so it is surfaced as a warning.
 //
 // The pass reads a `Context` the caller assembles from the run it already
 // performed. Dependency discovery arrives as thunks, not values: the walk they
@@ -31,10 +31,10 @@ import graded/internal/types.{
   DotlessReturnsClauseWarning, QualifiedName, StaleFunctionAssumeWarning,
   StaleReturnsClauseWarning, UnboundAssumeTermVariableWarning,
   UnclosedReturnsClauseWarning, UngroundReturnsClauseWarning,
-  UnknownClauseWarning, UnmatchedCheckWarning, UnmatchedFieldAssumeWarning,
-  UnmatchedFunctionAssumeWarning, UnmatchedModuleAssumeWarning,
-  UnmatchedReturnsClauseWarning, UnverifiedCheckShapeWarning,
-  UnverifiedReturnsClauseWarning,
+  UnkeyedEffectsShapeWarning, UnknownClauseWarning, UnmatchedCheckWarning,
+  UnmatchedFieldAssumeWarning, UnmatchedFunctionAssumeWarning,
+  UnmatchedModuleAssumeWarning, UnmatchedReturnsClauseWarning,
+  UnverifiedCheckShapeWarning, UnverifiedReturnsClauseWarning,
 }
 import simplifile
 
@@ -103,11 +103,12 @@ type Resolver {
   )
 }
 
-// Flag `check`/`assume` spec lines whose target resolves nothing. A
+// Flag `check`/`assume`/`effects` spec lines whose target resolves nothing. A
 // `check` line names a function that must exist in some project module; a field
 // `assume` line names a `module.Type.field` that must be a callable
 // (function-typed) field; an `assume` line names foreign code, so it must name
-// something graded cannot see the body of, and something that exists at all.
+// something graded cannot see the body of, and something that exists at all; an
+// `effects` line names a function by shape, whatever it resolves to.
 // When the qualifier is missing or wrong, the field plainly can't be called, or
 // the declaration covers a body sitting in plain sight, the line is silently
 // dead or silently ignored, so surface it as a warning.
@@ -225,6 +226,21 @@ pub fn run_recording_lookups(
     effects_lines
     |> list.filter_map(unclosed_clause_warning(_, registry))
 
+  // Only a `module.function` path keys an `effects` line, so the question is
+  // put to `split_function_name` — the reader every consumer of this tier goes
+  // through — rather than to a second classification of the same path. A
+  // dangling function path is left alone on purpose: this tier is rewritten
+  // from source on every `infer`, so a stale line is a line doing its job,
+  // while a field or module path is one no run can key at all.
+  let effects_shape_warnings =
+    effects_lines
+    |> list.filter_map(fn(ann) {
+      case annotation.split_function_name(ann.function) {
+        Ok(_) -> Error(Nil)
+        Error(Nil) -> Ok(UnkeyedEffectsShapeWarning(name: ann.function))
+      }
+    })
+
   // A clause whose key this version does not read. Reported here rather than by
   // the parser, so a dependency's spec stays silent — its consumer cannot fix it
   // — and so the cache reader inherits that silence instead of a default nobody
@@ -239,6 +255,7 @@ pub fn run_recording_lookups(
   #(
     list.flatten([
       check_warnings,
+      effects_shape_warnings,
       assume_warnings,
       unbound_term_variable_warnings(assumes, dead_assumes),
       aliased_bound_variable_warnings(assumes, effects_lines, dead_assumes),

--- a/src/graded/internal/lint.gleam
+++ b/src/graded/internal/lint.gleam
@@ -226,18 +226,25 @@ pub fn run_recording_lookups(
     effects_lines
     |> list.filter_map(unclosed_clause_warning(_, registry))
 
-  // Only a `module.function` path keys an `effects` line, so the question is
-  // put to `split_function_name` — the reader every consumer of this tier goes
-  // through — rather than to a second classification of the same path. A
-  // dangling function path is left alone on purpose: this tier is rewritten
-  // from source on every `infer`, so a stale line is a line doing its job,
-  // while a field or module path is one no run can key at all.
+  // Only a `module.function` path keys an `effects` line. The question goes to
+  // the two readers that already answer it — `split_function_name`, which every
+  // consumer of this tier goes through, and the field reader the `check` lint
+  // above asks — rather than to a third classification of the same path. Both
+  // are needed: the segment count alone reads `Handler.on_click`, the field
+  // spelling whose module its type implies, as a function of a module named
+  // `Handler`, and no Gleam module is named that. A dangling function path is
+  // left alone on purpose: this tier is rewritten from source on every `infer`,
+  // so a stale line is a line doing its job, while a field or module path is
+  // one no run can key at all.
   let effects_shape_warnings =
     effects_lines
     |> list.filter_map(fn(ann) {
-      case annotation.split_function_name(ann.function) {
-        Ok(_) -> Error(Nil)
-        Error(Nil) -> Ok(UnkeyedEffectsShapeWarning(name: ann.function))
+      case
+        annotation.is_field_path(ann.function),
+        annotation.split_function_name(ann.function)
+      {
+        False, Ok(_) -> Error(Nil)
+        _, _ -> Ok(UnkeyedEffectsShapeWarning(name: ann.function))
       }
     })
 

--- a/src/graded/internal/types.gleam
+++ b/src/graded/internal/types.gleam
@@ -864,6 +864,15 @@ pub type Warning {
   // weighs a check's returned operator, while the effects budget on the same
   // line is checked as any other. So the line is live and the clause is not.
   UnverifiedReturnsClauseWarning(function: String)
+  // An `effects` line whose path is not `module.function` — a field path
+  // (`m.Handler.on_click`) or a bare module path. Only a function path keys
+  // this tier, so the line resolves nothing and the next `infer`, which
+  // rewrites the tier from source, drops it without a word. The `check`
+  // counterpart is `UnverifiedCheckShapeWarning`. A *dangling* function path is
+  // deliberately not this: a stale line regenerating is the tier's normal life,
+  // while these two shapes are ones no run can ever key. `name` is the subject
+  // as written.
+  UnkeyedEffectsShapeWarning(name: String)
   // A field `assume` line whose module/type/field matches no field of a project custom
   // type — unqualified, mis-qualified, or a typo. The annotation then resolves
   // nothing and the field call silently degrades to `[Unknown]`, so it's

--- a/test/checker_test.gleam
+++ b/test/checker_test.gleam
@@ -5210,6 +5210,17 @@ pub fn format_warning_unverified_check_shape_test() {
   )
 }
 
+pub fn format_warning_unkeyed_effects_shape_test() {
+  // The sentence carries the whole rule: what keys the tier, that this line
+  // does not, and that the next `infer` removes it — a reader who sees it after
+  // the removal has no line left to read.
+  types.UnkeyedEffectsShapeWarning(name: "app.Handler.on_click")
+  |> checker.format_warning("proj.graded", _)
+  |> should.equal(
+    "proj.graded: warning: effects app.Handler.on_click is not a function path — only `module.function` keys an effects line, so this one resolves nothing and the next `graded infer` drops it; `assume` is the line that takes a field or module path",
+  )
+}
+
 pub fn format_warning_unverified_returns_clause_test() {
   // Scoped to the clause: the sentence has to keep the budget on the same line
   // out of what it calls unverified, or a reader deletes a check that runs.

--- a/test/release_test.gleam
+++ b/test/release_test.gleam
@@ -205,29 +205,28 @@ pub fn a_field_shaped_check_warns_about_its_shape_test() {
   )
 }
 
-// The same mistake one tier over. An `effects` line only ever keys
-// `module.function`, so a field path on one is a line no run can read — and
-// `infer`, which rewrites this tier from source, deletes it without a word.
-pub fn a_field_shaped_effects_line_warns_about_its_shape_test() {
+// The same mistake one tier over, in all three spellings. An `effects` line
+// only ever keys `module.function`, so a field path — qualified or with its
+// module implied by the type — and a bare module path are lines no run can
+// read, and `infer`, which rewrites this tier from source, deletes them
+// without a word. One fixture, since the three lines are read by one pass.
+pub fn a_field_or_module_shaped_effects_line_warns_about_its_shape_test() {
   let warnings =
     lint_warnings("effects_shape", [
       #("opts.gleam", opts_module),
-      #("app.graded", "effects opts.Opts.on_change : []\n"),
+      #(
+        "app.graded",
+        "effects opts.Opts.on_change : []\neffects Opts.on_change : []\neffects opts : []\n",
+      ),
     ])
 
   expect_warning(
     warnings,
     UnkeyedEffectsShapeWarning(name: "opts.Opts.on_change"),
   )
-}
-
-pub fn a_module_shaped_effects_line_warns_about_its_shape_test() {
-  let warnings =
-    lint_warnings("effects_shape_module", [
-      #("opts.gleam", opts_module),
-      #("app.graded", "effects opts : []\n"),
-    ])
-
+  // The spelling the segment count alone cannot tell from a function: read as
+  // `module.function` it names a module `Opts`, which no Gleam module is.
+  expect_warning(warnings, UnkeyedEffectsShapeWarning(name: "Opts.on_change"))
   expect_warning(warnings, UnkeyedEffectsShapeWarning(name: "opts"))
 }
 

--- a/test/release_test.gleam
+++ b/test/release_test.gleam
@@ -18,8 +18,8 @@ import graded/internal/annotation
 import graded/internal/effect_term
 import graded/internal/effects
 import graded/internal/types.{
-  type EffectSet, type Warning, Specific, UnknownClauseWarning,
-  UnmatchedCheckWarning, UnmatchedFieldAssumeWarning,
+  type EffectSet, type Warning, Specific, UnkeyedEffectsShapeWarning,
+  UnknownClauseWarning, UnmatchedCheckWarning, UnmatchedFieldAssumeWarning,
   UnverifiedCheckShapeWarning,
 }
 import simplifile
@@ -203,6 +203,46 @@ pub fn a_field_shaped_check_warns_about_its_shape_test() {
     warnings,
     UnmatchedCheckWarning(function: "opts.Opts.on_change"),
   )
+}
+
+// The same mistake one tier over. An `effects` line only ever keys
+// `module.function`, so a field path on one is a line no run can read — and
+// `infer`, which rewrites this tier from source, deletes it without a word.
+pub fn a_field_shaped_effects_line_warns_about_its_shape_test() {
+  let warnings =
+    lint_warnings("effects_shape", [
+      #("opts.gleam", opts_module),
+      #("app.graded", "effects opts.Opts.on_change : []\n"),
+    ])
+
+  expect_warning(
+    warnings,
+    UnkeyedEffectsShapeWarning(name: "opts.Opts.on_change"),
+  )
+}
+
+pub fn a_module_shaped_effects_line_warns_about_its_shape_test() {
+  let warnings =
+    lint_warnings("effects_shape_module", [
+      #("opts.gleam", opts_module),
+      #("app.graded", "effects opts : []\n"),
+    ])
+
+  expect_warning(warnings, UnkeyedEffectsShapeWarning(name: "opts"))
+}
+
+// The line the shape lint must not draw. A dangling function path is stale, not
+// malformed: this tier is regenerated from source on every `infer`, so a line
+// outliving its function is the tier working as designed, and warning about it
+// would fire on every renamed function until the next `infer`.
+pub fn a_dangling_effects_line_is_not_a_shape_warning_test() {
+  let warnings =
+    lint_warnings("effects_shape_dangling", [
+      #("opts.gleam", opts_module),
+      #("app.graded", "effects opts.ghost : []\n"),
+    ])
+
+  refute_warning(warnings, UnkeyedEffectsShapeWarning(name: "opts.ghost"))
 }
 
 pub fn qualified_check_and_type_lines_do_not_warn_test() {


### PR DESCRIPTION
An `effects` line keys `module.function` and nothing else. A field path or a
bare module path on one parses, resolves nothing, and is deleted by the next
`infer` — both steps silent until now. Writing the field spelling next to a
field `assume` is the likely way in, and it cost the reader the line with no
diagnostic from either command.

The `check` half of the same mistake has been flagged since the grammar
migration. This is its `effects` counterpart.

## What it looks like

On a spec holding all four shapes, only the two that can never key anything are
reported:

```
effects probe/rec.Pair.left : [Dom]     # warns — field path
effects probe/rec : [Dom]               # warns — module path
effects probe/rec.ghost : [Dom]         # silent — dangling, see below
effects probe/rec.use_left : [Stdout]   # silent — a live line
```

```
probe.graded: warning: effects probe/rec.Pair.left is not a function path — only
`module.function` keys an effects line, so this one resolves nothing and the next
`graded infer` drops it; `assume` is the line that takes a field or module path
```

## How

One arm in the fold `lint.gleam` already runs over the spec's `effects` lines,
asking `annotation.split_function_name` — the reader every consumer of this tier
goes through — rather than classifying the path a second way. If the readers
that key a line and the lint that judges it can't disagree by construction,
neither can drift.

That oracle also catches the bare module path, which the field case does not
imply and which was silent for the same reason.

## The line it does not draw

A **dangling** function path (`effects m.ghost : []`) stays silent, and a test
pins that. This tier is rewritten from source on every `infer`, so a line
outliving its function is the tier working as designed — warning there would
fire on every renamed function until the next `infer`. Stale and malformed look
alike from a distance, which is exactly why the distinction is a test and not a
comment.

## Why a warning rather than a parse error

The shape is meaningless in this version, so rejecting it at parse time is a
fair question. Two things argue against it.

**Blast radius.** A spec is read whole or not at all: one rejected line fails
`check`, `infer`, `format`, `effect`, `why` and `pack`, and nothing writes —
including the `infer` that would have removed the line. Across a package
boundary it is worse: a dependency's unparseable spec drops that dependency's
*entire* spec for its consumers, over a line they cannot fix. The line is inert,
not dangerous, and the severity should say so.

**"Never valid" is not settled.** Verifying a field `check` at construction
sites is open work; if a field's effect becomes provable, an inferred field line
stops being nonsense. A parse error is the one choice that forecloses that for
readers already shipped, which cuts against the same design that has the clause
list retain unknown keys instead of rejecting them.

Worth naming as a known limit either way: warnings never fail a check, so this
one prints and exits zero. If a spec saying something impossible should stop a
run, that is a severity graded does not have yet, and it would want to cover the
field `check` and the dangling-name lints too rather than this shape alone.

## Scope

`lint.run` is reached from the `check` path only, so `infer` still deletes such
a line without a word. Every lint in that module has the same reach; giving
`infer` a lint pass means splitting its assembly and is its own change.

## Also in this branch

`Document the returned-structure false positive` — a LIMITATIONS section for
functions returned inside a tuple or `Result`, which is not on `main` yet, so it
rides along here. Independent of the lint; happy to split it out.

## Tests and gates

1351 passing, up from 1347. The four new tests: the warning's wording, the field
path, the module path, and the dangling path that must stay quiet.

`gleam format --check src/ test/`, `gleam build --warnings-as-errors`,
`gleam test`, `gleam run -m glinter`, `gleam run -m check_public_interface` —
all green. Dogfooded: `graded check .` on this repo is unchanged.
