### PR TITLE
Cover the span-keyed type index

### DIFF
--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -2590,7 +2590,8 @@ fn qualify_by_module(
 // Type index
 
 // Run girard's whole-package type inference once over every project module
-// and fold the result into a `TypeInfo` (module path -> span start -> type).
+// and fold the result into a `TypeInfo`: per-module expression types keyed by
+// their `#(start, end)` span, plus the fn-typed parameters girard inferred.
 // girard is best-effort: a function it can't type contributes no expressions,
 // so the checker silently falls back to syntax-level resolution for it.
 fn build_type_index(

--- a/test/typeinfo_test.gleam
+++ b/test/typeinfo_test.gleam
@@ -1,0 +1,228 @@
+// Tests for `graded/internal/typeinfo` — the index of girard's per-expression
+// types that the checker reads receiver types out of. Two properties carry the
+// module and are pinned here: every lookup miss answers with an empty value
+// rather than an error, which is what keeps girard a pure enhancement layer,
+// and expressions key on the full `#(start, end)` span, so neighbouring
+// expressions sharing one offset never resolve to each other's type.
+
+import girard.{type Type, Fn, Named, Tuple, Var}
+import gleam/dict.{type Dict}
+import gleam/option.{None, Some}
+import gleam/set
+import gleeunit/should
+import graded/internal/typeinfo
+
+// The empty index
+//
+// `none()` is the index the checker runs with when type inference is
+// unavailable.
+
+pub fn none_has_no_module_types_test() {
+  typeinfo.for_module(typeinfo.none(), "any/module")
+  |> should.equal(dict.new())
+}
+
+pub fn none_has_no_fn_typed_params_test() {
+  let module_fn_typed = typeinfo.fn_typed_for_module(typeinfo.none(), "any")
+  module_fn_typed |> should.equal(dict.new())
+  typeinfo.fn_typed_params(module_fn_typed, "handle")
+  |> should.equal(set.new())
+}
+
+pub fn none_resolves_no_receiver_type_test() {
+  typeinfo.receiver_type(
+    typeinfo.for_module(typeinfo.none(), "any/module"),
+    0,
+    4,
+  )
+  |> should.equal(None)
+}
+
+// Building an index
+//
+// `from_modules` keeps the span map and the fn-typed map independent: neither
+// is derived from, or gated on, the other.
+
+pub fn from_modules_serves_each_module_its_own_types_test() {
+  let info =
+    typeinfo.from_modules(
+      [
+        #("app/log", spans([#(#(0, 3), Named("app/log", "Logger", []))])),
+        #("app/count", spans([#(#(0, 3), Named("app/count", "Counter", []))])),
+      ],
+      [],
+    )
+  typeinfo.receiver_type(typeinfo.for_module(info, "app/log"), 0, 3)
+  |> should.equal(Some(#("app/log", "Logger")))
+  typeinfo.receiver_type(typeinfo.for_module(info, "app/count"), 0, 3)
+  |> should.equal(Some(#("app/count", "Counter")))
+}
+
+pub fn a_module_with_types_but_no_fn_typed_entry_reads_empty_test() {
+  let info =
+    typeinfo.from_modules(
+      [#("app/log", spans([#(#(0, 3), Named("app/log", "Logger", []))]))],
+      [],
+    )
+  typeinfo.receiver_type(typeinfo.for_module(info, "app/log"), 0, 3)
+  |> should.equal(Some(#("app/log", "Logger")))
+  typeinfo.fn_typed_for_module(info, "app/log") |> should.equal(dict.new())
+}
+
+pub fn a_module_with_fn_typed_but_no_types_reads_empty_test() {
+  let info =
+    typeinfo.from_modules([], [
+      #("app/log", dict.from_list([#("each", set.from_list(["f"]))])),
+    ])
+  typeinfo.fn_typed_params(
+    typeinfo.fn_typed_for_module(info, "app/log"),
+    "each",
+  )
+  |> should.equal(set.from_list(["f"]))
+  typeinfo.for_module(info, "app/log") |> should.equal(dict.new())
+}
+
+// Module misses
+//
+// A module girard could not annotate is absent from both maps, and reads back
+// the same as a module it annotated to nothing.
+
+pub fn an_unknown_module_has_no_types_test() {
+  let info =
+    typeinfo.from_modules(
+      [#("app/log", spans([#(#(0, 3), Named("app/log", "Logger", []))]))],
+      [],
+    )
+  typeinfo.for_module(info, "app/other") |> should.equal(dict.new())
+}
+
+pub fn an_unknown_module_has_no_fn_typed_params_test() {
+  let info =
+    typeinfo.from_modules([], [
+      #("app/log", dict.from_list([#("each", set.from_list(["f"]))])),
+    ])
+  typeinfo.fn_typed_for_module(info, "app/other") |> should.equal(dict.new())
+}
+
+pub fn a_function_girard_did_not_type_has_no_fn_typed_params_test() {
+  let info =
+    typeinfo.from_modules([], [
+      #("app/log", dict.from_list([#("each", set.from_list(["f"]))])),
+    ])
+  typeinfo.fn_typed_params(
+    typeinfo.fn_typed_for_module(info, "app/log"),
+    "untyped",
+  )
+  |> should.equal(set.new())
+}
+
+// Receiver types
+//
+// `receiver_type` answers only for `Named` types, and only on an exact
+// `#(start, end)` match.
+
+pub fn a_named_type_resolves_to_its_module_and_name_test() {
+  typeinfo.receiver_type(
+    spans([#(#(10, 11), Named("app/log", "Logger", []))]),
+    10,
+    11,
+  )
+  |> should.equal(Some(#("app/log", "Logger")))
+}
+
+pub fn a_named_types_arguments_do_not_change_its_identity_test() {
+  typeinfo.receiver_type(
+    spans([
+      #(#(0, 6), Named("gleam", "List", [Named("gleam", "Int", [])])),
+    ]),
+    0,
+    6,
+  )
+  |> should.equal(Some(#("gleam", "List")))
+}
+
+pub fn spans_sharing_a_start_resolve_apart_test() {
+  let module_types =
+    spans([
+      #(#(10, 11), Named("app/log", "Logger", [])),
+      #(#(10, 17), Fn([], Named("gleam", "Nil", []))),
+      #(#(10, 20), Named("gleam", "Nil", [])),
+    ])
+  typeinfo.receiver_type(module_types, 10, 11)
+  |> should.equal(Some(#("app/log", "Logger")))
+  typeinfo.receiver_type(module_types, 10, 17) |> should.equal(None)
+  typeinfo.receiver_type(module_types, 10, 20)
+  |> should.equal(Some(#("gleam", "Nil")))
+}
+
+pub fn spans_sharing_an_end_resolve_apart_test() {
+  let module_types =
+    spans([
+      #(#(0, 8), Named("gleam", "Bool", [])),
+      #(#(5, 8), Named("app/log", "Logger", [])),
+    ])
+  typeinfo.receiver_type(module_types, 0, 8)
+  |> should.equal(Some(#("gleam", "Bool")))
+  typeinfo.receiver_type(module_types, 5, 8)
+  |> should.equal(Some(#("app/log", "Logger")))
+}
+
+pub fn a_span_with_the_wrong_end_does_not_resolve_test() {
+  typeinfo.receiver_type(
+    spans([#(#(10, 11), Named("app/log", "Logger", []))]),
+    10,
+    12,
+  )
+  |> should.equal(None)
+}
+
+pub fn a_span_with_the_wrong_start_does_not_resolve_test() {
+  typeinfo.receiver_type(
+    spans([
+      #(#(0, 8), Named("gleam", "Bool", [])),
+      #(#(5, 8), Named("app/log", "Logger", [])),
+    ]),
+    2,
+    8,
+  )
+  |> should.equal(None)
+}
+
+pub fn an_absent_span_resolves_to_none_test() {
+  typeinfo.receiver_type(
+    spans([#(#(10, 11), Named("app/log", "Logger", []))]),
+    30,
+    34,
+  )
+  |> should.equal(None)
+}
+
+pub fn a_function_type_resolves_to_none_test() {
+  typeinfo.receiver_type(
+    spans([#(#(0, 4), Fn([], Named("app/log", "Logger", [])))]),
+    0,
+    4,
+  )
+  |> should.equal(None)
+}
+
+pub fn a_type_variable_resolves_to_none_test() {
+  typeinfo.receiver_type(spans([#(#(0, 4), Var(0))]), 0, 4)
+  |> should.equal(None)
+}
+
+pub fn a_tuple_type_resolves_to_none_test() {
+  typeinfo.receiver_type(
+    spans([
+      #(#(0, 4), Tuple([Named("gleam", "Int", []), Named("gleam", "Int", [])])),
+    ]),
+    0,
+    4,
+  )
+  |> should.equal(None)
+}
+
+// One module's span->type slice.
+fn spans(entries: List(#(#(Int, Int), Type))) -> Dict(#(Int, Int), Type) {
+  dict.from_list(entries)
+}


### PR DESCRIPTION
`src/graded/internal/typeinfo.gleam` was the only module under `src/` with no test file, and no test anywhere named it. It is 100 lines of dictionary access, but two of its properties are load-bearing and were stated only in a module comment.

## What is covered

`test/typeinfo_test.gleam`, 19 tests in four sections:

- **The empty index** — `none()`'s three lookups (`for_module`, `fn_typed_for_module` + `fn_typed_params`, `receiver_type`) each answer with an empty value. This is what makes girard a pure enhancement layer: a function girard could not type contributes no spans, and the checker falls through to the syntax-level path instead of erroring.
- **Building an index** — `from_modules` serves each module its own slice, and keeps the span map and the fn-typed map independent: a module in one and absent from the other still answers from the one it is in.
- **Module misses** — an unknown module path, and a function girard did not type inside a module that is present, both miss to empty.
- **Receiver types** — the span-keying invariant and the `Named`-only rule. Three types at `#(10, 11)`, `#(10, 17)` and `#(10, 20)` (a receiver, the access on it, the whole call) read back apart; in the `a == b.c` shape, `#(0, 8)` and `#(5, 8)` read back apart. Narrowing the key to either offset alone fails one of these, and a field call would silently pick up a neighbouring expression's nominal type. A wrong start, a wrong end, and an absent span all resolve to `None`, as do the three non-`Named` variants (`Fn`, `Var`, `Tuple`).

Also corrects `build_type_index`'s comment in `src/graded.gleam`, which described the index as `module path -> span start -> type` while the fold two lines below keys on `#(span.start, span.end)` — the exact invariant this test file exists to pin.

No behaviour change. The suite goes from 1488 to 1507 passing; nothing else moved.

## Deliberately out of scope

- `build_type_index` and `fn_typed_params_from_schemes` (`src/graded.gleam`), the producers that call girard. They are exercised end-to-end by the integration fixtures; testing them here would mean running girard from a unit test.
- A qcheck generator for `girard.Type` in `test/generators.gleam`. The shared generator module would gain a generator used by exactly one file, and the variants are four and enumerable. Worth revisiting only if a second module needs it.
- A test for a duplicated module path in `from_modules`. It is `dict.from_list`, so duplicates are last-wins, but the only producer builds its lists from `dict.to_list` and the paths are unique by construction — pinning it would enshrine behaviour no caller can reach.

One note on style: `receiver_type`'s `_ -> None` arm is a catch-all, against the codebase's usual rule. It is deliberate — the match is over a dependency's type, so the arm is what makes a variant girard adds later resolve to `None` rather than fail to compile. Tests 17–19 cover every non-`Named` variant that exists today.

No changelog entry: new coverage and a corrected internal comment are not observable changes.