### PR TITLE
Anchor the dry-run diff so its cost tracks the change, not the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `graded infer --dry-run` no longer stalls previewing a large spec file.
+  Unchanged lines now pin the two renderings together, so the search runs on
+  the gaps between them rather than on everything from the first change to the
+  last; a five-thousand-line spec whose every tenth line moved previewed in
+  43 seconds and now previews in under 20 milliseconds.
 - A field call whose receiver shares a name with an imported module now resolves
   to the receiver's own field where the value is known to have one, instead of
   to the module. `let int = Fmt(to_string: shout)` then `int.to_string("hi")`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `graded infer --dry-run` no longer stalls previewing a large spec file.
-  Unchanged lines now pin the two renderings together, so the search runs on
-  the gaps between them rather than on everything from the first change to the
-  last; a five-thousand-line spec whose every tenth line moved previewed in
-  43 seconds and now previews in under 20 milliseconds.
+- `graded infer --dry-run` no longer stalls previewing a large spec file. A
+  five-thousand-line spec with every tenth line changed took 43 seconds to
+  preview and now takes milliseconds.
 - A field call whose receiver shares a name with an imported module now resolves
   to the receiver's own field where the value is known to have one, instead of
   to the module. `let int = Fmt(to_string: shout)` then `int.to_string("hi")`

--- a/src/graded/internal/diff.gleam
+++ b/src/graded/internal/diff.gleam
@@ -12,6 +12,7 @@ import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/set
 import gleam/string
 
 // Diffing
@@ -106,30 +107,12 @@ fn note_for(line: Line) -> Note {
   }
 }
 
-// Longest common subsequence
+// Alignment
 //
-// Lines the two sides share stay context; everything else is a removal or an
-// addition. Common leading and trailing lines are matched directly so the
-// quadratic search only runs over the part that actually differs.
-
-// The two sides indexed by position, so the search can address a line by
-// index instead of walking a list. Indices run from zero without gaps, so a
-// lookup misses exactly when it has walked past the end of that side — which
-// makes the lookup itself the bounds check.
-type Grid {
-  Grid(old: Dict(Int, Line), new: Dict(Int, Line))
-}
-
-// Which side a step at a disagreeing line advances.
-type Move {
-  DropOld
-  DropNew
-}
-
-// Lengths of the longest common subsequence of the two suffixes, keyed by
-// where each suffix starts.
-type Memo =
-  Dict(#(Int, Int), Int)
+// Which lines the two sides share. Common leading and trailing lines are
+// matched off directly, lines occurring exactly once on each side pin the rest
+// of the two sides together, and the quadratic search runs only on the gaps
+// between those pins.
 
 fn diff_lines(old: List(Line), new: List(Line)) -> List(Edit) {
   let #(prefix, old_rest, new_rest) = take_common_prefix(old, new, [])
@@ -162,17 +145,256 @@ fn take_common_suffix(
   #(list.reverse(suffix), list.reverse(old_rest), list.reverse(new_rest))
 }
 
-// Diff the part left over once the shared ends are matched off.
+// Diff the part left over once the shared ends are matched off. Anchors are
+// context wherever they are found, and the gaps they leave are diffed apart
+// from one another; finding none leaves the whole middle as one gap.
 fn middle_edits(old: List(Line), new: List(Line)) -> List(Edit) {
-  case old, new {
-    [], _ -> list.map(new, add)
-    _, [] -> list.map(old, remove)
-    _, _ -> {
-      let grid = Grid(old: index_lines(old), new: index_lines(new))
-      let #(edits, _memo) = walk(grid, 0, 0, dict.new(), [])
-      list.reverse(edits)
+  stitch(old, new, anchors(old, new), 0, 0, [])
+}
+
+// Emit each gap, the anchor that closes it, and finally the gap past the last
+// anchor. The two indices say how far into each side the walk has come, so an
+// anchor's recorded position gives the length of the gap before it.
+fn stitch(
+  old: List(Line),
+  new: List(Line),
+  anchors: List(Anchor),
+  old_index: Int,
+  new_index: Int,
+  acc: List(List(Edit)),
+) -> List(Edit) {
+  case anchors {
+    [] -> list.flatten(list.reverse([gap_edits(old, new), ..acc]))
+    [anchor, ..rest] -> {
+      let #(old_gap, old_rest) = list.split(old, anchor.old_index - old_index)
+      let #(new_gap, new_rest) = list.split(new, anchor.new_index - new_index)
+      stitch(
+        list.drop(old_rest, 1),
+        list.drop(new_rest, 1),
+        rest,
+        anchor.old_index + 1,
+        anchor.new_index + 1,
+        [[keep(anchor.line)], gap_edits(old_gap, new_gap), ..acc],
+      )
     }
   }
+}
+
+// Diff one gap. Two sides sharing no line at all have an empty longest common
+// subsequence, so every step of the search ties and `better_move` takes the
+// removal — every removal and then every addition, which is what this emits
+// without filling a rectangle to reach it.
+fn gap_edits(old: List(Line), new: List(Line)) -> List(Edit) {
+  use <- bool.lazy_guard(when: shares_a_line(old, new), return: fn() {
+    searched_edits(old, new)
+  })
+  list.append(list.map(old, remove), list.map(new, add))
+}
+
+fn shares_a_line(old: List(Line), new: List(Line)) -> Bool {
+  let old_lines = set.from_list(old)
+  list.any(new, set.contains(old_lines, _))
+}
+
+// Anchors
+//
+// A line occurring exactly once on each side pins those two positions
+// together. Not every such line can be kept: two of them cross when one sits
+// earlier than the other on the old side and later on the new, and keeping
+// both would align the sides two ways at once. The anchors are the longest run
+// of candidates that does not cross.
+
+// A line occurring exactly once on each side, and where it sits on both.
+type Anchor {
+  Anchor(old_index: Int, new_index: Int, line: Line)
+}
+
+fn anchors(old: List(Line), new: List(Line)) -> List(Anchor) {
+  candidates(old, new) |> longest_run
+}
+
+// Every line unique to one occurrence on both sides, in old-side order.
+fn candidates(old: List(Line), new: List(Line)) -> List(Anchor) {
+  let old_occurrences = occurrences(old)
+  let new_occurrences = occurrences(new)
+  old
+  |> list.index_fold([], fn(acc, line, index) {
+    case single_position(new_occurrences, line) {
+      Error(Nil) -> acc
+      Ok(new_index) ->
+        case single_position(old_occurrences, line) {
+          Error(Nil) -> acc
+          Ok(_) -> [Anchor(old_index: index, new_index:, line:), ..acc]
+        }
+    }
+  })
+  |> list.reverse
+}
+
+// How often a line occurs on one side, and where it sits when that is once.
+type Occurrence {
+  Once(index: Int)
+  Repeated
+}
+
+// How often each line occurs on one side. A line occurring more than once
+// pins nothing: which of its occurrences matches which is the question the
+// search exists to answer.
+fn occurrences(lines: List(Line)) -> Dict(Line, Occurrence) {
+  list.index_fold(lines, dict.new(), fn(acc, line, index) {
+    case dict.get(acc, line) {
+      Error(Nil) -> dict.insert(acc, line, Once(index))
+      Ok(_) -> dict.insert(acc, line, Repeated)
+    }
+  })
+}
+
+fn single_position(
+  occurrences: Dict(Line, Occurrence),
+  line: Line,
+) -> Result(Int, Nil) {
+  case dict.get(occurrences, line) {
+    Ok(Once(index)) -> Ok(index)
+    Ok(Repeated) -> Error(Nil)
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+// The piles of a patience sort: the candidate topping each pile, keyed by pile
+// index, and the candidate preceding a given one in the run being built, keyed
+// by old-side position. How many piles are open is `dict.size(tops)`, since a
+// candidate either tops a pile that exists or opens the next one.
+type Piles {
+  Piles(tops: Dict(Int, Anchor), predecessors: Dict(Int, Anchor))
+}
+
+// The longest run of candidates whose new-side positions strictly ascend, over
+// candidates already in old-side order.
+//
+// Patience sorting: each candidate lands on the leftmost pile whose top sits at
+// or past its new-side position, opening a pile when every top sits before it,
+// and records the top of the pile to its left as its predecessor. The run is
+// the chain of predecessors back from the top of the last pile. Those two rules
+// settle which run is chosen when several are equally long, so the alignment is
+// the same on every run.
+//
+// The piles live in a dict rather than an array, since the standard library
+// ships no indexed sequence, so each probe of the binary search costs a lookup.
+fn longest_run(candidates: List(Anchor)) -> List(Anchor) {
+  let piles =
+    list.fold(
+      candidates,
+      Piles(tops: dict.new(), predecessors: dict.new()),
+      place,
+    )
+  let last = dict.get(piles.tops, dict.size(piles.tops) - 1)
+  chase(piles.predecessors, last, [])
+}
+
+fn place(piles: Piles, candidate: Anchor) -> Piles {
+  let open = dict.size(piles.tops)
+  case dict.get(piles.tops, open - 1) {
+    Error(Nil) -> stack(piles, candidate, 0, Error(Nil))
+    Ok(last) ->
+      case last.new_index < candidate.new_index {
+        // Tops ascend left to right, so a candidate past the last of them opens
+        // the next pile and follows that same top — one lookup, no search. A
+        // file whose changes are scattered takes this path for every candidate,
+        // since the unchanged lines between them already ascend.
+        True -> stack(piles, candidate, open, Ok(last))
+        False -> {
+          let index = leftmost_pile(piles.tops, candidate.new_index, 0, open)
+          stack(piles, candidate, index, dict.get(piles.tops, index - 1))
+        }
+      }
+  }
+}
+
+// Put the candidate on top of pile `index`, recording `previous` — the top of
+// the pile to its left — as the candidate it follows in the run.
+fn stack(
+  piles: Piles,
+  candidate: Anchor,
+  index: Int,
+  previous: Result(Anchor, Nil),
+) -> Piles {
+  Piles(
+    tops: dict.insert(piles.tops, index, candidate),
+    predecessors: case previous {
+      Ok(previous) ->
+        dict.insert(piles.predecessors, candidate.old_index, previous)
+      Error(Nil) -> piles.predecessors
+    },
+  )
+}
+
+// The leftmost pile whose top sits at or past `position`, or the pile after the
+// last one when every top sits before it. A pile below the count always has a
+// top, so a missing one can only mean the search has run past them.
+fn leftmost_pile(
+  tops: Dict(Int, Anchor),
+  position: Int,
+  low: Int,
+  high: Int,
+) -> Int {
+  use <- bool.guard(when: low >= high, return: low)
+  let middle = { low + high } / 2
+  case dict.get(tops, middle) {
+    Ok(top) ->
+      case top.new_index >= position {
+        True -> leftmost_pile(tops, position, low, middle)
+        False -> leftmost_pile(tops, position, middle + 1, high)
+      }
+    Error(Nil) -> leftmost_pile(tops, position, middle + 1, high)
+  }
+}
+
+// Follow predecessors back from the last pile's top, which lands the run in
+// ascending order on both sides.
+fn chase(
+  predecessors: Dict(Int, Anchor),
+  anchor: Result(Anchor, Nil),
+  acc: List(Anchor),
+) -> List(Anchor) {
+  case anchor {
+    Error(Nil) -> acc
+    Ok(anchor) ->
+      chase(predecessors, dict.get(predecessors, anchor.old_index), [
+        anchor,
+        ..acc
+      ])
+  }
+}
+
+// Longest common subsequence
+//
+// The search over one gap: the step taken at a disagreement is the one leaving
+// the longer common subsequence behind. Scoring a step fills a rectangle the
+// size of the gap, which is what the anchors above exist to keep small.
+
+// The two sides of a gap indexed by position, so the search can address a line
+// by index instead of walking a list. Indices run from zero without gaps, so a
+// lookup misses exactly when it has walked past the end of that side — which
+// makes the lookup itself the bounds check.
+type Grid {
+  Grid(old: Dict(Int, Line), new: Dict(Int, Line))
+}
+
+// Which side a step at a disagreeing line advances.
+type Move {
+  DropOld
+  DropNew
+}
+
+// Lengths of the longest common subsequence of the two suffixes, keyed by
+// where each suffix starts.
+type Memo =
+  Dict(#(Int, Int), Int)
+
+fn searched_edits(old: List(Line), new: List(Line)) -> List(Edit) {
+  let grid = Grid(old: index_lines(old), new: index_lines(new))
+  let #(edits, _memo) = walk(grid, 0, 0, dict.new(), [])
+  list.reverse(edits)
 }
 
 fn index_lines(lines: List(Line)) -> Dict(Int, Line) {

--- a/src/graded/internal/diff.gleam
+++ b/src/graded/internal/diff.gleam
@@ -532,10 +532,29 @@ fn hunks(edits: List(Edit)) -> List(List(Edit)) {
       }
     })
     |> merge_ranges
-  list.map(ranges, fn(range) {
-    let #(start, end) = range
-    edits |> list.drop(start) |> list.take(end - start + 1)
-  })
+  cut_ranges(edits, 0, ranges, [])
+}
+
+// Cut each range out of the edit list in one forward pass. Ranges ascend and
+// none overlaps the one before it, so the walk never goes back: each range
+// drops what lies between it and where the previous one started, then takes
+// its own span from there. `offset` is where the list in hand begins.
+fn cut_ranges(
+  edits: List(Edit),
+  offset: Int,
+  ranges: List(#(Int, Int)),
+  acc: List(List(Edit)),
+) -> List(List(Edit)) {
+  case ranges {
+    [] -> list.reverse(acc)
+    [#(start, end), ..rest] -> {
+      let remaining = list.drop(edits, start - offset)
+      cut_ranges(remaining, start, rest, [
+        list.take(remaining, end - start + 1),
+        ..acc
+      ])
+    }
+  }
 }
 
 fn is_change(edit: Edit) -> Bool {

--- a/test/diff_test.gleam
+++ b/test/diff_test.gleam
@@ -62,6 +62,42 @@ pub fn contextual_nearby_edits_make_one_hunk_test() {
   |> should.equal(Some("- a\n+ A\n  b\n- c\n+ C"))
 }
 
+// Ambiguous alignments
+//
+// Inputs whose longest common subsequence is not unique: two alignments keep
+// the same number of lines, so which one the diff picks is a choice rather
+// than a consequence. These pin the choice, since it decides where the `-`
+// and `+` lines land in a preview.
+
+// `b` is the line both sides agree on the position of relative to nothing
+// else, so it stays context and `a` moves around it.
+pub fn contextual_swapped_lines_test() {
+  diff.contextual("a\nb\n", "b\na\n")
+  |> should.equal(Some("- a\n  b\n+ a"))
+}
+
+pub fn contextual_dropping_a_repeated_line_test() {
+  diff.contextual("a\nb\na\n", "a\nb\n")
+  |> should.equal(Some("  a\n  b\n- a"))
+}
+
+pub fn contextual_adding_a_repeated_line_test() {
+  diff.contextual("a\nb\n", "a\nb\na\n")
+  |> should.equal(Some("  a\n  b\n+ a"))
+}
+
+// Two lines trading places around a third: the removals lead and the
+// additions follow, rather than the pair being split into two hunks.
+pub fn contextual_reordered_lines_test() {
+  diff.contextual("a\nb\na\nc\n", "a\nc\na\nb\n")
+  |> should.equal(Some("  a\n- b\n- a\n  c\n+ a\n+ b"))
+}
+
+pub fn contextual_collapsing_a_repeated_line_test() {
+  diff.contextual("a\na\n", "a\n")
+  |> should.equal(Some("  a\n- a"))
+}
+
 // Trailing newlines
 //
 // `annotation.format_file` does not append a trailing newline, so a spec file

--- a/test/diff_test.gleam
+++ b/test/diff_test.gleam
@@ -3,7 +3,9 @@
 // diff is byte-exact, so the trailing newline gets as much attention here as
 // the changed lines do.
 
-import gleam/option.{None, Some}
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleeunit/should
 import graded/internal/diff
@@ -49,8 +51,8 @@ pub fn contextual_replacement_test() {
 // Only two context lines on each side of a change, so the untouched lines
 // between two distant edits split the output into separate hunks.
 pub fn contextual_distant_edits_make_two_hunks_test() {
-  let old = string.join(["a", "b", "c", "d", "e", "f", "g", "h"], "\n") <> "\n"
-  let new = string.join(["A", "b", "c", "d", "e", "f", "g", "H"], "\n") <> "\n"
+  let old = lines(["a", "b", "c", "d", "e", "f", "g", "h"])
+  let new = lines(["A", "b", "c", "d", "e", "f", "g", "H"])
   diff.contextual(old, new)
   |> should.equal(Some("- a\n+ A\n  b\n  c\n@@\n  f\n  g\n- h\n+ H"))
 }
@@ -96,6 +98,126 @@ pub fn contextual_reordered_lines_test() {
 pub fn contextual_collapsing_a_repeated_line_test() {
   diff.contextual("a\na\n", "a\n")
   |> should.equal(Some("  a\n- a"))
+}
+
+// Anchors and gaps
+//
+// Lines occurring exactly once on each side pin the two sides together, and
+// only the gaps between those pins are searched. These are the shapes where
+// the pinning has to hold: a block of changed lines with a second change too
+// far away for the trimming of the shared ends to reach, and sides with
+// nothing to pin at all.
+
+// The inserted block and the distant change stay separate hunks, rather than
+// the search losing its place and rewriting everything between them.
+pub fn contextual_block_insertion_with_a_distant_change_test() {
+  let old = lines(numbered("a", 1, 8))
+  let new =
+    lines(
+      list.flatten([["a1"], numbered("x", 1, 3), numbered("a", 2, 7), ["B8"]]),
+    )
+  diff.contextual(old, new)
+  |> should.equal(Some(
+    "  a1\n+ x1\n+ x2\n+ x3\n  a2\n  a3\n@@\n  a6\n  a7\n- a8\n+ B8",
+  ))
+}
+
+pub fn contextual_block_deletion_with_a_distant_change_test() {
+  let old =
+    lines(
+      list.flatten([["a1"], numbered("x", 1, 3), numbered("a", 2, 7), ["a8"]]),
+    )
+  let new = lines(list.flatten([["a1"], numbered("a", 2, 7), ["B8"]]))
+  diff.contextual(old, new)
+  |> should.equal(Some(
+    "  a1\n- x1\n- x2\n- x3\n  a2\n  a3\n@@\n  a6\n  a7\n- a8\n+ B8",
+  ))
+}
+
+// The same shape at a size the exact assertions above cannot spell out: fifty
+// inserted lines and one distant replacement, in a two-hundred-line file.
+pub fn contextual_large_block_insertion_with_a_distant_change_test() {
+  let old = lines(numbered("a", 1, 200))
+  let new =
+    lines(
+      list.flatten([
+        numbered("a", 1, 20),
+        numbered("x", 1, 50),
+        numbered("a", 21, 199),
+        ["B200"],
+      ]),
+    )
+  let rendered = diff.contextual(old, new)
+  count_starting_with(rendered, "+ ") |> should.equal(51)
+  count_starting_with(rendered, "- ") |> should.equal(1)
+  count_starting_with(rendered, "@@") |> should.equal(1)
+}
+
+// Scattered changes stay one hunk each: five changes far apart are five hunks,
+// not one covering the whole file.
+pub fn contextual_scattered_changes_make_one_hunk_each_test() {
+  let rendered =
+    diff.contextual(
+      lines(numbered("a", 1, 100)),
+      lines(every_twentieth(1, 100)),
+    )
+  count_starting_with(rendered, "+ ") |> should.equal(5)
+  count_starting_with(rendered, "- ") |> should.equal(5)
+  count_starting_with(rendered, "@@") |> should.equal(4)
+}
+
+// Sides with no line in common share no subsequence either, so the diff is
+// every removal and then every addition.
+pub fn contextual_sides_sharing_no_line_test() {
+  diff.contextual("a\nb\nc\n", "x\ny\nz\n")
+  |> should.equal(Some("- a\n- b\n- c\n+ x\n+ y\n+ z"))
+}
+
+// Repeated lines pin nothing — which occurrence matches which is the question
+// — so the whole middle is searched, and the changed ends stay two hunks.
+pub fn contextual_repeated_lines_between_changed_ends_test() {
+  let repeated = ["a", "b", "a", "b", "a", "b"]
+  diff.contextual(
+    lines(list.flatten([["h1"], repeated, ["t1"]])),
+    lines(list.flatten([["h2"], repeated, ["t2"]])),
+  )
+  |> should.equal(Some("- h1\n+ h2\n  a\n  b\n@@\n  a\n  b\n- t1\n+ t2"))
+}
+
+fn lines(items: List(String)) -> String {
+  string.join(items, "\n") <> "\n"
+}
+
+// Lines named by their position, `prefix` deciding what each one is called.
+fn named(from: Int, to: Int, prefix: fn(Int) -> String) -> List(String) {
+  case from > to {
+    True -> []
+    False -> [
+      prefix(from) <> int.to_string(from),
+      ..named(from + 1, to, prefix)
+    ]
+  }
+}
+
+fn numbered(prefix: String, from: Int, to: Int) -> List(String) {
+  named(from, to, fn(_) { prefix })
+}
+
+// Every twentieth line replaced, the rest of them untouched.
+fn every_twentieth(from: Int, to: Int) -> List(String) {
+  named(from, to, fn(n) {
+    case n % 20 == 0 {
+      True -> "B"
+      False -> "a"
+    }
+  })
+}
+
+fn count_starting_with(rendered: Option(String), prefix: String) -> Int {
+  rendered
+  |> option.unwrap("")
+  |> string.split("\n")
+  |> list.count(fn(line) { string.starts_with(line, prefix) })
 }
 
 // Trailing newlines


### PR DESCRIPTION
`graded infer --dry-run` could stall for the better part of a minute
previewing a large spec file. The cost tracked the *span between the first
and last change*, not the size of the change: at a disagreement both `lcs`
probes leave the sides offset by one, so the memoized search filled the
rectangle from there to the end of the middle. A 5000-line spec took 46 s
to preview a full rewrite, and 43 s with only every tenth line changed —
the number of changes never entered it.

## What changed

A line occurring exactly once on each side now pins those two positions
together. The pins are cut to the longest run whose matches do not cross
(patience sorting over the candidates in old-side order), and only the gaps
between consecutive pins are searched. The search itself — `walk`,
`better_move`, `lcs`, `compute_lcs` — is untouched; it just runs on gaps
instead of on everything.

A gap whose two sides share no line has an empty common subsequence, so
every step of the search would tie and take the removal. That case is
emitted directly as every removal then every addition, which is what makes
the full-rewrite preview cheap.

Rendering had a second problem the speedup exposed: `hunks` dropped from the
front of the whole edit list once per hunk, re-walking it 500 times on a
500-hunk preview. The ranges are already ascending and non-overlapping, so
one forward walk covers them all.

## Measured

Regenerated on the same machine, before → after:

| case | before | after |
|---|---|---|
| 2 changes 1000 lines apart, 2000-line spec | 963 ms | 3 ms |
| 5000 lines, every 10th changed | 43.1 s | 12 ms |
| 5000 lines, full rewrite | 46.5 s | 12 ms |
| duplicate-heavy middle, 1000 / 2000 lines | 347 ms / 2.39 s | 287 ms / 2.37 s |

The last row is the case anchoring cannot help — a middle of repeated lines
where nothing is unique, so the old engine still runs on the whole of it.
It is unchanged by construction, which is the point: nothing regresses.

The hunk fix on top, best of seven: a 500-hunk preview renders in 7.9 ms
against 9.8 ms, a 300-hunk one in 4.6 ms against 5.3 ms.

## On the output

Anchoring commits to a common subsequence a global search need not have
picked, so an alignment *could* have moved. None did. The first commit pins
five inputs whose longest common subsequence is not unique — recording
today's choice before the engine moves — and every one of them, plus every
pre-existing expectation, is byte-identical afterwards. The hunk fix is a
pure refactor: the rendered output hashes identically on every case measured.

## Tests

1488 passing, up from 1477. New coverage, all through `contextual` (the only
public function in the module):

- Five ambiguous alignments, landed in their own commit ahead of the change.
- A block insertion and a block deletion each straddled by a distant change,
  so neither prefix nor suffix trimming can isolate them — the shape that
  breaks a naive bound on the search.
- The same shape at 200 lines, asserted on hunk and edit counts.
- Scattered changes in a long file, which must stay one hunk each.
- Two sides sharing no line, and a duplicate-heavy middle.

All five CI gates green locally: `gleam format --check src/ test/`,
`gleam build --warnings-as-errors`, `gleam test`, `gleam run -m glinter`,
`gleam run -m check_public_interface`.