### PR TITLE
Patch only the project's own release tarball

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Sixteen modules, no circular dependencies. Only `src/graded.gleam` is the public
 | `src/graded/internal/signatures.gleam` | Glance-backed parameter signatures: fn-typed and operator (second-order) parameter detection, positions, for call-site substitution |
 | `src/graded/internal/topo.gleam` | Kahn's-algorithm topological sort over a string-keyed dependency graph |
 | `src/graded/internal/lint.gleam` | Spec-file lint: `check`/`assume`/field lines whose target resolves nothing, `effects` lines whose path is not a function's, and `where returns` clauses their own line does not scope |
-| `src/graded/internal/pack.gleam` | Hex tarball patching for `graded pack`: pick the archive, inject the spec through a temporary file, verify, replace |
+| `src/graded/internal/pack.gleam` | Hex tarball patching for `graded pack`: resolve `build/<name>-<version>.tar` and check its `metadata.config` names this project, inject the spec through a temporary file, verify, replace |
 | `src/graded/internal/diff.gleam` | Line diff between two renderings of a spec file, for `infer --dry-run` |
 
 ## .graded Annotation Syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on a *field* path is reported as unsupported; the field budget on that line is
   still verified.
 
+### Removed
+
+- `graded.pack_project` no longer takes a tarball path: the signature is now
+  `pack_project(project_root: String)`, and the archive it patches is
+  `build/<name>-<version>.tar` and no other. The `graded pack` command never
+  accepted an archive path, so nothing changes for it. A caller that named a
+  path builds the archive at the default location instead — re-run `gleam
+  export hex-tarball` if it built the archive itself, or copy the one it kept
+  to `build/<name>-<version>.tar` before packing.
+
 ### Fixed
 
+- `graded pack` on a package whose `gleam.toml` states no `version` now says to
+  add one, instead of advising a tarball path that no caller could pass.
 - `graded infer --dry-run` no longer stalls previewing a large spec file. A
   five-thousand-line spec with every tenth line changed took 43 seconds to
   preview and now takes milliseconds.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ gleam export hex-tarball        # build the release tarball
 gleam run -m graded pack        # inject <spec_file> into it, then publish as printed
 ```
 
-`pack` places your spec at `build/packages/<your-package>/<spec_file>` in downstream projects — where graded's resolver already looks — so consumers need no setup. It patches `build/<name>-<version>.tar` in place (the `graded.pack_project` API also accepts an explicit tarball path) and prints the Hex publish API command to run next. Do **not** run `gleam publish` afterwards: it rebuilds the tarball from source and drops the injected spec. Documentation still publishes via `gleam docs publish`. The cache directory under `build/` is gitignored and never ships.
+`pack` places your spec at `build/packages/<your-package>/<spec_file>` in downstream projects — where graded's resolver already looks — so consumers need no setup. It patches `build/<name>-<version>.tar` in place — that path and no other, whether you run the command or call the `graded.pack_project` API — and prints the Hex publish API command to run next. Do **not** run `gleam publish` afterwards: it rebuilds the tarball from source and drops the injected spec. Documentation still publishes via `gleam docs publish`. The cache directory under `build/` is gitignored and never ships.
 
 Two cases need no packing:
 

--- a/src/graded.gleam
+++ b/src/graded.gleam
@@ -219,7 +219,7 @@ pub fn main() -> Nil {
 }
 
 fn pack_and_report(directory: String) -> Nil {
-  case pack_project(resolve_package_root(directory), None) {
+  case pack_project(resolve_package_root(directory)) {
     Ok(message) -> io.println(message)
     Error(error) -> fail(error)
   }
@@ -312,14 +312,11 @@ Usage:
 // publish`, which rebuilds the tarball and drops the injected file).
 
 /// Inject the configured `.graded` spec into `project_root`'s hex tarball.
-/// `tarball` overrides the default `build/<name>-<version>.tar`. Returns a
-/// success message (with the publish command), a `GradedParseError` when the
-/// spec does not parse — nothing a consumer would read is ever packed — or a
-/// `PackError`.
-pub fn pack_project(
-  project_root: String,
-  tarball: option.Option(String),
-) -> Result(String, GradedError) {
+/// The archive patched is `build/<name>-<version>.tar` and no other path.
+/// Returns a success message (with the publish command), a `GradedParseError`
+/// when the spec does not parse — nothing a consumer would read is ever packed
+/// — or a `PackError`.
+pub fn pack_project(project_root: String) -> Result(String, GradedError) {
   let gleam_toml = filepath.join(project_root, "gleam.toml")
 
   // The raw (relative) spec path is the archive entry; the resolved path is
@@ -364,7 +361,7 @@ pub fn pack_project(
   })
 
   use tarball_path <- result.try(
-    pack.resolve_tarball(tarball, project_root, gleam_toml, raw_cfg)
+    pack.resolve_tarball(project_root, gleam_toml, raw_cfg)
     |> result.map_error(pack_error),
   )
 
@@ -388,12 +385,8 @@ fn pack_error(problem: pack.PackProblem) -> GradedError {
         <> entry
         <> "` must be a relative path inside the package",
       )
-    pack.UnreadableTarball(path:, message:) ->
-      PackError("not a readable hex tarball: " <> path <> ": " <> message)
     pack.MissingVersion(gleam_toml:) ->
-      PackError(
-        "no `version` in " <> gleam_toml <> "; pass the tarball path explicitly",
-      )
+      PackError("no `version` in " <> gleam_toml <> "; add one to publish")
     pack.MissingDefaultTarball(path:, message:) ->
       PackError(
         "could not read "

--- a/src/graded/internal/pack.gleam
+++ b/src/graded/internal/pack.gleam
@@ -8,7 +8,7 @@
 
 import filepath
 import gleam/list
-import gleam/option.{type Option, None, Some}
+import gleam/option
 import gleam/result
 import gleam/string
 import graded/internal/config
@@ -21,8 +21,6 @@ pub type PackProblem {
   // The configured `spec_file` is absolute or escapes the package root, so it
   // names no safe archive-relative entry.
   UnsafeSpecEntry(entry: String)
-  // The tarball the caller named is not a readable hex tarball.
-  UnreadableTarball(path: String, message: String)
   // No default tarball path can be derived: `gleam.toml` states no `version`.
   MissingVersion(gleam_toml: String)
   // The default tarball is there and holds another package or version, so
@@ -82,51 +80,39 @@ pub fn patch_tarball(
   Ok(checksum)
 }
 
-// Resolve the tarball to patch. An explicit path is validated as a readable hex
-// tarball. Without one, the default `build/<name>-<version>.tar` is opened and
-// its identity checked against the project's name and version, so `pack` can't
-// silently patch the wrong archive.
+// Resolve the tarball to patch: `build/<name>-<version>.tar`, the one archive
+// the command touches. It is opened and its identity checked against the
+// project's name and version, so `pack` can't silently patch the wrong
+// archive.
 pub fn resolve_tarball(
-  tarball: Option(String),
   project_root: String,
   gleam_toml: String,
   cfg: config.GradedConfig,
 ) -> Result(String, PackProblem) {
   let package_name = cfg.package_name
-  case tarball {
-    Some(path) -> {
-      use _ <- result.try(
-        read_package_identity(path)
-        |> result.map_error(UnreadableTarball(path, _)),
-      )
-      Ok(path)
-    }
-    None -> {
-      use version <- result.try(option.to_result(
-        cfg.version,
-        MissingVersion(gleam_toml),
+  use version <- result.try(option.to_result(
+    cfg.version,
+    MissingVersion(gleam_toml),
+  ))
+  let path =
+    filepath.join(
+      project_root,
+      "build/" <> package_name <> "-" <> version <> ".tar",
+    )
+  use #(name, tar_version) <- result.try(
+    read_package_identity(path)
+    |> result.map_error(MissingDefaultTarball(path, _)),
+  )
+  case name == package_name && tar_version == version {
+    True -> Ok(path)
+    False ->
+      Error(WrongTarball(
+        path:,
+        found: name,
+        found_version: tar_version,
+        expected: package_name,
+        expected_version: version,
       ))
-      let path =
-        filepath.join(
-          project_root,
-          "build/" <> package_name <> "-" <> version <> ".tar",
-        )
-      use #(name, tar_version) <- result.try(
-        read_package_identity(path)
-        |> result.map_error(MissingDefaultTarball(path, _)),
-      )
-      case name == package_name && tar_version == version {
-        True -> Ok(path)
-        False ->
-          Error(WrongTarball(
-            path:,
-            found: name,
-            found_version: tar_version,
-            expected: package_name,
-            expected_version: version,
-          ))
-      }
-    }
   }
 }
 

--- a/test/pack_test.gleam
+++ b/test/pack_test.gleam
@@ -4,7 +4,6 @@
 // Project trees are materialised under `build/` (gitignored) at runtime.
 
 import gleam/list
-import gleam/option.{None, Some}
 import gleam/set
 import gleam/string
 import gleeunit/should
@@ -42,7 +41,7 @@ pub fn pack_injects_and_reports_test() {
   let tarball =
     setup_dep(root, "dep", "1.0.0", "dep.graded", "effects dep.work : []\n")
 
-  let assert Ok(message) = graded.pack_project(root, None)
+  let assert Ok(message) = graded.pack_project(root)
   string.contains(message, "injected dep.graded") |> should.be_true()
   // The publish guidance names the Hex API, never `gleam publish`, and
   // shell-quotes the tarball path.
@@ -75,7 +74,7 @@ pub fn pack_preserves_entry_modes_test() {
     #("priv/helper", "#!/bin/sh\n", 0o755),
   ])
 
-  let assert Ok(_) = graded.pack_project(root, None)
+  let assert Ok(_) = graded.pack_project(root)
 
   let dest = root <> "/unpacked"
   unpack_inner(tarball, dest)
@@ -92,9 +91,9 @@ pub fn pack_rerun_is_idempotent_test() {
   let tarball =
     setup_dep(root, "dep", "1.0.0", "dep.graded", "effects dep.work : []\n")
 
-  let assert Ok(_) = graded.pack_project(root, None)
+  let assert Ok(_) = graded.pack_project(root)
   write_file(root <> "/dep.graded", "effects dep.work : [Stdout]\n")
-  let assert Ok(_) = graded.pack_project(root, None)
+  let assert Ok(_) = graded.pack_project(root)
 
   metadata_files(tarball)
   |> list.filter(fn(file) { file == "dep.graded" })
@@ -118,7 +117,7 @@ pub fn pack_scratch_collision_is_an_error_test() {
   // A user directory at the `.packing` temp path survives the failed pack.
   let packing_marker = tarball <> ".packing"
   write_file(packing_marker <> "/keep.txt", "precious\n")
-  let assert Error(_) = graded.pack_project(root, None)
+  let assert Error(_) = graded.pack_project(root)
   simplifile.read(packing_marker <> "/keep.txt")
   |> should.equal(Ok("precious\n"))
   let assert Ok(Nil) = simplifile.delete(packing_marker)
@@ -127,7 +126,7 @@ pub fn pack_scratch_collision_is_an_error_test() {
   // and the failed run cleans up its own temp file.
   let work_marker = tarball <> ".packing.work"
   write_file(work_marker <> "/keep.txt", "precious\n")
-  let assert Error(_) = graded.pack_project(root, None)
+  let assert Error(_) = graded.pack_project(root)
   simplifile.read(work_marker <> "/keep.txt") |> should.equal(Ok("precious\n"))
   simplifile.is_file(tarball <> ".packing") |> should.equal(Ok(False))
   let assert Ok(Nil) = simplifile.delete(work_marker)
@@ -136,19 +135,19 @@ pub fn pack_scratch_collision_is_an_error_test() {
   // the pack fails and nothing is written through to the symlink's target.
   let assert Ok(Nil) =
     simplifile.create_symlink("dangling_target", packing_marker)
-  let assert Error(_) = graded.pack_project(root, None)
+  let assert Error(_) = graded.pack_project(root)
   simplifile.is_file(root <> "/build/dangling_target")
   |> should.equal(Ok(False))
 
   cleanup(root)
 }
 
-pub fn pack_default_tarball_identity_mismatch_test() {
+pub fn pack_requires_the_default_tarball_test() {
   let root = "build/pack_mismatch"
   let _ = simplifile.delete(root)
   // Project declares version 2.0.0, but only a 1.0.0 tarball exists — the
-  // default path build/dep-2.0.0.tar is missing, so pack errors rather than
-  // patching the wrong archive.
+  // default path build/dep-2.0.0.tar is missing, so pack names that path
+  // rather than reaching for the well-formed archive beside it.
   write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"2.0.0\"\n")
   write_file(root <> "/dep.graded", "effects dep.work : []\n")
   let tarball = root <> "/build/dep-1.0.0.tar"
@@ -157,17 +156,42 @@ pub fn pack_default_tarball_identity_mismatch_test() {
     #("src/dep.gleam", "pub fn work() {\n  Nil\n}\n"),
   ])
 
-  let assert Error(_) = graded.pack_project(root, None)
+  let assert Error(graded.PackError(message)) = graded.pack_project(root)
+  string.contains(message, "build/dep-2.0.0.tar") |> should.be_true()
   cleanup(root)
 }
 
-pub fn pack_explicit_tarball_test() {
-  let root = "build/pack_explicit"
-  let tarball =
-    setup_dep(root, "dep", "9.9.9", "dep.graded", "effects dep.work : []\n")
+pub fn pack_refuses_another_packages_tarball_test() {
+  let root = "build/pack_wrong_tarball"
+  let _ = simplifile.delete(root)
+  // The archive sits at the expected default path but its metadata names
+  // another package, so patching it would touch the wrong release.
+  write_file(root <> "/gleam.toml", "name = \"dep\"\nversion = \"1.0.0\"\n")
+  write_file(root <> "/dep.graded", "effects dep.work : []\n")
+  let tarball = root <> "/build/dep-1.0.0.tar"
+  ensure_parent(tarball)
+  build_tarball(tarball, "other", "9.9.9", [
+    #("src/other.gleam", "pub fn work() {\n  Nil\n}\n"),
+  ])
 
-  // No default build/dep-<version>.tar is looked for; the explicit path is used.
-  let assert Ok(_) = graded.pack_project(root, Some(tarball))
+  let assert Error(graded.PackError(message)) = graded.pack_project(root)
+  string.contains(message, "not the project's") |> should.be_true()
+  string.contains(message, "other") |> should.be_true()
+  string.contains(message, "9.9.9") |> should.be_true()
+  cleanup(root)
+}
+
+pub fn pack_requires_a_version_in_gleam_toml_test() {
+  let root = "build/pack_no_version"
+  let _ = simplifile.delete(root)
+  // Without a version there is no default tarball path to derive, and the
+  // advice is the field to add — not an archive path, which `pack` never takes.
+  write_file(root <> "/gleam.toml", "name = \"dep\"\n")
+  write_file(root <> "/dep.graded", "effects dep.work : []\n")
+
+  let assert Error(graded.PackError(message)) = graded.pack_project(root)
+  string.contains(message, "no `version` in") |> should.be_true()
+  string.contains(message, "tarball path") |> should.be_false()
   cleanup(root)
 }
 
@@ -185,7 +209,7 @@ pub fn pack_custom_spec_file_test() {
     #("src/dep.gleam", "pub fn work() {\n  Nil\n}\n"),
   ])
 
-  let assert Ok(_) = graded.pack_project(root, None)
+  let assert Ok(_) = graded.pack_project(root)
 
   // The spec lands at the configured archive-relative path, not `dep.graded`.
   let dest = root <> "/unpacked"
@@ -202,7 +226,9 @@ pub fn pack_rejects_absolute_spec_path_test() {
     root <> "/gleam.toml",
     "name = \"dep\"\n\n[tools.graded]\nspec_file = \"/etc/dep.graded\"\n",
   )
-  let assert Error(_) = graded.pack_project(root, Some("unused.tar"))
+  // No archive is built: entry validation runs before the tarball is resolved,
+  // so the run fails on the spec path with nothing at build/dep-<version>.tar.
+  let assert Error(_) = graded.pack_project(root)
   cleanup(root)
 }
 
@@ -213,7 +239,8 @@ pub fn pack_rejects_escaping_spec_path_test() {
     root <> "/gleam.toml",
     "name = \"dep\"\n\n[tools.graded]\nspec_file = \"../escape.graded\"\n",
   )
-  let assert Error(_) = graded.pack_project(root, Some("unused.tar"))
+  // As above: the spec path is refused before any archive is looked for.
+  let assert Error(_) = graded.pack_project(root)
   cleanup(root)
 }
 
@@ -237,7 +264,7 @@ pub fn pack_refuses_a_spec_that_does_not_parse_test() {
 
   // The standard parse error, naming the file and the retired line.
   let assert Error(graded.GradedParseError(path, message)) =
-    graded.pack_project(root, None)
+    graded.pack_project(root)
   string.ends_with(path, "dep.graded") |> should.be_true()
   message
   |> should.equal(
@@ -269,7 +296,7 @@ pub fn pack_without_a_spec_names_infer_test() {
     #("src/dep.gleam", "pub fn work() {\n  Nil\n}\n"),
   ])
 
-  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  let assert Error(graded.PackError(message)) = graded.pack_project(root)
   string.contains(message, "no spec file at") |> should.be_true()
   string.contains(message, "run `graded infer` first") |> should.be_true()
   cleanup(root)
@@ -289,7 +316,7 @@ pub fn pack_reports_an_unreadable_spec_as_a_read_error_test() {
   case simplifile.read(spec) {
     Error(_) -> {
       let assert Error(graded.FileReadError(path, _cause)) =
-        graded.pack_project(root, None)
+        graded.pack_project(root)
       path |> should.equal(spec)
     }
     Ok(_) -> Nil
@@ -310,7 +337,7 @@ pub fn pack_consumer_resolves_injected_spec_test() {
       "packdep.graded",
       "effects packdep.work : [Stdout]\n",
     )
-  let assert Ok(_) = graded.pack_project(dep_root, None)
+  let assert Ok(_) = graded.pack_project(dep_root)
 
   // Simulate `gleam` installing the published dependency: unpack the patched
   // tarball's inner contents into the consumer's build/packages/packdep/.
@@ -373,7 +400,7 @@ fn setup_crafted(root: String, members: List(Member)) -> String {
 
 // The `PackError` message `pack` fails a project with.
 fn pack_error(root: String) -> String {
-  let assert Error(graded.PackError(message)) = graded.pack_project(root, None)
+  let assert Error(graded.PackError(message)) = graded.pack_project(root)
   message
 }
 


### PR DESCRIPTION
`graded.pack_project` took an optional tarball path, reachable only by a library caller — the `graded pack` command has never accepted one. This drops it: the command patches `build/<name>-<version>.tar` and no other path, with its identity checked against `gleam.toml` exactly as before.

## Why now

Nobody passes an explicit path, on every signal available:

| Probe | Result |
|---|---|
| Issues and discussions | One issue in the whole repo (build-time files in `priv/`, unrelated); no discussions. No flow described. |
| Public callers | `gh search code "pack_project" --language gleam` returns four hits, all in this repo. |
| The documented flow | `gleam export hex-tarball` on gleam 1.18.0 exposes no output-path option, so a user following the README has no second path to name. |
| Internal use | Three tests. graded's own release flow passes `None`. |

The parameter was designed in from the command's first commit rather than added on request, so there is no recorded demand behind it either. A 1.0 would freeze it; removing it under 0.x is a minor bump.

## This narrows an API, not a threat

`build/<name>-<version>.tar` is an ordinary path in a build directory. A crafted archive can be written there with a `metadata.config` naming this project's own name and version, so the identity comparison passes and `erl_tar` parses the crafted `contents.tar.gz` exactly as it does today — the default path reaches the same surface the explicit one did.

Every `graded_pack_ffi` guard is untouched and stays load-bearing. What this buys is one public entry point, one contract to document, and one code path under test.

## What changes

- `pub fn pack_project(project_root: String) -> Result(String, GradedError)` — **breaking** for a library caller. A caller that named a path builds the archive at the default location instead: re-run `gleam export hex-tarball` if it built the archive itself, or copy a kept archive to `build/<name>-<version>.tar` before packing.
- `resolve_tarball` loses its `Some` arm; `PackProblem.UnreadableTarball` is deleted with it, since that arm was its only producer.
- `MissingVersion` stops advising the impossible. It told a CLI user to "pass the tarball path explicitly" — advice no CLI user could act on — and now names the field to add to `gleam.toml`.
- No CLI behaviour changes. `parse_directory_args` never accepted a tarball, so the command patches the same archive on the same terms as before.

## Suite corrections

Three, all worth making whichever way the contract went:

- `pack_default_tarball_identity_mismatch_test` **did not test the identity check**. The project declared `2.0.0` with the only archive at `build/dep-1.0.0.tar`, so the default path was simply absent and the run failed as `MissingDefaultTarball`; the bare `Error(_)` assertion hid it. It is now `pack_requires_the_default_tarball_test` and asserts the path it names.
- `WrongTarball` had **no coverage at all**. `pack_refuses_another_packages_tarball_test` puts an archive whose metadata names another package at the expected default filename.
- `MissingVersion` had none either. `pack_requires_a_version_in_gleam_toml_test` asserts the prose names the field **and** does not mention a tarball path, which is what keeps the fixed message from regressing.

The crafted-archive tests go through the default path and are untouched.

## Verification

All five CI gates green: `gleam format --check`, `gleam build --warnings-as-errors`, `gleam test` (1508 passed, no failures), `gleam run -m glinter`, `gleam run -m check_public_interface`.